### PR TITLE
Fix pylint warnings, part 2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -36,7 +36,6 @@ disable=I,
         comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
         dangerous-default-value,  # should be enabled
         deprecated-lambda,  # nice to have
-        expression-not-assigned,  # should be enabled
         fixme,
         import-error,  # requires to having all modules installed
         invalid-name,

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,6 @@ disable=I,
         bad-whitespace,  # pep8, nice to have
         broad-except,
         comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
-        dangerous-default-value,  # should be enabled
         deprecated-lambda,  # nice to have
         fixme,
         import-error,  # requires to having all modules installed

--- a/.pylintrc
+++ b/.pylintrc
@@ -30,7 +30,6 @@ disable=I,
         R,  # refactoring checks
         abstract-method,  # nice to have
         arguments-differ,  # nice to have
-        attribute-defined-outside-init,  # should be enabled
         bad-continuation,  # pep8
         bad-whitespace,  # pep8, nice to have
         broad-except,

--- a/.pylintrc
+++ b/.pylintrc
@@ -38,7 +38,6 @@ disable=I,
         deprecated-lambda,  # nice to have
         expression-not-assigned,  # should be enabled
         fixme,
-        global-statement,  # should be enabled, we have fixtures in test
         import-error,  # requires to having all modules installed
         invalid-name,
         len-as-condition,  # nice to have

--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -148,6 +148,8 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         # arguments for build
         self.source = source
         self.base_image = None
+        self.base_image_insecure = None
+        self.base_image_dockercfg_path = None
         self.original_base_image = None
         self._base_image_inspect = None
         self.parents_pulled = False

--- a/atomic_reactor/cli/main.py
+++ b/atomic_reactor/cli/main.py
@@ -109,6 +109,7 @@ class CLI(object):
         self.build_parser = None
         self.bi_parser = None
         self.ib_parser = None
+        self.source_types_parsers = None
 
         locale.setlocale(locale.LC_ALL, '')
 

--- a/atomic_reactor/outer.py
+++ b/atomic_reactor/outer.py
@@ -37,6 +37,7 @@ class BuildManager(BuilderStateMachine):
         self.uri = build_args['source']['uri']
 
         self.temp_dir = None
+        self.build_container_id = None
         # build image after build
         self.buildroot_image_id = None
         self.buildroot_image_name = None

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -509,7 +509,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         unique_fragment = '%r.%s' % (time.time(), random_chars)
         return os.path.join(dir_prefix, unique_fragment)
 
-    def _update_content_versions(self, worker_reactor_conf, valid_values=['v2']):
+    def _update_content_versions(self, worker_reactor_conf, valid_values=('v2',)):
         if 'content_versions' not in worker_reactor_conf:
             return
 

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -124,6 +124,7 @@ class KojiImportPlugin(ExitPlugin):
 
         self.osbs = get_openshift_session(self.workflow, self.openshift_fallback)
         self.build_id = None
+        self.session = None
 
     def get_output(self, worker_metadatas):
         """

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -138,6 +138,7 @@ class KojiPromotePlugin(ExitPlugin):
         self.osbs = get_openshift_session(self.workflow, self.openshift_fallback)
         self.build_id = None
         self.pullspec_image = None
+        self.koji_session = None
 
     def get_rpms(self):
         """

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -45,6 +45,9 @@ class OSv3InputPlugin(InputPlugin):
         """
         # call parent constructor
         super(OSv3InputPlugin, self).__init__(**kwargs)
+        self.target_registry = None
+        self.reactor_env = None
+        self.plugins_json = None
 
     def validate_user_data(self, user_params):
         # make sure the input json is valid
@@ -184,7 +187,6 @@ class OSv3InputPlugin(InputPlugin):
         git_ref = os.environ.get('SOURCE_REF', None)
         image = os.environ['OUTPUT_IMAGE']
         self.target_registry = os.environ.get('OUTPUT_REGISTRY', None)
-        self.reactor_env = None
 
         git_commit_depth = None
         git_branch = None

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -130,6 +130,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
         self.architecture = architecture
         self.scratch = util.is_scratch_build()
         self.koji_target = koji_target
+        self.session = None
 
     def is_image_build_type(self, base_image):
         return base_image.strip().lower() == 'koji/image-build'

--- a/atomic_reactor/plugins/pre_hide_files.py
+++ b/atomic_reactor/plugins/pre_hide_files.py
@@ -36,13 +36,13 @@ class HideFilesPlugin(PreBuildPlugin):
         run the plugin
         """
         try:
-            self.hide_files = get_hide_files(self.workflow)
+            hide_files = get_hide_files(self.workflow)
         except KeyError:
             self.log.info("Skipping hide files: no files to hide")
             return
 
-        self._populate_start_file_lines()
-        self._populate_end_file_lines()
+        self._populate_start_file_lines(hide_files)
+        self._populate_end_file_lines(hide_files)
 
         self.dfp = df_parser(self.workflow.builder.df_path)
         stages = self._find_stages()
@@ -72,15 +72,15 @@ class HideFilesPlugin(PreBuildPlugin):
 
         return stages
 
-    def _populate_start_file_lines(self):
-        for file_to_hide in self.hide_files['files']:
+    def _populate_start_file_lines(self, hide_files):
+        for file_to_hide in hide_files['files']:
             self.start_lines.append('RUN mv -f {} {} || :'.format(file_to_hide,
-                                                                  self.hide_files['tmpdir']))
+                                                                  hide_files['tmpdir']))
 
-    def _populate_end_file_lines(self):
-        for file_to_hide in self.hide_files['files']:
+    def _populate_end_file_lines(self, hide_files):
+        for file_to_hide in hide_files['files']:
             file_base = os.path.basename(file_to_hide)
-            tmp_dest = os.path.join(self.hide_files['tmpdir'], file_base)
+            tmp_dest = os.path.join(hide_files['tmpdir'], file_base)
 
             self.end_lines.append('RUN mv -fZ {} {} || :'.format(tmp_dest, file_to_hide))
 

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -71,12 +71,15 @@ class PullBaseImagePlugin(PreBuildPlugin):
             metadata = self.workflow.builder.parent_images_digests
             metadata.update(parent_images_digests)
 
+        self.manifest_list_cache = {}
+
     def run(self):
         """
         Pull parent images and retag them uniquely for this build.
         """
+        self.manifest_list_cache.clear()
+
         build_json = get_build_json()
-        self.manifest_list_cache = {}
         organization = get_registries_organization(self.workflow)
         digest_fetching_exceptions = []
         for nonce, parent in enumerate(sorted(self.workflow.builder.parent_images.keys(),

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -66,6 +66,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         :param workflow: DockerBuildWorkflow instance
         """
         super(FlatpakCreateOciPlugin, self).__init__(tasker, workflow)
+        self.builder = None
 
     def _export_container(self, container_id):
         export_generator = self.tasker.d.export(container_id)
@@ -91,11 +92,11 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
             self.tasker.d.remove_container(container_id)
 
     def run(self):
-        self.source = get_flatpak_source_info(self.workflow)
-        if self.source is None:
+        source = get_flatpak_source_info(self.workflow)
+        if source is None:
             raise RuntimeError("flatpak_create_dockerfile must be run before flatpak_create_oci")
 
-        self.builder = FlatpakBuilder(self.source, self.workflow.source.workdir,
+        self.builder = FlatpakBuilder(source, self.workflow.source.workdir,
                                       'var/tmp/flatpak-build',
                                       parse_manifest=parse_rpm_output)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -322,6 +322,7 @@ class LazyGit(object):
         # commit ID of HEAD; we'll figure this out ourselves
         self._commit_id = None
         self.provided_tmpdir = tmpdir
+        self.our_tmpdir = None
         self._git_path = None
         self._branch = branch
         self._git_depth = depth

--- a/atomic_reactor/yum_util.py
+++ b/atomic_reactor/yum_util.py
@@ -43,6 +43,7 @@ class YumRepo(object):
         self.dst_repos_dir = dst_repos_dir
 
         self.content = content
+        self.config = None
 
     @property
     def filename(self):

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -43,7 +43,7 @@ mock_image = \
      'Size': 0,
      'VirtualSize': 856564160}
 
-mock_images = None
+mock_images = []
 
 mock_logs = 'uid=0(root) gid=0(root) groups=10(wheel)'
 
@@ -194,8 +194,6 @@ mock_inspect_container = {
 
 
 def _find_image(img, ignore_registry=False):
-    global mock_images
-
     tagged_img = ImageName.parse(img).to_str(explicit_tag=True)
     for im in mock_images:
         im_name = im['RepoTags'][0]
@@ -387,7 +385,7 @@ def mock_docker(build_should_fail=False,
              .and_raise(docker.errors.APIError, "xyz", response))
 
     if remember_images:
-        global mock_images
+        global mock_images  # pylint: disable=global-statement
         mock_images = [mock_image]
 
         flexmock(docker.APIClient, inspect_image=_mock_inspect)

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -266,7 +266,7 @@ def mock_docker(build_should_fail=False,
                 inspect_should_fail=False,
                 wait_should_fail=False,
                 provided_image_repotags=None,
-                should_raise_error={},
+                should_raise_error=None,
                 remember_images=False,
                 push_should_fail=False):
     """
@@ -276,7 +276,7 @@ def mock_docker(build_should_fail=False,
     :param inspect_should_fail: True == inspect_image() will raise docker.errors.NotFound
     :param wait_should_fail: True == wait() will return 1 instead of 0
     :param provided_image_repotags: images() will contain provided image
-    :param should_raise_error: methods (with args) to raise docker.errors.APIError
+    :param should_raise_error: dict, methods (with args) to raise docker.errors.APIError
     :param remember_images: keep track of available image tags
     """
     if provided_image_repotags:
@@ -372,6 +372,7 @@ def mock_docker(build_should_fail=False,
 
     flexmock(docker.APIClient, remove_volume=lambda iid, **kwargs: remove_volume(iid))
 
+    should_raise_error = should_raise_error or {}
     for method, args in should_raise_error.items():
         response = flexmock(content="abc", status_code=123)
         if args:

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -312,20 +312,22 @@ SDK_CONFIG = {
 }
 
 
-def build_flatpak_test_configs(extensions={}):
+def build_flatpak_test_configs(extensions=None):
     configs = {
         'app': APP_CONFIG,
         'runtime': RUNTIME_CONFIG,
         'sdk': SDK_CONFIG,
     }
 
+    extensions = extensions or {}
     for key, config in extensions.items():
         configs[key].update(config)
 
     return configs
 
 
-def setup_flatpak_compose_info(workflow, config=APP_CONFIG):
+def setup_flatpak_compose_info(workflow, config=None):
+    config = APP_CONFIG if config is None else config
     modules = {}
     for name, module_config in config['modules'].items():
         mmd = Modulemd.Module.new_from_string(module_config['metadata'])
@@ -354,7 +356,8 @@ def setup_flatpak_compose_info(workflow, config=APP_CONFIG):
     return compose
 
 
-def setup_flatpak_source_info(workflow, config=APP_CONFIG):
+def setup_flatpak_source_info(workflow, config=None):
+    config = APP_CONFIG if config is None else config
     compose = setup_flatpak_compose_info(workflow, config)
 
     flatpak_yaml = yaml.safe_load(config['container_yaml'])['flatpak']

--- a/tests/plugins/test_add_help.py
+++ b/tests/plugins/test_add_help.py
@@ -26,14 +26,14 @@ from flexmock import flexmock
 
 
 class Y(object):
-    pass
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = None
 
 
 class X(object):
     image_id = "xxx"
     source = Y()
-    source.dockerfile_path = None
-    source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
 
 

--- a/tests/plugins/test_add_help.py
+++ b/tests/plugins/test_add_help.py
@@ -15,26 +15,15 @@ import pytest
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
-from atomic_reactor.util import ImageName, df_parser
+from atomic_reactor.util import df_parser
 from atomic_reactor import start_time as atomic_reactor_start_time
 
 from datetime import datetime as dt
 from tests.constants import MOCK_SOURCE
+from tests.stubs import StubInsideBuilder
 
 from textwrap import dedent
 from flexmock import flexmock
-
-
-class Y(object):
-    def __init__(self):
-        self.dockerfile_path = None
-        self.path = None
-
-
-class X(object):
-    image_id = "xxx"
-    source = Y()
-    base_image = ImageName(repo="qwe", tag="asd")
 
 
 class MockedPopen(object):
@@ -69,9 +58,7 @@ def test_add_help_plugin(tmpdir, docker_tasker, filename):
     df.content = df_content
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
-    workflow.builder = X
-    workflow.builder.df_path = df.dockerfile_path
-    workflow.builder.df_dir = str(tmpdir)
+    workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)
     generate_a_file(help_markdown_path, "foo")
@@ -113,9 +100,7 @@ def test_add_help_no_help_file(request, tmpdir, docker_tasker, filename):
     df.content = df_content
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
-    workflow.builder = X
-    workflow.builder.df_path = df.dockerfile_path
-    workflow.builder.df_dir = str(tmpdir)
+    workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
         docker_tasker,
@@ -144,9 +129,7 @@ def test_add_help_md2man_error(request, tmpdir, docker_tasker, filename,
     df.content = df_content
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
-    workflow.builder = X
-    workflow.builder.df_path = df.dockerfile_path
-    workflow.builder.df_dir = str(tmpdir)
+    workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)
     if go_md2man_result != 'input_missing':
@@ -258,9 +241,7 @@ def test_add_help_generate_metadata(tmpdir, docker_tasker, filename):
     df.content = df_content
 
     workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
-    workflow.builder = X
-    workflow.builder.df_path = df.dockerfile_path
-    workflow.builder.df_dir = str(tmpdir)
+    workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)
     generate_a_file(help_markdown_path, "foo")

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -217,7 +217,9 @@ class TestBumpRelease(object):
 
         class MockedClientSession(object):
             def __init__(self, hub, opts=None):
-                pass
+                self.ca_path = None
+                self.cert_path = None
+                self.serverca_path = None
 
             def getNextRelease(self, build_info):
                 assert build_info['name'] == list(component.values())[0]

--- a/tests/plugins/test_delete_from_registry.py
+++ b/tests/plugins/test_delete_from_registry.py
@@ -39,14 +39,14 @@ DIGEST_LIST = 'sha256:deadbeef'
 
 
 class Y(object):
-    pass
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = None
 
 
 class X(object):
     image_id = INPUT_IMAGE
     source = Y()
-    source.dockerfile_path = None
-    source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
 
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -55,6 +55,7 @@ class MockBuilder(object):
     def __init__(self):
         self.image_id = "xxx"
         self.base_image = ImageName.parse("org.gnome.eog")
+        self.df_path = None
 
     def set_base_image(self, base_image):
         pass

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -302,14 +302,14 @@ def mock_registries(registries, config, schema_version='v2', foreign_layers=Fals
 
 
 class Y(object):
-    pass
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = None
 
 
 class X(object):
     image_id = INPUT_IMAGE
     source = Y()
-    source.dockerfile_path = None
-    source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
 
 

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -314,7 +314,7 @@ class X(object):
 
 
 def mock_environment(tmpdir, primary_images=None,
-                     annotations={}):
+                     annotations=None):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
@@ -335,7 +335,7 @@ def mock_environment(tmpdir, primary_images=None,
                 workflow.tag_conf.add_primary_image(image)
         workflow.tag_conf.add_unique_image(primary_images[0])
 
-    workflow.build_result = BuildResult(image_id='123456', annotations=annotations)
+    workflow.build_result = BuildResult(image_id='123456', annotations=annotations or {})
 
     return tasker, workflow
 

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -17,7 +17,8 @@ import os
 import requests
 from six import binary_type, text_type
 
-from tests.constants import SOURCE, INPUT_IMAGE, MOCK, DOCKER0_REGISTRY
+from tests.constants import SOURCE, MOCK, DOCKER0_REGISTRY
+from tests.stubs import StubInsideBuilder
 
 from atomic_reactor.core import DockerTasker
 from atomic_reactor.build import BuildResult
@@ -301,18 +302,6 @@ def mock_registries(registries, config, schema_version='v2', foreign_layers=Fals
     }
 
 
-class Y(object):
-    def __init__(self):
-        self.dockerfile_path = None
-        self.path = None
-
-
-class X(object):
-    image_id = INPUT_IMAGE
-    source = Y()
-    base_image = ImageName(repo="qwe", tag="asd")
-
-
 def mock_environment(tmpdir, primary_images=None,
                      annotations=None):
     if MOCK:
@@ -321,10 +310,10 @@ def mock_environment(tmpdir, primary_images=None,
     workflow = DockerBuildWorkflow(SOURCE, "test-image")
     base_image_id = '123456parent-id'
     setattr(workflow, '_base_image_inspect', {'Id': base_image_id})
-    setattr(workflow, 'builder', X())
+    setattr(workflow, 'builder', StubInsideBuilder())
     setattr(workflow.builder, 'image_id', '123456imageid')
     setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='22'))
-    setattr(workflow.builder, 'source', X())
+    setattr(workflow.builder, 'source', StubInsideBuilder())
     setattr(workflow.builder, 'built_image_info', {'ParentId': base_image_id})
     setattr(workflow.builder.source, 'dockerfile_path', None)
     setattr(workflow.builder.source, 'path', None)

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -63,7 +63,9 @@ ROOT = "http://example.com"
 # ClientSession is xmlrpc instance, we need to mock it explicitly
 class MockedClientSession(object):
     def __init__(self, hub, opts=None):
-        pass
+        self.ca_path = None
+        self.cert_path = None
+        self.serverca_path = None
 
     def getBuildTarget(self, target):
         if target == KOJI_TARGET_BROKEN_TAG:

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -96,6 +96,9 @@ class MockedClientSession(object):
         self.getLoggedInUser = lambda: {'name': SUBMITTER}
         self.getUser = lambda *_: {'name': None}
 
+        self.blocksize = None
+        self.server_dir = None
+
     def krb_login(self, principal=None, keytab=None, proxyuser=None):
         return True
 
@@ -111,7 +114,9 @@ class MockedClientSession(object):
         self.blocksize = blocksize
 
     def CGImport(self, metadata, server_dir):
-        self.metadata = metadata
+        # metadata cannot be defined in __init__ because tests assume
+        # the attribute will not be defined unless this method is called
+        self.metadata = metadata    # pylint: disable=attribute-defined-outside-init
         self.server_dir = server_dir
         return {"id": "123"}
 

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -137,6 +137,10 @@ class MockedClientSession(object):
         self.task_states.reverse()
         self.tag_task_state = self.task_states.pop()
 
+        self.blocksize = None
+        self.metadata = None
+        self.server_dir = None
+
     def krb_login(self, principal=None, keytab=None, proxyuser=None):
         return True
 

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -123,7 +123,7 @@ class fake_manifest_list(object):
         return self.content
 
 
-def mock_workflow(tmpdir, platforms=['x86_64', 'ppc64le']):
+def mock_workflow(tmpdir, platforms=None):
     workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
     builder = MockInsideBuilder()
     source = MockSource(tmpdir)
@@ -142,6 +142,7 @@ def mock_workflow(tmpdir, platforms=['x86_64', 'ppc64le']):
     df = df_parser(df_path)
     setattr(workflow.builder, 'df_path', df.dockerfile_path)
 
+    platforms = ['x86_64', 'ppc64le'] if platforms is None else platforms
     workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = set(platforms)
 
     build = {

--- a/tests/plugins/test_pulp_publish.py
+++ b/tests/plugins/test_pulp_publish.py
@@ -56,7 +56,7 @@ class BuildInfo(object):
         self.build = BuildResponse({'metadata': {'annotations': annotations}})
 
 
-def prepare(success=True, v1_image_ids={}):
+def prepare(success=True, v1_image_ids=None):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
@@ -132,6 +132,7 @@ def prepare(success=True, v1_image_ids={}):
     build_info['ppc64le'] = BuildInfo()
     build_info['bogus'] = BuildInfo(unset_annotations=True)  # OSBS-5262
 
+    v1_image_ids = v1_image_ids or {}
     for platform, v1_image_id in v1_image_ids.items():
         build_info[platform] = BuildInfo(v1_image_id)
 

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -57,7 +57,7 @@ class BuildInfo(object):
         self.build = BuildResponse({'metadata': {'annotations': annotations}})
 
 
-def prepare(v1_image_ids={}):
+def prepare(v1_image_ids=None):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
@@ -143,6 +143,7 @@ def prepare(v1_image_ids={}):
     build_info['x86_64'] = BuildInfo()
     build_info['ppc64le'] = BuildInfo()
 
+    v1_image_ids = v1_image_ids or {}
     for platform, v1_image_id in v1_image_ids.items():
         build_info[platform] = BuildInfo(v1_image_id)
 

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -1228,7 +1228,7 @@ class TestResolveComposes(object):
 
     def run_plugin_with_args(self, workflow, plugin_args=None,
                              expect_error=None, reactor_config_map=False,
-                             platforms=ODCS_COMPOSE_DEFAULT_ARCH_LIST, is_pulp=None,
+                             platforms=None, is_pulp=None,
                              check_for_default_id=True):
         plugin_args = plugin_args or {}
         plugin_args.setdefault('odcs_url', ODCS_URL)
@@ -1260,7 +1260,8 @@ class TestResolveComposes(object):
 
         results = runner.run()[ResolveComposesPlugin.key]
         if results:
-            for platform in platforms or []:
+            platforms = ODCS_COMPOSE_DEFAULT_ARCH_LIST if platforms is None else platforms
+            for platform in platforms:
                 yum_repourls = self.get_override_yum_repourls(workflow, platform)
                 # Koji tag compose is present in each one
                 if check_for_default_id:

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -78,6 +78,7 @@ class MockBuilder(object):
     def __init__(self):
         self.image_id = "xxx"
         self.base_image = ImageName.parse("org.gnome.eog")
+        self.df_path = None
 
     def set_base_image(self, base_image):
         pass

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -49,7 +49,7 @@ def mock_logs_empty(cid, **kwargs):
     return ''
 
 
-def mock_logs_retry(cid, cache={}, **kwargs):
+def mock_logs_retry(cid, cache={}, **kwargs):   # pylint: disable=dangerous-default-value
     cache.setdefault('attempt', 0)
 
     if cache['attempt'] < 4:

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -144,7 +144,8 @@ DEFAULT_ANNOTATIONS = {
 }
 
 
-def mock_store_metadata_results(workflow, annotations=DEFAULT_ANNOTATIONS):
+def mock_store_metadata_results(workflow, annotations=None):
+    annotations = DEFAULT_ANNOTATIONS if annotations is None else annotations
     result = {}
     if annotations:
         result['annotations'] = {key: json.dumps(value) for key, value in annotations.items()}
@@ -467,7 +468,7 @@ class TestSendMailPlugin(object):
                 else:
                     mock_store_metadata_results(workflow, {'repositories': {}})
             else:
-                mock_store_metadata_results(workflow, None)
+                mock_store_metadata_results(workflow, {})
 
         if reactor_config_map:
             openshift_map = {'url': 'https://something.com'}

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -64,6 +64,9 @@ class MockInsideBuilder(object):
 
 
 class TestSquashPlugin(object):
+    workflow = None
+    tasker = None
+    output_path = None
 
     def setup_method(self, method):
         if MOCK:

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -81,6 +81,7 @@ class XBeforeDockerfile(object):
         self.base_image = None
         self.parent_images = {}
         self.base_from_scratch = False
+        self.df_dir = None
 
     def parent_images_to_str(self):
         return {}

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -83,14 +83,14 @@ PUSH_ERROR_LOGS = [
 
 
 class Y(object):
-    pass
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = None
 
 
 class X(object):
     image_id = INPUT_IMAGE
     source = Y()
-    source.dockerfile_path = None
-    source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
 
 

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -18,9 +18,10 @@ from atomic_reactor.plugins.post_tag_and_push import TagAndPushPlugin
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        WORKSPACE_CONF_KEY,
                                                        ReactorConfig)
-from atomic_reactor.util import ImageName, ManifestDigest, get_exported_image_metadata
+from atomic_reactor.util import ManifestDigest, get_exported_image_metadata
 from tests.constants import (LOCALHOST_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME, INPUT_IMAGE, MOCK,
                              DOCKER0_REGISTRY)
+from tests.stubs import StubInsideBuilder
 
 import json
 import logging
@@ -82,18 +83,6 @@ PUSH_ERROR_LOGS = [
 ]
 
 
-class Y(object):
-    def __init__(self):
-        self.dockerfile_path = None
-        self.path = None
-
-
-class X(object):
-    image_id = INPUT_IMAGE
-    source = Y()
-    base_image = ImageName(repo="qwe", tag="asd")
-
-
 @pytest.mark.parametrize("use_secret", [
     True,
     False,
@@ -135,7 +124,8 @@ def test_tag_and_push_plugin(
     tasker = DockerTasker(retry_times=0)
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
     workflow.tag_conf.add_primary_image(image_name)
-    setattr(workflow, 'builder', X)
+    workflow.builder = StubInsideBuilder()
+    workflow.builder.image_id = INPUT_IMAGE
 
     secret_path = None
     if use_secret:
@@ -363,7 +353,8 @@ def test_tag_and_push_plugin_oci(
 
     tasker = DockerTasker()
     workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
-    setattr(workflow, 'builder', X)
+    workflow.builder = StubInsideBuilder()
+    workflow.builder.image_id = INPUT_IMAGE
 
     secret_path = None
     if use_secret:

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -22,14 +22,14 @@ if MOCK:
 
 
 class Y(object):
-    pass
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = None
 
 
 class X(object):
     image_id = INPUT_IMAGE
     source = Y()
-    source.dockerfile_path = None
-    source.path = None
     base_image = ImageName(repo="qwe", tag="asd")
     image = ImageName.parse("test-image:unique_tag_123")
 

--- a/tests/plugins/test_tag_by_labels.py
+++ b/tests/plugins/test_tag_by_labels.py
@@ -14,24 +14,12 @@ from atomic_reactor.plugin import PostBuildPluginsRunner
 from atomic_reactor.plugins.post_tag_by_labels import TagByLabelsPlugin
 from atomic_reactor.util import ImageName
 from atomic_reactor.constants import INSPECT_CONFIG
-from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, INPUT_IMAGE, MOCK
+from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, MOCK
+from tests.stubs import StubInsideBuilder
 import pytest
 
 if MOCK:
     from tests.docker_mock import mock_docker
-
-
-class Y(object):
-    def __init__(self):
-        self.dockerfile_path = None
-        self.path = None
-
-
-class X(object):
-    image_id = INPUT_IMAGE
-    source = Y()
-    base_image = ImageName(repo="qwe", tag="asd")
-    image = ImageName.parse("test-image:unique_tag_123")
 
 
 @pytest.mark.parametrize('args', [
@@ -60,7 +48,8 @@ def test_tag_by_labels_plugin(tmpdir, args):
                       tag="%s_%s" % (version, release),
                       registry=LOCALHOST_REGISTRY)
 
-    setattr(workflow, 'builder', X)
+    workflow.builder = (StubInsideBuilder()
+                        .set_image(ImageName.parse("test-image:unique_tag_123")))
 
     runner = PostBuildPluginsRunner(
         tasker,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,8 +29,8 @@ from tests.constants import LOCALHOST_REGISTRY, DOCKERFILE_GIT, DOCKERFILE_OK_PA
 if MOCK:
     from tests.docker_mock import mock_docker
 
-PRIV_BUILD_IMAGE = None
-DH_BUILD_IMAGE = None
+PRIV_BUILD_IMAGE = uuid_value()
+DH_BUILD_IMAGE = uuid_value()
 
 
 logger = logging.getLogger('atomic_reactor.tests')
@@ -49,9 +49,6 @@ with_all_sources = pytest.mark.parametrize('source_provider, uri', [
 
 
 def setup_module(module):
-    global PRIV_BUILD_IMAGE, DH_BUILD_IMAGE
-    PRIV_BUILD_IMAGE = uuid_value()
-    DH_BUILD_IMAGE = uuid_value()
     if MOCK:
         return
 

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -424,7 +424,7 @@ class TestLockedPulpRepository(object):
         for i in range(failures):
             expectation = expectation.and_raise(exc).ordered()
 
-        expectation.and_return(None).ordered
+        expectation.and_return(None).ordered()
 
         pulp.should_receive('deleteRepo').once().ordered()
 

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -40,12 +40,12 @@ input_image_name = ImageName.parse(INPUT_IMAGE)
 def setup_module(module):
     if MOCK:
         return
-    d = docker.Client()
+    d = docker.Client()  # TODO: current version of python-docker does not have Client anymore
     try:
         d.inspect_image(INPUT_IMAGE)
         setattr(module, 'HAS_IMAGE', True)
     except docker.errors.APIError:
-        [x for x in d.pull(INPUT_IMAGE, decode=True, stream=True)]
+        d.pull(INPUT_IMAGE)
         setattr(module, 'HAS_IMAGE', False)
 
 


### PR DESCRIPTION
Part 2 of pylint issue fixes.

For attributes defined outside `__init__`, I usually just defined them as `None`, though in some cases it seemed possible to turn them into basic local variables so I did that.

For global statements, I just made slight workarounds to get rid of the `global` statement, but `docker_mock.py` still heavily relies on global variables.

Also, `test_tasker.py` uses `docker.Client`, which no longer exists. I don't know where (or if) these tests are used with NOMOCK, so I just added a TODO about it.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
