### PR TITLE
Add the posibility to use koji's fast upload API.

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -126,16 +126,21 @@ def koji_login(session,
     return result
 
 
-def create_koji_session(hub_url, auth_info=None):
+def create_koji_session(hub_url, auth_info=None, use_fast_upload=True):
     """
     Creates and returns a Koji session. If auth_info
     is provided, the session will be authenticated.
 
     :param hub_url: str, Koji hub URL
     :param auth_info: dict, authentication parameters used for koji_login
+    :param use_fast_upload: bool, flag to use or not Koji's fast upload API.
     :return: koji.ClientSession instance
     """
-    session = KojiSessionWrapper(koji.ClientSession(hub_url, opts={'krb_rdns': False}))
+    session = KojiSessionWrapper(koji.ClientSession(
+        hub_url,
+        opts={'krb_rdns': False, 'use_fast_upload': use_fast_upload}
+        )
+    )
 
     if auth_info is not None:
         koji_login(session, **auth_info)

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -77,7 +77,9 @@ def get_koji_session(workflow, fallback):
         "krb_keytab": config['auth'].get('krb_keytab_path')
     }
 
-    return create_koji_session(config['hub_url'], auth_info)
+    use_fast_upload = config.get('use_fast_upload', True)
+
+    return create_koji_session(config['hub_url'], auth_info, use_fast_upload)
 
 
 def get_koji_path_info(workflow, fallback):

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -99,6 +99,11 @@
                         "additionalProperties": false
                     }
                 ]
+            },
+            "use_fast_upload": {
+                "description": "Use Koji's fast upload API",
+                "type": "boolean",
+                "default": true
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -714,6 +714,18 @@ class TestReactorConfigPlugin(object):
               root_url: https://koji.example.com/root
               auth:
                   proxyuser: proxyuser
+                  krb_principal: krb_principal
+                  krb_keytab_path: /tmp/krb_keytab
+              use_fast_upload: false
+        """, False),
+
+        ("""\
+          version: 1
+          koji:
+              hub_url: https://koji.example.com/hub
+              root_url: https://koji.example.com/root
+              auth:
+                  proxyuser: proxyuser
                   ssl_certs_dir: /var/certs
         """, False),
 
@@ -805,17 +817,20 @@ class TestReactorConfigPlugin(object):
             "krb_keytab": config_json['koji']['auth'].get('krb_keytab_path')
         }
 
+        use_fast_upload = config_json['koji'].get('use_fast_upload', True)
+
         fallback_map = {}
         if fallback:
             fallback_map = {'auth': deepcopy(auth_info), 'hub_url': config_json['koji']['hub_url']}
             fallback_map['auth']['krb_keytab_path'] = fallback_map['auth'].pop('krb_keytab')
+            fallback_map['use_fast_upload'] = use_fast_upload
         else:
             workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] = \
                 ReactorConfig(config_json)
 
         (flexmock(atomic_reactor.koji_util)
             .should_receive('create_koji_session')
-            .with_args(config_json['koji']['hub_url'], auth_info)
+            .with_args(config_json['koji']['hub_url'], auth_info, use_fast_upload)
             .once()
             .and_return(True))
 

--- a/tests/test_koji_util.py
+++ b/tests/test_koji_util.py
@@ -106,7 +106,7 @@ class TestCreateKojiSession(object):
         session = flexmock()
 
         (flexmock(koji_util.koji).should_receive('ClientSession').with_args(
-            url, opts={'krb_rdns': False}).and_return(session))
+            url, opts={'krb_rdns': False, 'use_fast_upload': True}).and_return(session))
         assert create_koji_session(url)._wrapped_session == session
 
     @pytest.mark.parametrize(('ssl_session'), [
@@ -124,7 +124,7 @@ class TestCreateKojiSession(object):
             session.should_receive('krb_login').once().and_return(True)
 
         (flexmock(koji_util.koji).should_receive('ClientSession').with_args(
-            url, opts={'krb_rdns': False}).and_return(session))
+            url, opts={'krb_rdns': False, 'use_fast_upload': True}).and_return(session))
         assert create_koji_session(url, args)._wrapped_session == session
 
     @pytest.mark.parametrize(('ssl_session'), [
@@ -142,7 +142,7 @@ class TestCreateKojiSession(object):
             session.should_receive('krb_login').once().and_return(False)
 
         (flexmock(koji_util.koji).should_receive('ClientSession').with_args(
-            url, opts={'krb_rdns': False}).and_return(session))
+            url, opts={'krb_rdns': False, 'use_fast_upload': True}).and_return(session))
         with pytest.raises(RuntimeError):
             create_koji_session(url, args)
 
@@ -163,7 +163,7 @@ class TestCreateKojiSession(object):
 
         session = flexmock(_value="test_value")
         (flexmock(koji_util.koji).should_receive('ClientSession').with_args(
-            url, opts={'krb_rdns': False}).and_return(session))
+            url, opts={'krb_rdns': False, 'use_fast_upload': True}).and_return(session))
 
         flexmock(time).should_receive('sleep').and_return(None)
 


### PR DESCRIPTION
This commit adds the possibility to set a flag in the configmap
to use or not Koji's fast upload API.
This solves https://pagure.io/fedora-infrastructure/issue/7846

Signed-off-by: Clement Verna <cverna@tutanota.com>

osbs-docs PR : https://github.com/containerbuildsystem/osbs-docs/pull/78

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
