### PR TITLE
omps_util: handle requests errors itself

### DIFF
--- a/atomic_reactor/omps_util.py
+++ b/atomic_reactor/omps_util.py
@@ -49,7 +49,9 @@ class OMPS(object):
         self._token = token
         self._insecure = insecure
         self.log = logging.getLogger(self.__class__.__name__)
-        self.req_session = get_retrying_requests_session()
+
+        # this class handle status errors itself
+        self.req_session = get_retrying_requests_session(raise_on_status=False)
 
     @property
     def organization(self):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1341,7 +1341,7 @@ def _http_retries_disabled():
 
 def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
                                   times=HTTP_MAX_RETRIES, delay=HTTP_BACKOFF_FACTOR,
-                                  method_whitelist=None):
+                                  method_whitelist=None, raise_on_status=True):
     if _http_retries_disabled():
         times = 0
 
@@ -1351,6 +1351,12 @@ def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
         status_forcelist=client_statuses,
         method_whitelist=method_whitelist
     )
+
+    # raise_on_status was added later to Retry, adding compatibility to work
+    # with newer versions and ignoring this option with older ones
+    if hasattr(retry, 'raise_on_status'):
+        retry.raise_on_status = raise_on_status
+
     session = SessionWithTimeout()
     session.mount('http://', HTTPAdapter(max_retries=retry))
     session.mount('https://', HTTPAdapter(max_retries=retry))


### PR DESCRIPTION
OMPS class will parse requests results to provide better error details.
Don't raise exception when retries fails due wrong status.

* OSBS-7542

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
