### PR TITLE
Omps integration

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -102,6 +102,7 @@ PLUGIN_RESOLVE_COMPOSES_KEY = 'resolve_composes'
 PLUGIN_SENDMAIL_KEY = 'sendmail'
 PLUGIN_VERIFY_MEDIA_KEY = 'verify_media'
 PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY = 'export_operator_manifests'
+PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY = 'push_operator_manifests'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.
@@ -150,3 +151,5 @@ DOCKERIGNORE = '.dockerignore'
 
 # Operator manifest constants
 OPERATOR_MANIFESTS_ARCHIVE = 'operator_manifests.zip'
+
+KOJI_BTYPE_OPERATOR_MANIFESTS = 'operator-manifests'

--- a/atomic_reactor/omps_util.py
+++ b/atomic_reactor/omps_util.py
@@ -1,0 +1,111 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import absolute_import
+
+import logging
+import os
+
+import requests
+
+from atomic_reactor.util import get_retrying_requests_session
+
+
+class OMPSError(Exception):
+    def __init__(self, msg, status_code=None, response=None):
+        super(OMPSError, self).__init__(msg)
+        self.status_code = status_code
+        self.response = response
+
+
+class OMPS(object):
+    """Implementation of OMPS REST API calls"""
+
+    @classmethod
+    def from_config(cls, config):
+        """Initialize instance from reactor config map"""
+        with open(os.path.join(config['omps_secret_dir'], 'token'), 'r') as f:
+            token = f.read().strip()
+        return cls(
+            config['omps_url'],
+            config['omps_namespace'],
+            token,
+            insecure=config.get('insecure', False)
+        )
+
+    def __init__(self, url, organization, token, insecure=False):
+        """
+        :param url: URL of OMPS service
+        :param organization: organization to be used for manifests
+        :param token: secret auth token
+        :param insecure: don't validate OMPS server cert
+        """
+        self._url = url
+        self._organization = organization
+        self._token = token
+        self._insecure = insecure
+        self.log = logging.getLogger(self.__class__.__name__)
+        self.req_session = get_retrying_requests_session()
+
+    @property
+    def organization(self):
+        return self._organization
+
+    @property
+    def url(self):
+        return self._url
+
+    def _handle_error(self, response):
+        if response.status_code != requests.codes.ok:
+            try:
+                response_json = response.json()
+            except Exception:
+                response_json = {}
+            self.log.debug(
+                "OMPS returned status code %s: %s", response.status_code, response_json)
+
+            error = response_json.get('error', 'unknown')
+
+            # provide list of validation errors (if available) to users
+            # so they don't have to inspect logs
+            validation_info = response_json.get('validation_info', {})
+            self.log.error("Operator manifests are invalid: %s", validation_info)
+            msg = response_json.get('message', 'no details available')
+            if validation_info:
+                msg = "{} (validation errors: {})".format(msg, validation_info)
+
+            raise OMPSError(
+                "OMPS service request failed with error: {err}: {msg}".format(
+                    err=error,
+                    msg=msg
+                ),
+                status_code=response.status_code,
+                response=response_json
+            )
+
+    def push_archive(self, fb):
+        """Push operator manifest archive to appregistry via OMPS service
+
+        :param fb: Binary file like object
+        :raises OMPSError: when failure response is received
+        :return: OMPS response
+        """
+        endpoint = '{url}/v2/{organization}/zipfile'.format(
+            url=self.url, organization=self.organization)
+
+        files = {'file': fb}
+        headers = {'Authorization': self._token}
+
+        self.log.debug("Pushing operator manifests via: %s", endpoint)
+        r = self.req_session.post(
+            endpoint, headers=headers, files=files,
+            verify=not self._insecure
+        )
+        self._handle_error(r)
+
+        self.log.debug("OMPS response - success: %s", r.json())
+        return r.json()

--- a/atomic_reactor/plugins/post_push_operator_manifest.py
+++ b/atomic_reactor/plugins/post_push_operator_manifest.py
@@ -1,0 +1,179 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import absolute_import
+
+import os
+
+from atomic_reactor.constants import (
+    DEFAULT_DOWNLOAD_BLOCK_SIZE,
+    PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
+    OPERATOR_MANIFESTS_ARCHIVE,
+)
+from atomic_reactor.omps_util import OMPS, OMPSError
+from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugins.build_orchestrate_build import get_koji_upload_dir
+from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
+from atomic_reactor.plugins.pre_reactor_config import (
+    get_omps_config,
+    get_koji_path_info,
+    NO_FALLBACK,
+)
+from atomic_reactor.util import (
+    get_platforms,
+    is_isolated_build,
+    is_scratch_build,
+    has_operator_manifest,
+    get_retrying_requests_session,
+)
+
+
+class PushOperatorManifestsPlugin(PostBuildPlugin):
+    """
+    Push operator manifest to appregistry via OMPS service
+    """
+    key = PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY
+    is_allowed_to_fail = False
+
+    DOWNLOAD_DIR = 'operators_artifacts'
+
+    def is_orchestrator(self):
+        """
+        Check if the plugin is running in orchestrator.
+
+        :return: bool
+        """
+        if get_platforms(self.workflow):
+            return True
+        return False
+
+    def should_run(self):
+        """
+        Check if the plugin should run or skip execution.
+
+        :return: bool, False if plugin should skip execution
+        """
+        if not self.is_orchestrator():
+            self.log.warning("%s plugin set to run on worker. Skipping", self.key)
+            return False
+
+        if not get_omps_config(self.workflow, None):
+            self.log.info("Integration with OMPS is not configured. Skipping")
+            return False
+
+        if not has_operator_manifest(self.workflow):
+            self.log.info("Not an operator build. Skipping")
+            return False
+
+        if is_scratch_build():
+            self.log.info('Scratch build. Skipping')
+            return False
+
+        if is_rebuild(self.workflow):
+            self.log.info('Autorebuild. Skipping')
+            return False
+
+        if is_isolated_build():
+            self.log.info('Isolated build. Skipping')
+            return False
+
+        return True
+
+    def get_koji_operator_manifest_url(self):
+        """Construct URL for downloading manifest from koji task work server_dir
+
+        :rtype: str
+        :return: URL of koji operator manifests archive
+        """
+
+        server_dir = get_koji_upload_dir(self.workflow)
+
+        pathinfo = get_koji_path_info(self.workflow, NO_FALLBACK)
+        file_url = "{}/work/{}/{}".format(
+            pathinfo.topdir, server_dir, OPERATOR_MANIFESTS_ARCHIVE)
+
+        return file_url
+
+    def download_file(self, url, dest_filename, insecure=False):
+        """Downloads file specified by URL
+
+        :param url: file url
+        :param dest_filename: filename to be used for downloaded content
+        :param insecure: download file without cert validation
+
+        :return: file path of downloaded content
+        """
+        self.log.debug('Downloading file: %s', url)
+
+        workdir = self.workflow.source.get_build_file_path()[1]
+        dest_dir = os.path.join(workdir, self.DOWNLOAD_DIR)
+        dest_path = os.path.join(dest_dir, dest_filename)
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+
+        req_session = get_retrying_requests_session()
+        request = req_session.get(url, stream=True,
+                                  verify=not insecure)
+        request.raise_for_status()
+
+        with open(dest_path, 'wb') as f:
+            for chunk in request.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
+                f.write(chunk)
+
+        self.log.debug('Download finished: %s', dest_path)
+
+        return dest_path
+
+    def run(self):
+        """
+        Run the plugin.
+
+        :return: dictionary with following keys:
+          - endpoint: appregistry API endpoint
+          - registryNamespace: namespace/organization where operator manifest was pushed
+          - repository: repository name
+          - release: release version (related to appregistry repository)
+        """
+
+        if not self.should_run():
+            return
+
+        omps_config = get_omps_config(self.workflow)
+        omps = OMPS.from_config(omps_config)
+
+        operator_manifest_url = self.get_koji_operator_manifest_url()
+        operator_manifests_path = self.download_file(
+            operator_manifest_url, OPERATOR_MANIFESTS_ARCHIVE,
+            insecure=omps_config.get('koji_insecure', False)
+        )
+
+        try:
+            with open(operator_manifests_path, 'rb') as fb:
+                result = omps.push_archive(fb)
+        except OMPSError as e:
+            msg = "Failed to push operator manifests: {}".format(e)
+            self.log.error(msg)
+            raise RuntimeError(msg)
+
+        try:
+            os.remove(operator_manifests_path)
+        except OSError as e:
+            self.log.warning("Cleanup of the downloaded archive failed: %s", e)
+
+        org = result['organization']
+        repo = result['repo']
+        release = result['version']
+        self.log.info(
+            "Operator manifest pushed to %s/%s as release %s",
+            org, repo, release
+        )
+        return {
+            "endpoint": omps_config['appregistry_url'],
+            "registryNamespace": org,
+            "repository": repo,
+            "release": release,
+        }

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -374,6 +374,10 @@ def get_skip_koji_check_for_base_image(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'skip_koji_check_for_base_image', fallback)
 
 
+def get_omps_config(workflow, fallback=NO_FALLBACK):
+    return get_value(workflow, 'omps', fallback)
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -223,6 +223,38 @@
         "additionalProperties": false,
         "required": ["api_url", "auth", "signing_intents", "default_signing_intent"]
     },
+    "omps": {
+        "description": "Integration with OMPS service for pushing operators manifests to appregistry",
+        "type": ["object", "null"],
+        "properties": {
+            "omps_url": {
+                "description": "URL of OMPS REST API",
+                "type": "string"
+            },
+            "omps_namespace": {
+                "description": "Namespace (organization) where manifest will be pushed",
+                "type": "string"
+            },
+            "omps_secret_dir": {
+                "description": "Path to dir with secrets",
+                "type": "string"
+            },
+            "appregistry_url": {
+                "description": "URL for appregistry where operator manifests are stored",
+                "type": "string"
+            },
+            "koji_insecure": {
+                "description": "Download data from koji insecurely (default: false)",
+                "type": "boolean"
+            },
+            "insecure": {
+                "description": "Connect to OMPS service insecurely (default: false)",
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["omps_url", "omps_namespace", "omps_secret_dir", "appregistry_url"]
+    },
     "smtp": {
         "description": "SMTP notifications",
         "type": "object",

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -59,7 +59,8 @@ from importlib import import_module
 from requests.utils import guess_json_utf
 
 from osbs.exceptions import OsbsException
-from osbs.utils import clone_git_repo, reset_git_repo
+from osbs.utils import clone_git_repo, reset_git_repo, Labels
+
 from tempfile import NamedTemporaryFile
 try:
     # py3
@@ -1520,3 +1521,18 @@ def exception_message(exc):
     The message includes the type of the exception.
     """
     return '{exc.__class__.__name__}: {exc}'.format(exc=exc)
+
+
+def has_operator_manifest(workflow):
+    """
+    Check if Dockerfile sets the operator manifest label
+
+    :return: bool
+    """
+    dockerfile = df_parser(workflow.builder.df_path, workflow=workflow)
+    labels = Labels(dockerfile.labels)
+    try:
+        _, operator_label = labels.get_name_and_value(Labels.LABEL_TYPE_OPERATOR_MANIFESTS)
+    except KeyError:
+        operator_label = 'false'
+    return operator_label.lower() == 'true'

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -189,6 +189,9 @@ These are run after buildstep plugin has successfully finished.
  * **koji_upload**
    * Status: enabled
    * The 'docker save' output, build logs, and operator manifests are uploaded to Koji. The metadata is returned to be used by the store_metadata_osv3 plugin.  That plugin will use a ConfigMap object to store it for the orchestrator to retrieve it.  It will replace koji_promote when enabled.
+ * **push_operator_manifests**
+   * Status: enabled
+   * When OMPS service integration is configured and when specified through the com.redhat.delivery.appregistry Dockerfile label, plugin uploads manifests extracted by *export_operator_manifests* into app registry specified in configuration.
 
 ### Exit plugins
 

--- a/tests/plugins/test_push_operator_manifest.py
+++ b/tests/plugins/test_push_operator_manifest.py
@@ -1,0 +1,198 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import absolute_import
+
+import os
+
+import flexmock
+import pytest
+
+from atomic_reactor import util
+from atomic_reactor.constants import (
+    PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
+    PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
+)
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
+from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
+from atomic_reactor.plugins.build_orchestrate_build import (
+    OrchestrateBuildPlugin,
+    WORKSPACE_KEY_UPLOAD_DIR,
+)
+from atomic_reactor.plugins.pre_reactor_config import (
+    ReactorConfigPlugin,
+    WORKSPACE_CONF_KEY,
+    ReactorConfig,
+)
+from atomic_reactor.plugins.post_push_operator_manifest import PushOperatorManifestsPlugin
+from atomic_reactor.omps_util import OMPS, OMPSError
+
+from tests.constants import TEST_IMAGE
+from tests.stubs import StubInsideBuilder, StubSource
+
+
+KOJIROOT_TEST_URL = 'http://koji.localhost/kojiroot'
+KOJI_UPLOAD_TEST_WORKDIR = 'temp_workdir'
+
+TEST_OMPS_NAMESPACE = 'test_org'
+TEST_OMPS_APPREGISTRY = 'https://quay.io./cnr'
+TEST_OMPS_REPO = 'test_repo'
+TEST_OMPS_VERSION = '0.0.1'
+
+
+def mock_dockerfile(tmpdir, has_label=True, label=True):
+    base = 'From fedora:30'
+    cmd = 'CMD /bin/cowsay moo'
+    operator_label = ''
+    if has_label:
+        operator_label = 'LABEL com.redhat.delivery.appregistry={}'.format(str(label).lower())
+    data = '\n'.join([base, operator_label, cmd])
+    tmpdir.join('Dockerfile').write(data)
+
+
+class MockSource(StubSource):
+
+    def __init__(self, workdir):
+        super(MockSource, self).__init__()
+        self.workdir = workdir
+
+    def get_build_file_path(self):
+        return os.path.join(self.workdir, 'Dockerfile'), self.workdir
+
+
+def mock_workflow(tmpdir):
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow.source = MockSource(str(tmpdir))
+    builder = StubInsideBuilder().for_workflow(workflow)
+    builder.set_df_path(str(tmpdir))
+    builder.tasker = flexmock()
+    workflow.builder = flexmock(builder)
+    return workflow
+
+
+def mock_omps(push_fail=False):
+    mocked_omps = flexmock()
+    if push_fail:
+        (mocked_omps
+         .should_receive('push_archive')
+         .and_raise(OMPSError, 'OMPS failure'))
+    else:
+        (mocked_omps
+         .should_receive('push_archive')
+         .and_return({
+            'organization': TEST_OMPS_NAMESPACE,
+            'repo': TEST_OMPS_REPO,
+            'version': TEST_OMPS_VERSION,
+         }))
+    flexmock(OMPS).should_receive('from_config').and_return(mocked_omps)
+
+
+def mock_koji_manifest_download(requests_mock):
+    url = '{}/work/{}/operator_manifests.zip'.format(
+        KOJIROOT_TEST_URL, KOJI_UPLOAD_TEST_WORKDIR)
+    requests_mock.register_uri('GET', url, content=b'zip archive')
+
+
+def mock_env(tmpdir, docker_tasker, has_label=True, label=True,
+             scratch=False, isolated=False, rebuild=False,
+             orchestrator=True, omps_configured=True, omps_push_fail=False):
+    build_json = {'metadata': {'labels': {
+        'scratch': scratch,
+        'isolated': isolated,
+    }}}
+    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    mock_dockerfile(tmpdir, has_label, label)
+    workflow = mock_workflow(tmpdir)
+    if omps_configured:
+        omps_map = {
+            'omps_url': 'https://localhost',
+            'omps_namespace': TEST_OMPS_NAMESPACE,
+            'omps_secret_dir': '/var/run/secrets/atomic-reactor/ompssecret',
+            'appregistry_url': TEST_OMPS_APPREGISTRY,
+        }
+    else:
+        omps_map = {}
+
+    koji_map = {'root_url': KOJIROOT_TEST_URL}
+
+    mock_omps(push_fail=omps_push_fail)
+
+    if rebuild:
+        workflow.prebuild_results[CheckAndSetRebuildPlugin.key] = True
+
+    workflow.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = orchestrator
+    workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
+    workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] =\
+        ReactorConfig({'version': 1, 'omps': omps_map, 'koji': koji_map})
+    workflow.plugin_workspace[OrchestrateBuildPlugin.key] = {
+        WORKSPACE_KEY_UPLOAD_DIR: KOJI_UPLOAD_TEST_WORKDIR
+    }
+    plugin_conf = [{'name': PushOperatorManifestsPlugin.key}]
+
+    workflow.postbuild_plugins_conf = plugin_conf
+
+    runner = PostBuildPluginsRunner(docker_tasker, workflow, plugin_conf)
+
+    return runner
+
+
+class TestPushOperatorManifests(object):
+
+    @pytest.mark.parametrize('has_label', [True, False])
+    @pytest.mark.parametrize('label', [True, False])
+    @pytest.mark.parametrize('scratch', [True, False])
+    @pytest.mark.parametrize('isolated', [True, False])
+    @pytest.mark.parametrize('rebuild', [True, False])
+    @pytest.mark.parametrize('orchestrator', [True, False])
+    @pytest.mark.parametrize('omps_configured', [True, False])
+    def test_skip(
+        self, requests_mock, tmpdir, docker_tasker, caplog, has_label, label, scratch,
+        isolated, rebuild, orchestrator, omps_configured
+    ):
+        """Test if plugin execution is skipped in expected cases"""
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, has_label=has_label,
+                          label=label,
+                          scratch=scratch,
+                          isolated=isolated,
+                          rebuild=rebuild,
+                          orchestrator=orchestrator,
+                          omps_configured=omps_configured)
+        should_skip = any([
+            not has_label, not label,
+            scratch, rebuild, isolated,
+            not orchestrator, not omps_configured
+        ])
+        result = runner.run()
+        if should_skip:
+            assert 'Skipping' in caplog.text
+            assert result[PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY] is None
+        else:
+            assert 'Skipping' not in caplog.text
+            assert result[PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY]
+
+    def test_successful_push(self, requests_mock, tmpdir, docker_tasker):
+        """Test of plugin output in success run"""
+        expected = {
+            'endpoint': TEST_OMPS_APPREGISTRY,
+            'registryNamespace': TEST_OMPS_NAMESPACE,
+            'repository': TEST_OMPS_REPO,
+            'release': TEST_OMPS_VERSION,
+        }
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker)
+        result = runner.run()
+        assert result[PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY] == expected
+
+    def test_failed_push(self, requests_mock, tmpdir, docker_tasker):
+        """Test of plugin output when OMPS push failed"""
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, omps_push_fail=True)
+        with pytest.raises(PluginFailedException) as exc:
+            runner.run()
+        assert 'Failed to push operator manifests:' in str(exc)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,3 +7,4 @@ pytest-cov==2.6.*
 six>=1.10.0 # required by pytest-cov
 flake8
 koji
+requests-mock

--- a/tests/test_omps_util.py
+++ b/tests/test_omps_util.py
@@ -1,0 +1,101 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import
+
+from io import BytesIO
+import os
+
+import pytest
+
+from atomic_reactor.omps_util import OMPS, OMPSError
+
+
+class TestOMPS(object):
+
+    token = "supersecrettoken"
+    omps_url = 'https://omps.example.com'
+    omps_namespace = 'test_namespace'
+
+    def test_from_config(self, tmpdir):
+        """Test creation of OMPS instance from config"""
+        config = {
+            'omps_url': self.omps_url,
+            'omps_namespace': self.omps_namespace,
+            'omps_secret_dir': str(tmpdir)
+        }
+
+        token_path = os.path.join(str(tmpdir), 'token')
+        with open(token_path, 'w') as f:
+            f.write(self.token)
+            f.flush()
+
+        omps = OMPS.from_config(config)
+        assert omps
+        assert omps.organization == self.omps_namespace
+        assert omps.url == self.omps_url
+        assert omps._token == self.token
+
+    def test_push_archive(self, requests_mock):
+        """Test pushing manifest zipfile to omps service"""
+        omps_res = {'omps': 'answer'}
+        requests_mock.register_uri(
+            'POST',
+            "{}/v2/{}/zipfile".format(self.omps_url, self.omps_namespace),
+            request_headers={'Authorization': self.token},
+            json=omps_res
+        )
+        omps = OMPS(self.omps_url, self.omps_namespace, self.token)
+        fb = BytesIO(b'zip file')
+        res = omps.push_archive(fb)
+        assert res == omps_res
+
+    def test_push_archive_failure(self, requests_mock):
+        """Test failure when pushing manifest zipfile to omps service"""
+        error = 'ErrorCode'
+        emsg = 'Detailed message'
+        status_code = 400
+        # keep here only one entry to testing, to keep order deterministic
+        # after str() call
+        validation_info = {'errors': ['CSV is incorrect']}
+
+        omps_res = {
+            'error': error, 'message': emsg,
+            'validation_info': validation_info}
+        requests_mock.register_uri(
+            'POST',
+            "{}/v2/{}/zipfile".format(self.omps_url, self.omps_namespace),
+            request_headers={'Authorization': self.token},
+            json=omps_res,
+            status_code=status_code,
+        )
+        omps = OMPS(self.omps_url, self.omps_namespace, self.token)
+        fb = BytesIO(b'zip file')
+        with pytest.raises(OMPSError) as exc:
+            omps.push_archive(fb)
+            assert exc.value.status_code == status_code
+            assert exc.value.response == omps_res
+            assert '(validation errors: {})'.format(validation_info) in str(exc)
+
+    def test_push_archive_server_error(self, requests_mock):
+        """Service running behind HAProxy may return 503 error without json.
+        Test if this case is handled gracefully"""
+        status_code = 503
+        requests_mock.register_uri(
+            'POST',
+            "{}/v2/{}/zipfile".format(self.omps_url, self.omps_namespace),
+            request_headers={'Authorization': self.token},
+            text='Service unavailable',
+            status_code=status_code,
+        )
+        omps = OMPS(self.omps_url, self.omps_namespace, self.token)
+        fb = BytesIO(b'zip file')
+        with pytest.raises(OMPSError) as exc:
+            omps.push_archive(fb)
+            assert exc.value.status_code == status_code
+            assert exc.value.response == {}


### PR DESCRIPTION
Missing parts:
- [x] unittest
- [x] OMPS query retries
- [x] Set timeouts for queries

documentation update: https://github.com/containerbuildsystem/osbs-docs/pull/85

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
