### PR TITLE
Fail on digest mismatches

### DIFF
--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -122,7 +122,7 @@ class KojiParentPlugin(PreBuildPlugin):
         if manifest_mismatches:
             mismatch_msg = ('Error while comparing parent images manifest digests in koji with '
                             'related values from registries: %s')
-            if get_fail_on_digest_mismatch(self.workflow, fallback=False):
+            if get_fail_on_digest_mismatch(self.workflow, fallback=True):
                 self.log.error(mismatch_msg, manifest_mismatches)
                 raise RuntimeError(mismatch_msg % manifest_mismatches)
 

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -383,6 +383,10 @@ def get_deep_manifest_list_inspection(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'deep_manifest_list_inspection', fallback)
 
 
+def get_fail_on_digest_mismatch(workflow, fallback=NO_FALLBACK):
+    return get_value(workflow, 'fail_on_digest_mismatch', fallback)
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -489,6 +489,11 @@
         "type": "boolean",
         "default": true
     },
+    "fail_on_digest_mismatch": {
+        "description": "Raise an error and stop build when a manifest list digest check fails",
+        "type": "boolean",
+        "default": false
+    },
     "hide_files": {
         "description": "Hide files during build for each stage",
         "type": "object",

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -492,7 +492,7 @@
     "fail_on_digest_mismatch": {
         "description": "Raise an error and stop build when a manifest list digest check fails",
         "type": "boolean",
-        "default": false
+        "default": true
     },
     "hide_files": {
         "description": "Hide files during build for each stage",

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -173,6 +173,8 @@ skip_koji_check_for_base_image: False
 
 deep_manifest_list_inspection: True
 
+fail_on_digest_mismatch: True
+
 clusters:
   foo:
    - name: blah

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -513,7 +513,7 @@ class TestReactorConfigPlugin(object):
     @pytest.mark.parametrize('method', [
         'koji', 'pulp', 'odcs', 'smtp', 'arrangement_version',
         'artifacts_allowed_domains', 'image_labels',
-        'image_label_info_url_format', 'image_equal_labels',
+        'image_label_info_url_format', 'image_equal_labels', 'fail_on_digest_mismatch',
         'openshift', 'group_manifests', 'platform_descriptors', 'prefer_schema1_digest',
         'content_versions', 'registries', 'yum_proxy', 'source_registry', 'sources_command',
         'required_secrets', 'worker_token_secrets', 'clusters', 'hide_files',


### PR DESCRIPTION

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
