### PR TITLE
Don't pass token to CGImport when reserving builds is disabled,

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -553,7 +553,11 @@ class KojiImportPlugin(ExitPlugin):
             koji_metadata['build']['build_id'] = self.workflow.reserved_build_id
 
         try:
-            build_info = self.session.CGImport(koji_metadata, server_dir, token=build_token)
+            if build_token:
+                build_info = self.session.CGImport(koji_metadata, server_dir, token=build_token)
+            else:
+                build_info = self.session.CGImport(koji_metadata, server_dir)
+
         except Exception:
             self.log.debug("metadata: %r", koji_metadata)
             raise

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1309,7 +1309,7 @@ class TestKojiImport(object):
         else:
             (flexmock(session)
                 .should_call('CGImport')
-                .with_args(dict, text_type, token=None)
+                .with_args(dict, text_type)
              )
 
         target = 'images-docker-candidate'


### PR DESCRIPTION
to keep it compatible with old version of koji

* OSBS-7168

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
