### PR TITLE
Catch all exceptions for get_archive and remove_container

### DIFF
--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -118,8 +118,15 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
                            IMG_MANIFESTS_PATH, ex)
             self.log.error(msg)
             raise RuntimeError('%s %s' % (msg, ex))
+
+        except Exception as ex:
+            raise RuntimeError('%s' % ex)
+
         finally:
-            self.tasker.d.remove_container(container_id)
+            try:
+                self.tasker.d.remove_container(container_id)
+            except Exception as ex:
+                self.log.warning('Failed to remove container %s: %s' % (container_id, ex))
 
         with tempfile.NamedTemporaryFile() as extracted_file:
             for chunk in bits:


### PR DESCRIPTION
*OSBS-7560

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
