### PR TITLE
Fix pylint warnings, part 3 (final)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,6 @@ disable=I,
         unicode-builtin,
         unidiomatic-typecheck,  # nice to have
         ungrouped-imports,
-        unreachable,  # should be enabled, dead code
         unnecessary-lambda,  # nice to have
         unneeded-not,  # nice to have
         unused-argument,  # nice to have

--- a/.pylintrc
+++ b/.pylintrc
@@ -51,7 +51,6 @@ disable=I,
         no-self-argument,  # nice to have
         not-callable,  # disabled due to flexmock module
         not-context-manager,  # causes false positives
-        pointless-statement,  # should be enabled
         protected-access,
         redefined-outer-name,  # nice to have
         reimported,  # should be enabled

--- a/.pylintrc
+++ b/.pylintrc
@@ -63,7 +63,6 @@ disable=I,
         unnecessary-lambda,  # nice to have
         unneeded-not,  # nice to have
         unused-argument,  # nice to have
-        unused-variable,  # should be enabled
         useless-import-alias,  # nice to have
         useless-super-delegation,  # nice to have
         wrong-import-order,

--- a/.pylintrc
+++ b/.pylintrc
@@ -53,7 +53,6 @@ disable=I,
         not-context-manager,  # causes false positives
         protected-access,
         redefined-outer-name,  # nice to have
-        reimported,  # should be enabled
         relative-import,  # nice to have
         super-init-not-called,  # nice to have
         superfluous-parens,  # nice to have

--- a/.pylintrc
+++ b/.pylintrc
@@ -64,7 +64,6 @@ disable=I,
         unnecessary-lambda,  # nice to have
         unneeded-not,  # nice to have
         unused-argument,  # nice to have
-        unused-import,  # should be enabled
         unused-variable,  # should be enabled
         useless-import-alias,  # nice to have
         useless-super-delegation,  # nice to have

--- a/atomic_reactor/auth.py
+++ b/atomic_reactor/auth.py
@@ -82,7 +82,7 @@ class HTTPBearerAuth(AuthBase):
         # Consume content and release the original connection
         # to allow our new request to reuse the same one.
         # This pattern was inspired by the source code of requests.auth.HTTPDigestAuth
-        response.content
+        response.content    # pylint: disable=pointless-statement; is a property
         response.close()
         retry_request = response.request.copy()
         extract_cookies_to_jar(retry_request._cookies, response.request, response.raw)

--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -245,7 +245,7 @@ def get_koji_module_build(session, module_spec):
 
         for b in builds:
             if '.' in b['release']:
-                version, context = b['release'].split('.', 1)
+                version, _ = b['release'].split('.', 1)
                 if version == module_spec.version:
                     if build is not None:
                         raise RuntimeError("Multiple builds found for {}"

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -223,7 +223,7 @@ class KojiImportPlugin(ExitPlugin):
             extra['image']['go'] = go
 
     def set_operators_metadata(self, extra, worker_metadatas):
-        for platform, metadata in worker_metadatas.items():
+        for metadata in worker_metadatas.values():
             for output in metadata['output']:
                 if output.get('filename') == OPERATOR_MANIFESTS_ARCHIVE:
                     extra['operator_manifests_archive'] = OPERATOR_MANIFESTS_ARCHIVE

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -104,9 +104,6 @@ class OSv3InputPlugin(InputPlugin):
                                    'no koji root available')
 
     def remove_pulp_plugins(self):
-        def has_plugin(self, phase, target_plugin):
-            return self.find_plugin(phase, target_plugin) >= 0
-
         phases = ('postbuild_plugins', 'exit_plugins')
         pulp_registry = self.get_value('pulp')
         koji_hub = self.get_value('koji', {}).get('hub_url')
@@ -178,7 +175,6 @@ class OSv3InputPlugin(InputPlugin):
 
         response from plugin is kept and used in json result response
         """
-        user_params = None
         build_json = get_build_json()
         git_url = os.environ['SOURCE_URI']
         git_ref = os.environ.get('SOURCE_REF', None)

--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -109,8 +109,8 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
         container_dict = self.tasker.d.create_container(image, command=['/bin/bash'])
         container_id = container_dict['Id']
         try:
-            bits, stat = self.tasker.d.get_archive(container_id,
-                                                   IMG_MANIFESTS_PATH)
+            bits, _ = self.tasker.d.get_archive(container_id,
+                                                IMG_MANIFESTS_PATH)
         except APIError as ex:
             msg = ('Could not extract operator manifest files. '
                    'Is there a %s path in the image?' % (IMG_MANIFESTS_PATH))

--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -375,7 +375,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
                 found = False
                 if len(source) != 1:
                     raise RuntimeError('Without grouping only one source is expected')
-                for platform, digest in source.items():
+                for digest in source.values():
                     self.tag_manifest_into_registry(session, digest)
                     found = True
                 if not found:

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import absolute_import
 
 from copy import deepcopy
-import re
 import subprocess
 import time
 

--- a/atomic_reactor/yum_util.py
+++ b/atomic_reactor/yum_util.py
@@ -23,7 +23,7 @@ try:
     from urlparse import unquote, urlsplit
     import ConfigParser as configparser
     # We import BytesIO as StringIO as configparser can't properly write
-    from io import BytesIO, BytesIO as StringIO
+    from io import BytesIO, BytesIO as StringIO  # pylint: disable=reimported
 except ImportError:
     # py3
     from urllib.parse import unquote, urlsplit

--- a/tests/docker_mock.py
+++ b/tests/docker_mock.py
@@ -300,7 +300,7 @@ def mock_docker(build_should_fail=False,
 
     def mock_iter_content(chunk_size=1):
         assert chunk_size == 1024*2048
-        for i in range(0, 10):
+        for _ in range(0, 10):
             yield 'XXXXXXXXXX'
 
     def mock_get(url, **kwargs):

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -14,7 +14,6 @@ from atomic_reactor.core import DockerTasker
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_add_yum_repo_by_url import AddYumRepoByUrlPlugin
-from atomic_reactor.util import ImageName
 from atomic_reactor.yum_util import YumRepo
 import requests
 import pytest

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -104,8 +104,8 @@ class TestCheckRebuild(object):
         return workflow, runner
 
     def test_check_rebuild_no_build_json(self, tmpdir, monkeypatch, reactor_config_map):
-        workflow, runner = self.prepare(tmpdir, 'is_autorebuild', 'true',
-                                        reactor_config_map=reactor_config_map)
+        _, runner = self.prepare(tmpdir, 'is_autorebuild', 'true',
+                                 reactor_config_map=reactor_config_map)
         monkeypatch.delenv('BUILD', raising=False)
 
         with pytest.raises(PluginFailedException):
@@ -114,7 +114,7 @@ class TestCheckRebuild(object):
     def test_check_no_buildconfig(self, tmpdir, monkeypatch, reactor_config_map):
         key = 'is_autorebuild'
         value = 'true'
-        workflow, runner = self.prepare(tmpdir, key, value, reactor_config_map=reactor_config_map)
+        _, runner = self.prepare(tmpdir, key, value, reactor_config_map=reactor_config_map)
         monkeypatch.setenv("BUILD", json.dumps({
             "metadata": {
                 "labels": {

--- a/tests/plugins/test_distribution_scope.py
+++ b/tests/plugins/test_distribution_scope.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import absolute_import
 
 from atomic_reactor.constants import INSPECT_CONFIG
-from atomic_reactor.plugin import PreBuildPluginsRunner  # noqa
 from atomic_reactor.plugins.pre_distribution_scope import (DistributionScopePlugin,
                                                            DisallowedDistributionScope)
 from flexmock import flexmock

--- a/tests/plugins/test_distribution_scope.py
+++ b/tests/plugins/test_distribution_scope.py
@@ -66,13 +66,14 @@ class TestDistributionScope(object):
         if base_from_scratch:
             allowed = True
         if allowed:
-            with caplog.at_level(logging.ERROR):
+            with caplog.at_level(logging.DEBUG):
                 plugin.run()
 
             # No errors logged
-            assert not caplog.records
+            assert not any(log.levelno >= logging.ERROR for log in caplog.records)
+
             if base_from_scratch:
-                "no distribution scope set for" in caplog.text
+                assert "no distribution scope set for" in caplog.text
         else:
             with pytest.raises(DisallowedDistributionScope):
                 plugin.run()

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -133,7 +133,7 @@ def test_syntax_error():
         raise docker.errors.APIError(message='foo',
                                      response=http_error,
                                      explanation=explanation)
-        yield {}
+        yield {}    # pylint: disable=unreachable; this needs to be a generator
 
     fake_builder.tasker.build_image_from_path = raise_exc
     flexmock(InsideBuilder).new_instances(fake_builder)

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -459,7 +459,7 @@ class MockFlatpak(object):
         # flatpak build-export only actually handles very specific files
         # desktop files in share/applications, icons, etc.
         dest_exportdir = os.path.join(dest, "export")
-        for dirpath, dirname, filenames in os.walk(filesdir):
+        for dirpath, _, filenames in os.walk(filesdir):
             rel_dirpath = os.path.relpath(dirpath, filesdir)
             for f in filenames:
                 if f.startswith(appname):
@@ -578,7 +578,7 @@ class DefaultInspector(object):
             line = line.strip()
             if line == '':
                 continue
-            perms, user, group, size, path = line.split()
+            perms, _, _, _, path = line.split()
             if perms.startswith('d'):  # A directory
                 continue
             files.append(path)
@@ -599,7 +599,7 @@ class DefaultInspector(object):
             line = line.strip()
             if line == '':
                 continue
-            perms, user, group, size, path = line.split()
+            perms = line.split()[0]
             return perms
 
 
@@ -616,7 +616,7 @@ class MockInspector(object):
 
         files = []
         top = os.path.join(self.path, 'tree')
-        for dirpath, dirname, filenames in os.walk(top):
+        for dirpath, _, filenames in os.walk(top):
             rel_dirpath = os.path.relpath(dirpath, top)
             files.extend([_make_absolute(os.path.join(rel_dirpath, f)) for f in filenames])
 

--- a/tests/plugins/test_hide_files.py
+++ b/tests/plugins/test_hide_files.py
@@ -20,7 +20,7 @@ from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin, ReactorConfig,
                                                        WORKSPACE_CONF_KEY)
 from atomic_reactor.plugins.pre_hide_files import HideFilesPlugin
-from atomic_reactor.util import df_parser, ImageName
+from atomic_reactor.util import df_parser
 
 from tests.constants import SOURCE, MOCK
 from tests.stubs import StubInsideBuilder

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -29,7 +29,7 @@ except ImportError:
     import koji
 
 try:
-    import atomic_reactor.plugins.post_pulp_sync  # noqa:F401
+    import atomic_reactor.plugins.post_pulp_sync  # noqa:F401; pylint: disable=unused-import
     PULP_SYNC_AVAILABLE = True
 except ImportError:
     PULP_SYNC_AVAILABLE = False

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -310,7 +310,7 @@ def mock_environment(tmpdir, session=None, name=None,
                     'container_config': {}
                 }
 
-    for pulp_registry in range(pulp_registries):
+    for _ in range(pulp_registries):
         workflow.push_conf.add_pulp_registry('env', 'crane.example.com:5000')
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:
@@ -1721,7 +1721,7 @@ class TestKojiImport(object):
         for image in workflow.tag_conf.images:
             tag = image.to_str(registry=False)
             registry.digests[tag] = 'tag'
-        for platform, metadata in workflow.postbuild_results[FetchWorkerMetadataPlugin.key].items():
+        for metadata in workflow.postbuild_results[FetchWorkerMetadataPlugin.key].values():
             for output in metadata['output']:
                 if output['type'] != 'docker-image':
                     continue
@@ -1880,7 +1880,7 @@ class TestKojiImport(object):
             registry.digests[tag] = ManifestDigest(v1='sha256:v1',
                                                    v2='sha256:v2')
 
-        for platform, metadata in workflow.postbuild_results[FetchWorkerMetadataPlugin.key].items():
+        for metadata in workflow.postbuild_results[FetchWorkerMetadataPlugin.key].values():
             for output in metadata['output']:
                 if output['type'] != 'docker-image':
                     continue

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -53,7 +53,7 @@ from tests.flatpak import MODULEMD_AVAILABLE, setup_flatpak_source_info
 from tests.stubs import StubInsideBuilder, StubSource
 
 try:
-    import atomic_reactor.plugins.post_pulp_sync  # noqa:F401
+    import atomic_reactor.plugins.post_pulp_sync  # noqa:F401; pylint: disable=unused-import
     PULP_SYNC_AVAILABLE = True
 except ImportError:
     PULP_SYNC_AVAILABLE = False

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -287,7 +287,7 @@ def mock_environment(tmpdir, session=None, name=None,
         if PULP_SYNC_AVAILABLE and pulp_registries:
             workflow.plugin_workspace[PLUGIN_PULP_SYNC_KEY] = sync_result
 
-    for pulp_registry in range(pulp_registries):
+    for _ in range(pulp_registries):
         workflow.push_conf.add_pulp_registry('env', 'pulp.example.com')
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -852,7 +852,6 @@ class TestKojiPromote(object):
             ])
             if base_from_scratch:
                 expected_keys_set.remove('parent_id')
-                'parent_id' not in docker
             else:
                 assert is_string_type(docker['parent_id'])
             if has_config:

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -19,7 +19,6 @@ try:
     import koji
 except ImportError:
     import inspect
-    import sys  # noqa: F811
 
     # Find our mocked koji module
     import tests.koji as koji

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -303,7 +303,7 @@ def mock_environment(tmpdir, session=None, name=None,
                     'container_config': {}
                 }
 
-    for pulp_registry in range(pulp_registries):
+    for _ in range(pulp_registries):
         workflow.push_conf.add_pulp_registry('env', 'pulp.example.com')
 
     with open(os.path.join(str(tmpdir), 'image.tar.xz'), 'wt') as fp:

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -172,7 +172,7 @@ def mock_reactor_config(tmpdir, clusters=None, empty=False, add_config=None):
         .and_return(conf))
 
     with open(os.path.join(str(tmpdir), 'osbs.conf'), 'w') as f:
-        for plat, plat_clusters in clusters.items():
+        for plat_clusters in clusters.values():
             for cluster in plat_clusters:
                 f.write(dedent("""\
                     [{name}]
@@ -388,7 +388,7 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         expected_kwargs['pulp_registry_name'] = None
 
     with open(os.path.join(str(tmpdir), 'osbs.conf'), 'w') as f:
-        for plat, plat_clusters in clusters.items():
+        for plat_clusters in clusters.values():
             for cluster in plat_clusters:
                 f.write(dedent("""\
                     [{name}]

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -498,9 +498,6 @@ def test_try_with_library_pull_base_image(library, reactor_config_map):
     workflow.builder.base_image = ImageName.parse(base_image)
     workflow.builder.parent_images = {ImageName.parse(base_image): None}
 
-    class MockResponse(object):
-        content = ''
-
     cr = CommandResult()
     cr._error = "cmd_error"
     cr._error_detail = {"message": "error_detail"}

--- a/tests/plugins/test_pulp_tag.py
+++ b/tests/plugins/test_pulp_tag.py
@@ -190,7 +190,7 @@ def test_pulp_tag_basic(tmpdir, monkeypatch, v1_image_ids, should_raise, caplog,
 
     msg = None
     expected_results = {}
-    for platform, v1_image_id in v1_image_ids.items():
+    for v1_image_id in v1_image_ids.values():
         if v1_image_id:
             msg = "tagging v1-image-id ppc64le_v1_image_id for platform ppc64le"
             expected_results = {

--- a/tests/plugins/test_pyrpkg_fetch_artefacts.py
+++ b/tests/plugins/test_pyrpkg_fetch_artefacts.py
@@ -11,16 +11,13 @@ from __future__ import unicode_literals, absolute_import
 import pytest
 import os
 
-from atomic_reactor.core import DockerTasker  # noqa
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins import pre_pyrpkg_fetch_artefacts
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
-from tests.constants import INPUT_IMAGE, MOCK, MOCK_SOURCE
-if MOCK:
-    from tests.docker_mock import mock_docker  # noqa
+from tests.constants import INPUT_IMAGE, MOCK_SOURCE
 
 
 class Y(object):

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -96,7 +96,7 @@ class TestReactorConfigPlugin(object):
          False),
     ])
     def test_get_docker_registry(self, config, fallback, valid):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         config_json = read_yaml(config, 'schemas/config.json')
@@ -136,7 +136,7 @@ class TestReactorConfigPlugin(object):
                     get_docker_registry(workflow, docker_fallback)
 
     def test_no_config(self):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         conf = get_config(workflow)
         assert isinstance(conf, ReactorConfig)
 
@@ -517,7 +517,7 @@ class TestReactorConfigPlugin(object):
         'skip_koji_check_for_base_image'
     ])
     def test_get_methods(self, fallback, method):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
         if fallback is False:
             workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] = \
@@ -586,7 +586,7 @@ class TestReactorConfigPlugin(object):
           'ppc64le': 'ppc64le'}),
     ])
     def test_get_platform_to_goarch_mapping(self, fallback, config, expect):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         config_json = read_yaml(config, 'schemas/config.json')
@@ -635,7 +635,7 @@ class TestReactorConfigPlugin(object):
           'arm': 'registry.example.com/buildroot-arm:latest'}),
     ])
     def test_get_build_image_override(self, fallback, config, expect):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         config_json = read_yaml(config, 'schemas/config.json')
@@ -789,7 +789,7 @@ class TestReactorConfigPlugin(object):
         """, True),
     ])
     def test_get_koji_session(self, fallback, config, raise_error):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         if raise_error:
@@ -828,7 +828,7 @@ class TestReactorConfigPlugin(object):
         None
     ))
     def test_get_koji_path_info(self, fallback, root_url):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         config = {
@@ -934,7 +934,7 @@ class TestReactorConfigPlugin(object):
         """, True),
     ])
     def test_get_pulp_session(self, fallback, config, raise_error):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         if raise_error:
@@ -1049,7 +1049,7 @@ class TestReactorConfigPlugin(object):
         """, True),
     ])
     def test_get_odcs_session(self, tmpdir, fallback, config, raise_error):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         if raise_error:
@@ -1126,7 +1126,7 @@ class TestReactorConfigPlugin(object):
         """, True),
     ])
     def test_get_smtp_session(self, fallback, config, raise_error):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         if raise_error:
@@ -1242,7 +1242,7 @@ class TestReactorConfigPlugin(object):
         """, True),
     ])
     def test_get_openshift_session(self, fallback, build_json_dir, config, raise_error):
-        tasker, workflow = self.prepare()
+        _, workflow = self.prepare()
         workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
 
         if build_json_dir:

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -16,7 +16,6 @@ try:
     import koji as koji
 except ImportError:
     import inspect
-    import sys
 
     # Find our mocked koji module
     import tests.koji as koji

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -640,7 +640,7 @@ class TestSendMailPlugin(object):
                                'koji': koji_map})
 
         p = SendMailPlugin(None, workflow, **kwargs)
-        subject, body, fail_logs = p._render_mail(True, False, False, False)
+        _, _, fail_logs = p._render_mail(True, False, False, False)
         assert not fail_logs
 
     @pytest.mark.parametrize(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -153,13 +153,13 @@ def test_base_image_inspect(tmpdir, source_params, parents_pulled,
              .should_receive('inspect_image')
              .and_raise(docker.errors.NotFound, "xyz", response))
             with pytest.raises(KeyError):
-                b.base_image_inspect
+                b.base_image_inspect    # pylint: disable=pointless-statement; is a property
         else:
             (flexmock(atomic_reactor.util)
              .should_receive('get_inspect_for_image')
              .and_raise(NotImplementedError))
             with pytest.raises(NotImplementedError):
-                b.base_image_inspect
+                b.base_image_inspect    # pylint: disable=pointless-statement; is a property
 
 
 @requires_internet

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -12,7 +12,6 @@ import pytest
 import atomic_reactor.util
 import docker.errors
 from atomic_reactor.build import InsideBuilder, BuildResult
-from atomic_reactor.core import DockerTasker  # noqa
 from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.util import ImageName, df_parser
 from tests.constants import (

--- a/tests/test_pulp_util.py
+++ b/tests/test_pulp_util.py
@@ -96,7 +96,7 @@ def test_get_tar_metadata():
     pulp_registry_name = 'registry.example.com'
     testfile = 'foo'
 
-    tasker, workflow = prepare(testfile)
+    _, workflow = prepare(testfile)
     handler = PulpHandler(workflow, pulp_registry_name, log)
 
     expected = ("foo", ["foo"])
@@ -421,7 +421,7 @@ class TestLockedPulpRepository(object):
         pulp = flexmock()
         expectation = pulp.should_receive('createRepo').times(failures + 1)
         exc = dockpulp.errors.DockPulpError('error creating')
-        for i in range(failures):
+        for _ in range(failures):
             expectation = expectation.and_raise(exc).ordered()
 
         expectation.and_return(None).ordered

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -84,12 +84,12 @@ class TestGetSourceInstanceFor(object):
         s = get_source_instance_for({'provider': 'path', 'uri': DOCKERFILE_OK_PATH})
         flexmock(atomic_reactor.source, CONTAINER_BUILD_METHODS=[])
         with pytest.raises(AssertionError):
-            s.config
+            s.config    # pylint: disable=pointless-statement; is a property
 
     def test_broken_source_config_file(self):
         s = get_source_instance_for({'provider': 'path', 'uri': SOURCE_CONFIG_ERROR_PATH})
         with pytest.raises(ValidationError):
-            s.config
+            s.config    # pylint: disable=pointless-statement; is a property
 
 
 class TestSourceConfigSchemaValidation(object):

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -350,7 +350,7 @@ def test_export(no_container):
                 t.d.export('NOT_THERE')
         else:
             export_generator = t.d.export(container_id)
-            for chunk in export_generator:
+            for _ in export_generator:
                 pass
     finally:
         t.d.remove_container(container_id)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -56,7 +56,6 @@ from atomic_reactor.util import (ImageName, wait_for_command,
                                  get_platforms_in_limits, get_orchestrator_platforms,
                                  dump_stacktraces, setup_introspection_signal_handler,
                                  allow_repo_dir_in_dockerignore)
-from atomic_reactor import util
 from tests.constants import (DOCKERFILE_GIT,
                              INPUT_IMAGE, MOCK, MOCK_SOURCE,
                              REACTOR_CONFIG_MAP)
@@ -866,7 +865,7 @@ def test_get_build_json(environ, expected):
     ({}, None),
 ])
 def test_is_scratch_build(build_json, scratch):
-    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    flexmock(atomic_reactor.util).should_receive('get_build_json').and_return(build_json)
     if scratch is None:
         with pytest.raises(KeyError):
             is_scratch_build()
@@ -894,7 +893,7 @@ def test_is_custom_base_build(base_image, is_custom):
     ({}, None),
 ])
 def test_is_isolated_build(build_json, isolated):
-    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    flexmock(atomic_reactor.util).should_receive('get_build_json').and_return(build_json)
     if isolated is None:
         with pytest.raises(KeyError):
             is_isolated_build()


### PR DESCRIPTION
The last remaining pylint fixes.

Some clarifications for the individual commits:

__reimported__:
Reimporting `sys` in those `try: import koji` blocks seemed intentional, so I left it in.

__unused-import__:
Some were marked with `# noqa`, but removing them did not seem to change anything. So I removed them anyway.

__unreachable__:
The unreachable statement is a `yield`, used to make that function a generator. Unfortunately, I could not figure out _why_ that is necessary.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
