### PR TITLE
update dependencies

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -100,7 +100,7 @@ Requires:       python-docker-py
 Requires:       python-requests
 Requires:       python-setuptools
 Requires:       python-dockerfile-parse >= 0.0.11
-Requires:       python-docker-squash >= 1.0.0-0.3
+Requires:       python-docker-squash >= 1.0.7
 Requires:       python-backports-lzma
 Requires:       python-jsonschema
 Requires:       python-six
@@ -164,7 +164,7 @@ Requires:       python3-docker-py
 Requires:       python3-requests
 Requires:       python3-setuptools
 Requires:       python3-dockerfile-parse >= 0.0.11
-Requires:       python3-docker-squash >= 1.0.0-0.3
+Requires:       python3-docker-squash >= 1.0.7
 Requires:       python3-jsonschema
 Requires:       python3-PyYAML
 Requires:       python3-six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docker-py
-docker-squash>=1.0.0rc3
+docker-squash>=1.0.7
 dockerfile-parse>=0.0.11
 jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 PyYAML


### PR DESCRIPTION
Bump versions of things that we require to match up with what's actually used. Or, in the case of dockerfile-parse, required. This only affects creating virtual envs to run from source, or packaging, both of which our travis tests exercise.