### PR TITLE
Freeze pypng version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 flexmock
 ordereddict
 responses>=0.9.0
-pypng
+pypng==0.0.19
 pytest==4.0.*
 pytest-cov==2.6.*
 six>=1.10.0 # required by pytest-cov


### PR DESCRIPTION
* OSBS-7751

The latest pypng releses have been causing flatpak tests to fail.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
