### PR TITLE
Libmodulemd v2 api

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -28,7 +28,7 @@ from flatpak_module_tools.flatpak_builder import ModuleInfo
 
 import gi
 try:
-    gi.require_version('Modulemd', '1.0')
+    gi.require_version('Modulemd', '2.0')
 except ValueError as e:
     # Normalize to ImportError to simplify handling
     raise ImportError(str(e))
@@ -152,13 +152,11 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
                     .format(epochnum=rpm['epoch'] or 0, **rpm)
                     for rpm in rpm_list]
 
-            objects = Modulemd.objects_from_string(
-                build['extra']['typeinfo']['module']['modulemd_str'])
-            assert len(objects) == 1
-            mmd = objects[0]
-            assert isinstance(mmd, Modulemd.Module)
+            # strict=False - don't break if new fields are added
+            mmd = Modulemd.ModuleStream.read_string(
+                build['extra']['typeinfo']['module']['modulemd_str'], strict=False)
             # Make sure we have a version 2 modulemd file
-            mmd.upgrade()
+            mmd = mmd.upgrade(Modulemd.ModuleStreamVersionEnum.TWO)
 
             resolved_modules[module_spec.name] = ModuleInfo(module_spec.name,
                                                             module_spec.stream,

--- a/images/dockerhost-builder/Dockerfile
+++ b/images/dockerhost-builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:latest
-RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji libmodulemd ostree python2-gobject-base python2-flatpak-module-tools python-backports-lzma osbs gssproxy && dnf clean all
+RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji ostree python2-libmodulemd python2-flatpak-module-tools >= 0.10.0 python-backports-lzma osbs gssproxy && dnf clean all
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 CMD ["atomic-reactor", "--verbose", "inside-build"]

--- a/images/privileged-builder/Dockerfile
+++ b/images/privileged-builder/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:latest
-RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji libmodulemd ostree python2-gobject-base python2-flatpak-module-tools python-backports-lzma osbs gssproxy && dnf clean all
+RUN dnf -y install docker git python-docker-py python-setuptools desktop-file-utils e2fsprogs flatpak koji ostree python2-libmodulemd python2-flatpak-module-tools >= 0.10.0 python-backports-lzma osbs gssproxy && dnf clean all
 ADD ./atomic-reactor.tar.gz /tmp/
 RUN cd /tmp/atomic-reactor-*/ && python setup.py install
 ADD ./docker.sh /tmp/docker.sh

--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,1 +1,1 @@
-flatpak-module-tools<0.10
+flatpak-module-tools >= 0.10.3

--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,1 +1,0 @@
-flatpak-module-tools >= 0.10.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 docker-py
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
+flatpak-module-tools >= 0.10.4
 jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 PyYAML
 six

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,7 @@ if [[ $OS == "fedora" ]]; then
   PIP="pip$PYTHON_VERSION"
   PKG="dnf"
   ENABLE_REPO="--enablerepo=updates-testing"
-  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak libmodulemd ostree python$PYTHON_VERSION-gobject-base glibc-langpack-en"
+  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree python$PYTHON_VERSION-libmodulemd glibc-langpack-en"
   BUILDDEP="dnf builddep"
   PYTHON="python$PYTHON_VERSION"
 else

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,7 @@ else
   PIP="pip"
   PKG="yum"
   ENABLE_REPO=
-  PKG_EXTRA="yum-utils epel-release git-core desktop-file-utils"
+  PKG_EXTRA="yum-utils epel-release git-core desktop-file-utils flatpak ostree python2-libmodulemd2"
   BUILDDEP="yum-builddep"
   PYTHON="python"
 fi
@@ -101,11 +101,6 @@ $RUN $PIP install --upgrade --no-deps --force-reinstall git+https://github.com/D
 if [[ $PYTHON_VERSION == 2* ]]; then
   $RUN $PIP install git+https://github.com/release-engineering/dockpulp
   $RUN $PIP install -r requirements-py2.txt
-fi
-
-# Install flatpak dependencies only on fedora
-if [[ $OS == "fedora" ]]; then
-  $RUN $PIP install -r requirements-flatpak.txt
 fi
 
 # install with RPM_PY_SYS=true to avoid error caused by installing on system python

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -330,7 +330,7 @@ def setup_flatpak_compose_info(workflow, config=None):
     config = APP_CONFIG if config is None else config
     modules = {}
     for name, module_config in config['modules'].items():
-        mmd = Modulemd.Module.new_from_string(module_config['metadata'])
+        mmd = Modulemd.ModuleStream.read_string(module_config['metadata'], strict=True)
         modules[name] = ModuleInfo(name,
                                    module_config['stream'],
                                    module_config['version'],

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -31,9 +31,6 @@ from atomic_reactor.util import ImageName
 from tests.constants import (MOCK_SOURCE, FLATPAK_GIT, FLATPAK_SHA1)
 from tests.flatpak import MODULEMD_AVAILABLE, build_flatpak_test_configs, setup_flatpak_compose_info
 
-if MODULEMD_AVAILABLE:
-    from gi.repository import GLib
-
 
 class MockSource(object):
     def __init__(self, tmpdir):
@@ -100,20 +97,9 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker, config_name, breakage,
     compose = setup_flatpak_compose_info(workflow, config)
 
     if breakage == 'branch_mismatch':
-        xmd = compose.base_module.mmd.props.xmd
-
-        # Modifying the xmd from Python requires creating a new GVariant
-        flatpak_xmd = xmd['flatpak']
-
-        new_flatpak_xmd = {}
-        for i in range(flatpak_xmd.n_children()):
-            v = flatpak_xmd.get_child_value(i)
-            new_flatpak_xmd[v.get_child_value(0).unpack()] = v.get_child_value(1)
-
-        new_flatpak_xmd['branch'] = GLib.Variant('s', 'MISMATCH')
-
-        xmd['flatpak'] = GLib.Variant('a{sv}', new_flatpak_xmd)
-        compose.base_module.mmd.props.xmd = xmd
+        xmd = compose.base_module.mmd.get_xmd()
+        xmd['flatpak']['branch'] = 'MISMATCH'
+        compose.base_module.mmd.set_xmd(xmd)
 
         expected_exception = "Mismatch for 'branch'"
     else:

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -486,7 +486,7 @@ COMMAND_PATTERNS = [
      MockFlatpak.build_init),
     (['ostree', 'commit',
       '--repo', '@repo',
-      '--owner-uid=0', '--owner-gid=0', '--no-xattrs',
+      '--owner-uid=0', '--owner-gid=0', '--no-xattrs', '--canonical-permissions',
       '--branch', '@branch', '-s', '@subject', '--tree=tar=@tar_tree', '--tree=dir=@dir_tree'],
      MockOSTree.commit),
     (['ostree', 'init', '--mode=archive-z2', '--repo', '@repo'], MockOSTree.init),

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -67,9 +67,9 @@ abattis-cantarell-fonts;0.0.25;2.module_e15740c0;noarch;(none);42;sigmd5;1491914
 
 ICON = BytesIO()
 # create minimal 256x256 RGBA PNG
-png.Writer(256, 256, alpha=True).write(ICON,
-                                       [[0 for _ in range(4 * 256)]
-                                        for _ in range(256)])
+png.Writer(256, 256, greyscale=False, alpha=True).write(ICON,
+                                                        [[0 for _ in range(4 * 256)]
+                                                         for _ in range(256)])
 
 APP_FILESYSTEM_CONTENTS = {
     '/usr/bin/not_eog': b'SHOULD_IGNORE',

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -708,14 +708,13 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
         config['modules']['eog'] = dict(config['modules']['eog'])
 
         module_config = config['modules']['eog']
-        mmd = Modulemd.Module.new_from_string(module_config['metadata'])
 
-        # Clear out all dependencies. Setting via the property causes a crash
-        # https://gitlab.gnome.org/GNOME/pygobject/issues/37
-#        mmd.props.dependencies = [Modulemd.Dependencies()]
-        mmd.set_dependencies([Modulemd.Dependencies()])
-
-        module_config['metadata'] = mmd.dumps()
+        mmd = Modulemd.ModuleStream.read_string(module_config['metadata'], strict=True)
+        mmd.clear_dependencies()
+        mmd.add_dependencies(Modulemd.Dependencies())
+        mmd_index = Modulemd.ModuleIndex.new()
+        mmd_index.add_module_stream(mmd)
+        module_config['metadata'] = mmd_index.dump_to_string()
 
         expected_exception = 'Failed to identify runtime module'
     else:

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -329,7 +329,7 @@ def test_resolve_module_compose(tmpdir, docker_tasker, compose_ids, modules,
         assert compose_info.base_module.name == MODULE_NAME
         assert compose_info.base_module.stream == MODULE_STREAM
         assert compose_info.base_module.version == MODULE_VERSION
-        assert compose_info.base_module.mmd.props.summary == 'Eye of GNOME Application Module'
+        assert compose_info.base_module.mmd.get_summary("C") == 'Eye of GNOME Application Module'
         assert compose_info.base_module.rpms == [
             'eog-0:3.28.3-1.module_2123+73a9ef6f.src.rpm',
             'eog-0:3.28.3-1.module_2123+73a9ef6f.x86_64.rpm',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 flexmock
 ordereddict
 responses>=0.9.0
-pypng==0.0.19
+pypng
 pytest==4.0.*
 pytest-cov==2.6.*
 six>=1.10.0 # required by pytest-cov


### PR DESCRIPTION
This pull request:
 - Updates the code to use latest flatpak-module-tools and the libmodulemd v2 API
 - Enables testing against real flatpak-module-tools, flatpak, ostree on RHEL 7 (this is used in production)
 - Fixes a problem with the Flatpak tests with PyPNG that started happening recently

Since we now test against flatpak on all platforms, it would be possible to remove the mock_flatpak code paths, but this PR doesn't do that.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
