### PR TITLE
Deep manifest inspection improvements

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -152,4 +152,5 @@ DOCKERIGNORE = '.dockerignore'
 # Operator manifest constants
 OPERATOR_MANIFESTS_ARCHIVE = 'operator_manifests.zip'
 
+KOJI_BTYPE_IMAGE = 'image'
 KOJI_BTYPE_OPERATOR_MANIFESTS = 'operator-manifests'

--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -9,7 +9,8 @@ from __future__ import print_function, unicode_literals, absolute_import
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import (
-    INSPECT_CONFIG, PLUGIN_KOJI_PARENT_KEY, BASE_IMAGE_KOJI_BUILD, PARENT_IMAGES_KOJI_BUILDS
+    INSPECT_CONFIG, PLUGIN_KOJI_PARENT_KEY, BASE_IMAGE_KOJI_BUILD, PARENT_IMAGES_KOJI_BUILDS,
+    KOJI_BTYPE_IMAGE
 )
 from atomic_reactor.plugins.pre_reactor_config import (
     get_deep_manifest_list_inspection, get_koji_session, get_source_registry,
@@ -214,7 +215,7 @@ class KojiParentPlugin(PreBuildPlugin):
 
         archives = self.koji_session.listArchives(build_id)
         koji_archives_data = {}
-        for archive in archives:
+        for archive in (a for a in archives if a['btype'] == KOJI_BTYPE_IMAGE):
             arch = archive['extra']['docker']['config']['architecture']
             v2_digest = archive['extra']['docker']['digests'][v2_type]
             koji_archives_data[arch] = v2_digest

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -377,6 +377,7 @@ class TestKojiParent(object):
         (koji_session.should_receive('getBuild')
             .and_return(koji_build))
         archives = [{
+            'btype': 'image',
             'extra': {
                 'docker': {
                     'config': {


### PR DESCRIPTION
- Fix bug which would lead a build to failure if deep manifest inspections were triggered for an operator build
- Use registry configuration to fetch manifest list

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
