### PR TITLE
fetch maven artifacts: allow empty yaml files

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
+++ b/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
@@ -116,7 +116,8 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
             self.log.debug('%s not found', self.NVR_REQUESTS_FILENAME)
             return []
 
-        nvr_requests = util.read_yaml_from_file_path(file_path, 'schemas/fetch-artifacts-nvr.json')
+        nvr_requests = util.read_yaml_from_file_path(file_path,
+                                                     'schemas/fetch-artifacts-nvr.json') or []
         return [NvrRequest(**nvr_request) for nvr_request in nvr_requests]
 
     def read_url_requests(self):
@@ -125,7 +126,7 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
             self.log.debug('%s not found', self.URL_REQUESTS_FILENAME)
             return []
 
-        return util.read_yaml_from_file_path(file_path, 'schemas/fetch-artifacts-url.json')
+        return util.read_yaml_from_file_path(file_path, 'schemas/fetch-artifacts-url.json') or []
 
     def process_by_nvr(self, nvr_requests):
         download_queue = []

--- a/atomic_reactor/schemas/fetch-artifacts-nvr.json
+++ b/atomic_reactor/schemas/fetch-artifacts-nvr.json
@@ -3,7 +3,7 @@
 
   "title": "Artifacts to be fetched from Koji builds",
 
-  "type": "array",
+  "type": ["array", "null"],
   "items": {
     "type": "object",
     "description": "A specific Koji buid and archives to be fetched",

--- a/atomic_reactor/schemas/fetch-artifacts-url.json
+++ b/atomic_reactor/schemas/fetch-artifacts-url.json
@@ -3,7 +3,7 @@
 
   "title": "Artifacts to be fetched by url",
 
-  "type": "array",
+  "type": ["array", "null"],
   "items": {
     "type": "object",
     "description": "A specific artifact to be fetched by URL",


### PR DESCRIPTION
Fixes osbs-6424

Adjust pre_fetch_maven_artifacts and the fetch-artifacts-* schema to allow for empty files.

docs PR: https://github.com/containerbuildsystem/osbs-docs/pull/88

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
