### PR TITLE
Address bandit warnings: B602

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -74,6 +74,7 @@ Requires:       python3-dockerfile-parse >= 0.0.11
 Requires:       python3-docker-squash >= 1.0.7
 Requires:       python3-jsonschema
 Requires:       python3-PyYAML
+Requires:       python3-rpm
 Requires:       python3-six
 Provides:       python3-dock = %{version}-%{release}
 Obsoletes:      python3-dock < %{dock_obsolete_vr}
@@ -139,6 +140,11 @@ Requires:       python-backports-lzma
 Requires:       python-jsonschema
 Requires:       python-six
 Requires:       PyYAML
+%if 0%{?fedora}
+Requires:       python2-rpm
+%else
+Requires:       rpm-python
+%endif
 Provides:       python-dock = %{version}-%{release}
 Obsoletes:      python-dock < %{dock_obsolete_vr}
 %{?python_provide:%python_provide python-atomic-reactor}

--- a/atomic_reactor/rpm_util.py
+++ b/atomic_reactor/rpm_util.py
@@ -5,6 +5,9 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+from __future__ import absolute_import
+
+import rpm
 
 image_component_rpm_tags = [
     'NAME',
@@ -18,6 +21,20 @@ image_component_rpm_tags = [
     'SIGPGP:pgpsig',
     'SIGGPG:pgpsig',
 ]
+
+
+def get_rpm_list(tags=None, separator=';'):
+    """
+    Return a list of RPMs in the format expected by parse_rpm_output.
+    """
+    if tags is None:
+        tags = image_component_rpm_tags
+    ts = rpm.TransactionSet()
+    mi = ts.dbMatch()
+    rpms = []
+    for h in mi:
+        rpms.append(separator.join([h.sprintf("%%{%s}" % tag) for tag in tags]))
+    return rpms
 
 
 def rpm_qf_args(tags=None, separator=';'):
@@ -61,8 +78,8 @@ def parse_rpm_output(output, tags=None, separator=';'):
 
     components = []
     sigmarker = 'Key ID '
-    for rpm in output:
-        fields = rpm.rstrip('\n').split(separator)
+    for rpm_info in output:
+        fields = rpm_info.rstrip('\n').split(separator)
         if len(fields) < len(tags):
             continue
 

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals, absolute_import
 
 import json
 import os
+import rpm
 import sys
 
 try:
@@ -147,27 +148,41 @@ class MockedClientSession(object):
         return self.tag_task_state in ['CLOSED', 'FAILED', 'CANCELED', None]
 
 
-FAKE_SIGMD5 = b'0' * 32
-FAKE_RPM_OUTPUT = (
-    b'name1;1.0;1;x86_64;0;' + FAKE_SIGMD5 + b';(none);'
-    b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID abcdef01234567\n'
+class MockedRpmHeader(object):
+    def __init__(self, name, version, release, arch=None, epoch=None, md5=None, pgp=None, gpg=None):
+        self.tags = {'NAME': name, 'VERSION': version, 'RELEASE': release, 'ARCH': arch,
+                     'EPOCH': epoch, 'SIGMD5': md5, 'SIGPGP:pgpsig': pgp, 'SIGGPG:pgpsig': gpg}
 
-    b'gpg-pubkey;01234567;01234567;(none);(none);(none);(none);(none)\n'
+    def sprintf(self, qf):
+        for k, v in self.tags.items():
+            if k in qf:
+                if v is None:
+                    v = '(none)'
+                return v
 
-    b'gpg-pubkey-doc;01234567;01234567;noarch;(none);' + FAKE_SIGMD5 +
-    b';(none);(none)\n'
 
-    b'name2;2.0;2;x86_64;0;' + FAKE_SIGMD5 + b';' +
-    b'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID bcdef012345678;(none)\n'
-    b'\n')
+class MockedTS(object):
+    def dbMatch(self):
+        return [
+                MockedRpmHeader(
+                    'name1', '1.0', '1', 'x86_64', '0', FAKE_SIGMD5,
+                    gpg='RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID abcdef01234567'),
+                MockedRpmHeader(
+                    'gpg-pubkey', '01234567', '01234567'),
+                MockedRpmHeader(
+                    'gpg-pubkey-doc', '01234567', '01234567', 'noarch', md5=FAKE_SIGMD5),
+                MockedRpmHeader(
+                    'name2', '2.0', '2', 'x86_64', '0', FAKE_SIGMD5,
+                    'RSA/SHA256, Mon 29 Jun 2015 13:58:22 BST, Key ID bcdef012345678')]
+
+
+FAKE_SIGMD5 = '0' * 32
 
 FAKE_OS_OUTPUT = 'fedora-22'
 
 
 def fake_subprocess_output(cmd):
-    if cmd.startswith('/bin/rpm'):
-        return FAKE_RPM_OUTPUT
-    elif 'os-release' in cmd:
+    if 'os-release' in cmd:
         return FAKE_OS_OUTPUT
     else:
         raise RuntimeError
@@ -245,6 +260,7 @@ def mock_environment(tmpdir, session=None, name=None,
                                               for tag in additional_tags])
 
     flexmock(subprocess, Popen=fake_Popen)
+    flexmock(rpm, TransactionSet=MockedTS)
     flexmock(koji, ClientSession=lambda hub, opts: session)
     flexmock(GitSource)
     if logs_return_bytes:
@@ -313,9 +329,9 @@ def mock_environment(tmpdir, session=None, name=None,
     workflow.prebuild_results[CheckAndSetRebuildPlugin.key] = is_rebuild
 
     workflow.image_components = parse_rpm_output([
-        "name1;1.0;1;x86_64;0;2000;" + FAKE_SIGMD5.decode() + ";23000;"
+        "name1;1.0;1;x86_64;0;2000;" + FAKE_SIGMD5 + ";23000;"
         "RSA/SHA256, Tue 30 Aug 2016 00:00:00, Key ID 01234567890abc;(none)",
-        "name2;2.0;1;x86_64;0;3000;" + FAKE_SIGMD5.decode() + ";24000"
+        "name2;2.0;1;x86_64;0;3000;" + FAKE_SIGMD5 + ";24000"
         "RSA/SHA256, Tue 30 Aug 2016 00:00:00, Key ID 01234567890abd;(none)",
     ])
 
@@ -661,6 +677,22 @@ class TestKojiPromote(object):
 
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)
         runner.run()
+
+    def test_koji_upload_rpm_components(self, tmpdir, os_env, reactor_config_map):  # noqa
+        session = MockedClientSession('')
+        tasker, workflow = mock_environment(tmpdir,
+                                            session=session,
+                                            name='ns/name',
+                                            version='1.0',
+                                            release='1')
+        runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)
+        runner.run()
+        data = session.metadata
+        buildroots = data['buildroots']
+        for buildroot in buildroots:
+            assert any(c['name'] == 'name1' for c in buildroot['components'])
+            assert any(c['version'] == '01234567' for c in buildroot['components'])
+            assert any(c['arch'] == 'noarch' for c in buildroot['components'])
 
     @staticmethod
     def check_components(components):


### PR DESCRIPTION
To avoid the shell=True in the rpm query command, we query the RPM DB
with the RPM python bidings.  Note that the python 3 code path would
crash, since no stderr variable was being defined at all. This patch
consolidates the codepaths for both python 2 and 3, addressing the
related Bandit warning.

* https://bandit.readthedocs.io/en/latest/plugins/b605_start_process_with_a_shell.html
* OSBS-7453

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
