### PR TITLE
Pre-declare koji builds in advance

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -136,6 +136,10 @@ HTTP_REQUEST_TIMEOUT = 600
 GIT_MAX_RETRIES = 3
 # how many seconds should wait before another try of git clone
 GIT_BACKOFF_FACTOR = 5
+# max retries for reserving koji builds
+KOJI_RESERVE_MAX_RETRIES = 20
+# wait for 2sec (usual time of bump_release with reserve)
+KOJI_RESERVE_RETRY_DELAY = 2
 
 # Media types
 MEDIA_TYPE_DOCKER_V2_SCHEMA1 = "application/vnd.docker.distribution.manifest.v1+json"

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -438,6 +438,10 @@ class DockerBuildWorkflow(object):
         # post-build plugins (such as koji_import) to record them.
         self.all_yum_repourls = None
 
+        # info about pre-declared build, build-id and token
+        self.reserved_build_id = None
+        self.reserved_token = None
+
         if client_version:
             logger.debug("build json was built by osbs-client %s", client_version)
 

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -546,8 +546,14 @@ class KojiImportPlugin(ExitPlugin):
                 if output.file:
                     output.file.close()
 
+        build_token = None
+        if (self.workflow.reserved_build_id is not None and
+                self.workflow.reserved_token is not None):
+            build_token = self.workflow.reserved_token
+            koji_metadata['build']['build_id'] = self.workflow.reserved_build_id
+
         try:
-            build_info = self.session.CGImport(koji_metadata, server_dir)
+            build_info = self.session.CGImport(koji_metadata, server_dir, token=build_token)
         except Exception:
             self.log.debug("metadata: %r", koji_metadata)
             raise

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -104,6 +104,11 @@
                 "description": "Use Koji's fast upload API",
                 "type": "boolean",
                 "default": true
+            },
+            "reserve_build": {
+                "description": "Reserve build id and NVR through Content Generator API. If set, requires koji > 1.17.0",
+                "type": "boolean",
+                "default": false
             }
         },
         "additionalProperties": false,


### PR DESCRIPTION
* OSBS-7168

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
