### PR TITLE
Perform deep manifest list inspections

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -378,6 +378,10 @@ def get_omps_config(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'omps', fallback)
 
 
+def get_deep_manifest_list_inspection(workflow, fallback=NO_FALLBACK):
+    return get_value(workflow, 'deep_manifest_list_inspection', fallback)
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -479,6 +479,11 @@
         "description": "Allow base image without related koji build (insecure)",
         "type": "boolean"
     },
+    "deep_manifest_list_inspection": {
+        "description": "If manifest list digest check fails, inspect the manifest list contents",
+        "type": "boolean",
+        "default": true
+    },
     "hide_files": {
         "description": "Hide files during build for each stage",
         "type": "object",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -171,6 +171,8 @@ hide_files:
 
 skip_koji_check_for_base_image: False
 
+deep_manifest_list_inspection: True
+
 clusters:
   foo:
    - name: blah

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -517,7 +517,7 @@ class TestReactorConfigPlugin(object):
         'openshift', 'group_manifests', 'platform_descriptors', 'prefer_schema1_digest',
         'content_versions', 'registries', 'yum_proxy', 'source_registry', 'sources_command',
         'required_secrets', 'worker_token_secrets', 'clusters', 'hide_files',
-        'skip_koji_check_for_base_image'
+        'skip_koji_check_for_base_image', 'deep_manifest_list_inspection'
     ])
     def test_get_methods(self, fallback, method):
         _, workflow = self.prepare()


### PR DESCRIPTION
Whenever a manifest list digest check fails, we perform a deeper
inspection on the manifest list, comparing its v2 manifest digests with
the values in the koji archives.

* OSBS-7665

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
