### PR TITLE
Require libmodulemd1 compat flatpak-module-tools

### DIFF
--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,1 +1,1 @@
-flatpak-module-tools
+flatpak-module-tools<0.10


### PR DESCRIPTION
libmodulemd introduces a new API (incompatible with the former one).
Atomic Reactor flatpak plugins will require further changes to be able
to use the new API. See
https://pagure.io/flatpak-module-tools/pull-request/4 for reference.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
