### PR TITLE
Use koji operator-manifests build type

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -227,6 +227,12 @@ class KojiImportPlugin(ExitPlugin):
             for output in metadata['output']:
                 if output.get('filename') == OPERATOR_MANIFESTS_ARCHIVE:
                     extra['operator_manifests_archive'] = OPERATOR_MANIFESTS_ARCHIVE
+                    operators_typeinfo = {
+                        'operator-manifests': {
+                            'archive': OPERATOR_MANIFESTS_ARCHIVE,
+                        },
+                    }
+                    extra.update({'typeinfo': operators_typeinfo})
                     break
 
     def remove_unavailable_manifest_digests(self, worker_metadatas):

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -459,8 +459,16 @@ class KojiUploadPlugin(PostBuildPlugin):
                                                           OPERATOR_MANIFESTS_ARCHIVE)
             operator_manifests_output = Output(file=operator_manifests_file,
                                                metadata=manifests_metadata)
-            # We use log type here until a more appropriate type name is supported by koji
-            operator_manifests_output.metadata.update({'arch': arch, 'type': 'log'})
+            operator_manifests_output.metadata.update({
+                'type': 'operator-manifests',
+                'extra': {
+                    'typeinfo': {
+                        'operator-manifests': {
+                        },
+                    },
+                },
+            })
+
             operator_manifests = add_buildroot_id(operator_manifests_output)
             output_files.append(operator_manifests)
 

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -35,7 +35,9 @@ The `koji_tag_build` exit plugin is used to tag the imported koji build based on
 
 # Type-specific build metadata
 
-For atomic-reactor container image builds the `image` type is used, and so type-specific information is placed into the `build.extra.image` map. Note that this does not use `build.extra.typeinfo.image` -- the `typeinfo` element was introduced after the `image` type started to be used.
+For atomic-reactor container image builds the `image` type is used, and so type-specific information is placed into the `build.extra.image` map. Note that this
+is a legacy type in koji and may be changed to use `build.extra.typeinfo.image`. Clients fetching such data should first look for it within `build.extra.typeinfo.image`
+and fall back to `build.extra.image` when the former is not available.
 
 Data which is placed here includes:
 
@@ -60,7 +62,7 @@ Data which is placed here includes:
 - `build.owner` (string or null): username that started the task
 - `build.extra.image.go` (map): information about container first Go modules
 - `build.extra.image.go.modules` (map list): entries with Go modules information
-- `build.extra.operator_manifests_archive` (string): name of the archive containing operator manifest files
+- `build.extra.operator_manifests_archive` (string): name of the archive containing operator manifest files. Included here for legacy reasons. `build.extra.typeinfo.operator-manifests.archive` should be preferred
 
 The index map has these entries:
 
@@ -73,6 +75,13 @@ The `build.extra.image.go.modules` entries are maps composed of the following en
 - `module` (str): module name for the top-level Go language package to be built, as in `example.com/go/packagename`
 - `archive` (str): possibly-compressed archive containing full source code including dependencies
 - `path` (str): path to directory containing source code (or its parent), possibly within archive
+
+For operator builds, the operator manifests metadata is placed in `build.extra.typeinfo.operator-manifests`. If this is present, the data in `build.extra.image` will also
+be appended into `build.extra.typeinfo.image` by koji.
+
+Data which is placed here includes:
+
+- `build.extra.typeinfo.operator-manifests.archive` (string): name of the archive containing operator manifest files
 
 # Type-specific buildroot metadata:
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -2125,5 +2125,11 @@ class TestKojiImport(object):
             operator_manifests = extra['operator_manifests_archive']
             assert isinstance(operator_manifests, str)
             assert operator_manifests == OPERATOR_MANIFESTS_ARCHIVE
+            assert 'typeinfo' in extra
+            assert 'operator-manifests' in extra['typeinfo']
+            operator_typeinfo = extra['typeinfo']['operator-manifests']
+            assert isinstance(operator_typeinfo, dict)
+            assert operator_typeinfo['archive'] == OPERATOR_MANIFESTS_ARCHIVE
         else:
             assert 'operator_manifests_archive' not in extra
+            assert 'typeinfo' not in extra


### PR DESCRIPTION
Operator manifest archives should use their own koji build type. This
replaces the former behavior, where the operator metadata archives were
uploaded to koji as log files.

* OSBS-7160

This shall create a new typeinfo section in the build.extra koij metadata, which currently looks like this:

```
{
   "typeinfo" : {
      "operator-manifests" : {
         "archive" : "operator_manifests.zip"
      }
   }
}
```

Currently, the build.extra.image is also being appended to `typeinfo`. Koji also shows a `info` link to the operator manifests archive metadata, but errors out when requested, with `File "/usr/share/koji-hub/kojihub.py", line 4539, in _fetchSingle raise koji.GenericError('query returned no rows')`.

@MartinBasti , Could this typeinfo content substitute the `build.extra.operator_manifests_archive`?

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
