### PR TITLE
initialize BuildStepPluginsRunner after prebuild plugins run,

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -471,9 +471,6 @@ class DockerBuildWorkflow(object):
             prebuild_runner = PreBuildPluginsRunner(self.builder.tasker, self,
                                                     self.prebuild_plugins_conf,
                                                     plugin_files=self.plugin_files)
-            buildstep_runner = BuildStepPluginsRunner(self.builder.tasker, self,
-                                                      self.buildstep_plugins_conf,
-                                                      plugin_files=self.plugin_files)
             prepublish_runner = PrePublishPluginsRunner(self.builder.tasker, self,
                                                         self.prepublish_plugins_conf,
                                                         plugin_files=self.plugin_files)
@@ -495,6 +492,12 @@ class DockerBuildWorkflow(object):
                 logger.info(str(ex))
                 self.autorebuild_canceled = True
                 raise
+
+            # we are delaying initialization, because prebuild plugin reactor_config
+            # might change build method
+            buildstep_runner = BuildStepPluginsRunner(self.builder.tasker, self,
+                                                      self.buildstep_plugins_conf,
+                                                      plugin_files=self.plugin_files)
 
             logger.info("running buildstep plugins")
             try:


### PR DESCRIPTION
because reactor_config plugin is changing build method

* OSBS-7530

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
