### PR TITLE
Sort generated manifest lists

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -195,7 +195,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
         return list_type, json.dumps({
                 "schemaVersion": 2,
                 "mediaType": list_type,
-                "manifests": [
+                "manifests": sorted([
                     {
                         "mediaType": media_type,
                         "size": m['size'],
@@ -205,8 +205,8 @@ class GroupManifestsPlugin(PostBuildPlugin):
                             "os": "linux"
                         }
                     } for m in manifests
-                ],
-        }, indent=4)
+                ], key=lambda entry: entry['platform']['architecture']),
+        }, indent=4, sort_keys=True, separators=(',', ': '))
 
     def group_manifests_and_tag(self, session, worker_digests):
         """


### PR DESCRIPTION
We sort the manifests based on their platform architectures. Then we
sort the keys in the manifest list file. This is done in favor of
reproducibility.

* OSBS-7664

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
