### PR TITLE
Add method to check if code is running in orchestrator

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -33,7 +33,10 @@ from atomic_reactor.plugin import (
 )
 from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
-from atomic_reactor.constants import CONTAINER_DEFAULT_BUILD_METHOD
+from atomic_reactor.constants import (
+    CONTAINER_DEFAULT_BUILD_METHOD,
+    PLUGIN_BUILD_ORCHESTRATE_KEY
+)
 from atomic_reactor.util import ImageName, exception_message
 from atomic_reactor.build import BuildResult
 from atomic_reactor import get_logging_encoding
@@ -447,6 +450,33 @@ class DockerBuildWorkflow(object):
 
         if kwargs:
             logger.warning("unprocessed keyword arguments: %s", kwargs)
+
+    def get_orchestrate_build_plugin(self):
+        """
+        Get the orchestrate_build plugin configuration for this workflow
+        if present (will be present for orchestrator, not for worker).
+
+        :return: orchestrate_build plugin configuration dict
+        :raises: ValueError if the orchestrate_build plugin is not present
+        """
+        for plugin in self.buildstep_plugins_conf or []:
+            if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
+                return plugin
+        # Not an orchestrator build
+        raise ValueError('Not an orchestrator build')
+
+    def is_orchestrator_build(self):
+        """
+        Check if the plugin configuration for this workflow is for
+        an orchestrator build or a worker build.
+
+        :return: True if orchestrator build, False if worker build
+        """
+        try:
+            self.get_orchestrate_build_plugin()
+            return True
+        except ValueError:
+            return False
 
     @property
     def build_process_failed(self):

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -110,6 +110,15 @@ class BuildPlugin(Plugin):
         self.workflow = workflow
         super(BuildPlugin, self).__init__(*args, **kwargs)
 
+    def is_in_orchestrator(self):
+        """
+        Check if the configuration this plugin is part of is for
+        an orchestrator build or a worker build.
+
+        :return: True if orchestrator build, False if worker build
+        """
+        return self.workflow.is_orchestrator_build()
+
 
 class PluginsRunner(object):
 

--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -17,7 +17,7 @@ import zipfile
 from atomic_reactor.constants import (PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY,
                                       OPERATOR_MANIFESTS_ARCHIVE)
 from atomic_reactor.plugin import PostBuildPlugin
-from atomic_reactor.util import is_scratch_build, get_platforms, has_operator_manifest
+from atomic_reactor.util import is_scratch_build, has_operator_manifest
 from docker.errors import APIError
 from platform import machine
 
@@ -45,23 +45,13 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
         else:
             self.platform = machine()
 
-    def is_orchestrator(self):
-        """
-        Check if the plugin is running in orchestrator.
-
-        :return: bool
-        """
-        if get_platforms(self.workflow):
-            return True
-        return False
-
     def should_run(self):
         """
         Check if the plugin should run or skip execution.
 
         :return: bool, False if plugin should skip execution
         """
-        if self.is_orchestrator():
+        if self.is_in_orchestrator():
             self.log.warning("%s plugin set to run on orchestrator. Skipping", self.key)
             return False
         if self.operator_manifests_extract_platform != self.platform:

--- a/atomic_reactor/plugins/post_push_operator_manifest.py
+++ b/atomic_reactor/plugins/post_push_operator_manifest.py
@@ -24,7 +24,6 @@ from atomic_reactor.plugins.pre_reactor_config import (
     NO_FALLBACK,
 )
 from atomic_reactor.util import (
-    get_platforms,
     is_isolated_build,
     is_scratch_build,
     has_operator_manifest,
@@ -41,23 +40,13 @@ class PushOperatorManifestsPlugin(PostBuildPlugin):
 
     DOWNLOAD_DIR = 'operators_artifacts'
 
-    def is_orchestrator(self):
-        """
-        Check if the plugin is running in orchestrator.
-
-        :return: bool
-        """
-        if get_platforms(self.workflow):
-            return True
-        return False
-
     def should_run(self):
         """
         Check if the plugin should run or skip execution.
 
         :return: bool, False if plugin should skip execution
         """
-        if not self.is_orchestrator():
+        if not self.is_in_orchestrator():
             self.log.warning("%s plugin set to run on worker. Skipping", self.key)
             return False
 

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -126,7 +126,6 @@ class AddFilesystemPlugin(PreBuildPlugin):
         self.blocksize = blocksize
         self.repos = repos or []
         self.architectures = get_platforms(self.workflow)
-        self.is_orchestrator = True if self.architectures else False
         self.architecture = architecture
         self.scratch = util.is_scratch_build()
         self.koji_target = koji_target
@@ -406,7 +405,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
         task_id, filesystem_regex = self.run_image_task(image_build_conf)
 
         new_base_image = None
-        if not self.is_orchestrator:
+        if not self.is_in_orchestrator():
             new_base_image = self.stream_filesystem(task_id, filesystem_regex)
 
         return {

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -43,7 +43,6 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA1, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
                                       MEDIA_TYPE_OCI_V1_INDEX,
-                                      PLUGIN_BUILD_ORCHESTRATE_KEY,
                                       PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
                                       PLUGIN_KOJI_PARENT_KEY,
                                       PARENT_IMAGE_BUILDS_KEY, PARENT_IMAGES_KOJI_BUILDS,
@@ -616,9 +615,13 @@ def base_image_is_custom(base_image_name):
 
 
 def get_orchestrator_platforms(workflow):
-    for plugin in workflow.buildstep_plugins_conf or []:
-        if plugin['name'] == PLUGIN_BUILD_ORCHESTRATE_KEY:
-            return plugin['args']['platforms']
+    try:
+        orchestrate_build_plugin = workflow.get_orchestrate_build_plugin()
+    except ValueError:
+        # Not an orchestrator build
+        return None
+    else:
+        return orchestrate_build_plugin['args']['platforms']
 
 
 def get_platforms(workflow):

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -35,7 +35,9 @@ import signal
 from atomic_reactor.inner import BuildResults, BuildResultsEncoder, BuildResultsJSONDecoder
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.inner import FSWatcher
-from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
+from atomic_reactor.constants import (INSPECT_ROOTFS,
+                                      INSPECT_ROOTFS_LAYERS,
+                                      PLUGIN_BUILD_ORCHESTRATE_KEY)
 
 
 BUILD_RESULTS_ATTRS = ['build_logs',
@@ -1420,6 +1422,21 @@ def test_layer_sizes():
     ]
 
     assert workflow.layer_sizes == expected
+
+
+@pytest.mark.parametrize('buildstep_plugins, is_orchestrator', [
+    (None, False),
+    ([], False),
+    ([{'name': 'some_name'}], False),
+    ([{'name': PLUGIN_BUILD_ORCHESTRATE_KEY}], True),
+
+    ([{'name': 'some_other_name'},
+      {'name': PLUGIN_BUILD_ORCHESTRATE_KEY}], True)
+])
+def test_workflow_is_orchestrator_build(buildstep_plugins, is_orchestrator):
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   buildstep_plugins=buildstep_plugins)
+    assert workflow.is_orchestrator_build() == is_orchestrator
 
 
 def test_fs_watcher_update(monkeypatch):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -928,11 +928,8 @@ def test_is_isolated_build(build_json, isolated):
      ['arm64', 'ppce64le'])
 ])
 def test_get_orchestrator_platforms(inputs, results):
-    class MockWorkflow(object):
-        def __init__(self, inputs):
-            self.buildstep_plugins_conf = inputs
-
-    workflow = MockWorkflow(inputs)
+    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+                                   buildstep_plugins=inputs)
     if results:
         assert sorted(get_orchestrator_platforms(workflow)) == sorted(results)
     else:


### PR DESCRIPTION
* OSBS-7005

The method assumes that a build is an orchestrator build if (and only if) it includes the `orchestrate_build` buildstep plugin. It is defined in `DockerBuildWorkflow`, which seems like the proper place for it given that it contains most of the build configuration. Build plugins also get an `is_in_orchestrator()` method which simply calls the `is_orchestrator_build()` method of their workflow (for convenience).


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
