### PR TITLE
Use inspect_image() instead of get_image() when checking for existence (#4).

### DIFF
--- a/dock/core.py
+++ b/dock/core.py
@@ -232,7 +232,7 @@ class DockerTasker(object):
 
     def image_exists(self, image_id):
         try:
-            return self.d.get_image(image_id) is not None
+            return self.d.inspect_image(image_id) is not None
         except APIError:
             return False
 


### PR DESCRIPTION
Fixes #4.
