### PR TITLE
Maintainers: ensure that new features can be disabled if needed

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -7,3 +7,4 @@ Maintainers will complete the following section:
 - [ ] JSON/YAML configuration changes are updated in the relevant schema
 - [ ] Changes to metadata also update the documentation for the metadata
 - [ ] Pull request includes link to an osbs-docs PR for user documentation updates
+- [ ] New feature can be disabled from a configuration file


### PR DESCRIPTION
All features should have turn off switch in atomic-reactor config file

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
