### PR TITLE
Allow RegistrySession to use local config file

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -663,6 +663,8 @@ class Dockercfg(object):
             self.json_secret_path = os.path.join(secret_path, '.dockercfg')
         elif os.path.exists(os.path.join(secret_path, '.dockerconfigjson')):
             self.json_secret_path = os.path.join(secret_path, '.dockerconfigjson')
+        elif os.path.exists(secret_path):
+            self.json_secret_path = secret_path
         else:
             raise RuntimeError("The registry secret was not found on the filesystem, "
                                "either .dockercfg or .dockerconfigjson are supported")


### PR DESCRIPTION
Signed-off-by: Luiz Carvalho <lucarval@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
