### PR TITLE
Do not raise when manifest digests mismatch

### DIFF
--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -112,8 +112,9 @@ class KojiParentPlugin(PreBuildPlugin):
                     raise RuntimeError(err_msg)
 
         if manifest_mismatches:
-            raise RuntimeError('Error while comparing parent images manifest digests in koji with '
-                               'related values from registries: {}'.format(manifest_mismatches))
+            # TODO: this should raise a RuntimeError instead
+            self.log.warning('Error while comparing parent images manifest digests in koji with '
+                             'related values from registries: %s', manifest_mismatches)
         return self.make_result()
 
     def check_manifest_digest(self, image, build_info):


### PR DESCRIPTION
This check may result in false positives if the manifest lists are
re-ordered and pushed. For now, we do not want a build to fail in such
cases.

* OSBS-7663

Signed-off-by: Athos Ribeiro <athos@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
