### PR TITLE
Fix tests for pytest version 5

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -78,13 +78,13 @@ fi
 $RUN $PKG install -y $PIP_PKG
 
 if [[ $OS == centos && $OS_VERSION == 7 ]]; then
+  # Get a less ancient version of pip to avoid installing py3-only packages
+  $RUN $PIP install "pip>=9.0.0,<10.0.0"
+  # ...but ancient enough to allow uninstalling packages installed by distutils
+
   # Older versions of setuptools don't understand the environment
   # markers used by docker-squash's requirements
   $RUN $PIP install -U setuptools
-  # Newer versions of more-itertools do not support python 2. And
-  # centos7 version of pip does not parse requires_python metadata
-  # https://github.com/pytest-dev/pytest/issues/4770#issuecomment-462630885
-  $RUN $PIP install more-itertools==5.0.0
 fi
 
 # Install other dependencies for tests

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -359,7 +359,7 @@ def test_missing_yum_repourls(tmpdir, reactor_config_map):  # noqa
     file_name = mock_image_build_file(str(tmpdir), contents=image_build_conf)
     with pytest.raises(ValueError) as exc:
         plugin.parse_image_build_config(file_name)
-    assert 'install_tree cannot be empty' in str(exc)
+    assert 'install_tree cannot be empty' in str(exc.value)
 
 
 @pytest.mark.parametrize(('build_cancel', 'error_during_cancel'), [
@@ -402,9 +402,9 @@ def test_image_task_failure(tmpdir, build_cancel, error_during_cancel, raise_err
                          logger='atomic_reactor'), pytest.raises(PluginFailedException) as exc:
         runner.run()
 
-    assert task_result in str(exc)
+    assert task_result in str(exc.value)
     # Also ensure getTaskResult exception message is wrapped properly
-    assert 'image task,' in str(exc)
+    assert 'image task,' in str(exc.value)
 
     if build_cancel:
         msg = "Build was canceled, canceling task %s" % FILESYSTEM_TASK_ID
@@ -649,7 +649,7 @@ def test_build_filesystem_missing_conf(tmpdir, reactor_config_map):  # noqa
     plugin = create_plugin_instance(tmpdir, reactor_config_map=reactor_config_map)
     with pytest.raises(RuntimeError) as exc:
         plugin.build_filesystem('image-build.conf')
-    assert 'Image build configuration file not found' in str(exc)
+    assert 'Image build configuration file not found' in str(exc.value)
 
 
 @pytest.mark.parametrize(('prefix', 'architecture', 'suffix'), [
@@ -786,4 +786,4 @@ def test_no_target_set(tmpdir, reactor_config_map):
     file_name = mock_image_build_file(str(tmpdir), contents=image_build_conf)
     with pytest.raises(ValueError) as exc:
         plugin.parse_image_build_config(file_name)
-    assert 'target cannot be empty' in str(exc)
+    assert 'target cannot be empty' in str(exc.value)

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -184,4 +184,4 @@ def test_invalid_repourl():
         runner.run()
 
     msg = "Failed to fetch yum repo {repo}".format(repo=WRONG_REPO_URL)
-    assert msg in str(exc)
+    assert msg in str(exc.value)

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -160,7 +160,7 @@ class TestBumpRelease(object):
         if build_exists and not scratch:
             with pytest.raises(RuntimeError) as exc:
                 plugin.run()
-            assert 'build already exists in Koji: ' in str(exc)
+            assert 'build already exists in Koji: ' in str(exc.value)
         else:
             plugin.run()
         assert 'not incrementing' in caplog.text
@@ -178,7 +178,7 @@ class TestBumpRelease(object):
         plugin = self.prepare(tmpdir, labels=labels, reactor_config_map=reactor_config_map)
         with pytest.raises(RuntimeError) as exc:
             plugin.run()
-        assert 'missing label' in str(exc)
+        assert 'missing label' in str(exc.value)
 
     @pytest.mark.parametrize('component', [
         {'com.redhat.component': 'component1'},
@@ -350,7 +350,7 @@ class TestBumpRelease(object):
         if init_fails and reserve_build and reactor_config_map and not next_release['scratch']:
             with pytest.raises(RuntimeError) as exc:
                 plugin.run()
-            assert 'unable to pre-declare build ' in str(exc)
+            assert 'unable to pre-declare build ' in str(exc.value)
             return
 
         plugin.run()

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -276,7 +276,7 @@ def test_check_and_set_platforms_no_koji(tmpdir, caplog, platforms, platform_onl
     else:
         with pytest.raises(Exception) as e:
             plugin_result = runner.run()
-            assert "no koji target or platform list" in str(e)
+            assert "no koji target or platform list" in str(e.value)
 
 
 @pytest.mark.parametrize(('platforms', 'platform_only', 'cluster_platforms', 'result'), [

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -166,7 +166,7 @@ class TestExportOperatorManifests(object):
                 runner.run()
                 if not has_archive:
                     assert 'Could not extract operator manifest files' in caplog.text
-                    assert 'Could not extract operator manifest files' in str(exc)
+                    assert 'Could not extract operator manifest files' in str(exc.value)
                 if remove_fails:
                     assert 'Failed to remove container' in caplog.text
 
@@ -177,6 +177,6 @@ class TestExportOperatorManifests(object):
             with pytest.raises(PluginFailedException) as exc:
                 runner.run()
                 assert 'Empty operator manifests directory' in caplog.text
-                assert 'Empty operator manifests directory' in str(exc)
+                assert 'Empty operator manifests directory' in str(exc.value)
         else:
             runner.run()

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -512,8 +512,8 @@ def test_fetch_maven_artifacts_nvr_no_match(tmpdir, docker_tasker, nvr_requests,
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'failed to find archives' in str(e)
-    assert error_msg in str(e)
+    assert 'failed to find archives' in str(e.value)
+    assert error_msg in str(e.value)
 
 
 @responses.activate  # noqa
@@ -539,7 +539,7 @@ def test_fetch_maven_artifacts_nvr_bad_checksum(tmpdir, docker_tasker, reactor_c
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'does not match expected checksum' in str(e)
+    assert 'does not match expected checksum' in str(e.value)
 
 
 @responses.activate  # noqa
@@ -565,7 +565,7 @@ def test_fetch_maven_artifacts_nvr_bad_url(tmpdir, docker_tasker, reactor_config
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert '404 Client Error' in str(e)
+    assert '404 Client Error' in str(e.value)
 
 
 @responses.activate  # noqa
@@ -594,7 +594,7 @@ def test_fetch_maven_artifacts_nvr_bad_nvr(tmpdir, docker_tasker, reactor_config
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'Build where-is-this-build-3.0-2 not found' in str(e)
+    assert 'Build where-is-this-build-3.0-2 not found' in str(e.value)
 
 
 @pytest.mark.parametrize('contents', (  # noqa
@@ -642,7 +642,7 @@ def test_fetch_maven_artifacts_nvr_schema_error(tmpdir, docker_tasker, contents,
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'ValidationError' in str(e)
+    assert 'ValidationError' in str(e.value)
 
 
 @pytest.mark.parametrize(('contents', 'expected'), (  # noqa
@@ -709,7 +709,7 @@ def test_fetch_maven_artifacts_url_bad_checksum(tmpdir, docker_tasker, reactor_c
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'does not match expected checksum' in str(e)
+    assert 'does not match expected checksum' in str(e.value)
 
 
 @responses.activate  # noqa
@@ -735,7 +735,7 @@ def test_fetch_maven_artifacts_url_bad_url(tmpdir, docker_tasker, reactor_config
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert '404 Client Error' in str(e)
+    assert '404 Client Error' in str(e.value)
 
 
 @pytest.mark.parametrize('contents', (  # noqa
@@ -790,7 +790,7 @@ def test_fetch_maven_artifacts_url_schema_error(tmpdir, docker_tasker, contents,
     with pytest.raises(PluginFailedException) as e:
         runner.run()
 
-    assert 'ValidationError' in str(e)
+    assert 'ValidationError' in str(e.value)
 
 
 @pytest.mark.parametrize(('domains', 'raises'), (  # noqa
@@ -838,7 +838,7 @@ def test_fetch_maven_artifacts_url_allowed_domains(tmpdir, docker_tasker, domain
     if raises:
         with pytest.raises(PluginFailedException) as e:
             runner.run()
-        assert 'is not in list of allowed domains' in str(e)
+        assert 'is not in list of allowed domains' in str(e.value)
 
     else:
         results = runner.run()

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -130,7 +130,7 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker, config_name, breakage,
     if expected_exception:
         with pytest.raises(PluginFailedException) as ex:
             runner.run()
-        assert expected_exception in str(ex)
+        assert expected_exception in str(ex.value)
     else:
         runner.run()
 

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -766,7 +766,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage, mock_f
     if expected_exception:
         with pytest.raises(PluginFailedException) as ex:
             runner.run()
-        assert expected_exception in str(ex)
+        assert expected_exception in str(ex.value)
     else:
         runner.run()
 

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -617,4 +617,4 @@ def test_group_manifests(tmpdir, schema_version, test_name, group, foreign_layer
     else:
         with pytest.raises(PluginFailedException) as ex:
             runner.run()
-        assert expected_exception in str(ex)
+        assert expected_exception in str(ex.value)

--- a/tests/plugins/test_inject_parent_image.py
+++ b/tests/plugins/test_inject_parent_image.py
@@ -164,7 +164,7 @@ class TestKojiParent(object):
         with pytest.raises(PluginFailedException) as exc_info:
             self.run_plugin_with_args(workflow, plugin_args={'koji_parent_build': unknown_build},
                                       reactor_config_map=reactor_config_map)
-        assert '{}, not found'.format(unknown_build) in str(exc_info)
+        assert '{}, not found'.format(unknown_build) in str(exc_info.value)
 
     @pytest.mark.parametrize(('repositories', 'selected'), (
         ([':26-3', '@sha256:12345'], '@sha256:12345'),

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -672,7 +672,7 @@ class TestKojiImport(object):
 
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert "plugin 'koji_import' raised an exception: KeyError" in str(exc)
+        assert "plugin 'koji_import' raised an exception: KeyError" in str(exc.value)
 
     def test_koji_import_no_build_metadata(self, tmpdir, monkeypatch, os_env, reactor_config_map):  # noqa
         tasker, workflow = mock_environment(tmpdir,
@@ -696,7 +696,7 @@ class TestKojiImport(object):
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert "plugin 'koji_import' raised an exception: RuntimeError" in str(exc)
+        assert "plugin 'koji_import' raised an exception: RuntimeError" in str(exc.value)
 
     @pytest.mark.parametrize(('isolated'), [
         False,

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -143,7 +143,7 @@ class TestKojiParent(object):
             .and_return(koji_no_extra))
         with pytest.raises(PluginFailedException) as exc_info:
             self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
-        assert 'does not have manifest digest data' in str(exc_info)
+        assert 'does not have manifest digest data' in str(exc_info.value)
 
     def test_koji_build_retry(self, workflow, koji_session, reactor_config_map):  # noqa
         (flexmock(koji_session)
@@ -231,7 +231,7 @@ class TestKojiParent(object):
                     self.run_plugin_with_args(workflow, expect_result=exp_result,
                                               reactor_config_map=reactor_config_map,
                                               external_base=external)
-                assert 'Was this image built in OSBS?' in str(exc)
+                assert 'Was this image built in OSBS?' in str(exc.value)
             else:
                 result = {PARENT_IMAGES_KOJI_BUILDS: {ImageName.parse('base'): None}}
                 self.run_plugin_with_args(workflow, expect_result=result,
@@ -355,7 +355,7 @@ class TestKojiParent(object):
         workflow.builder.parent_images_digests = {'base:latest': {'unexpected_type': 'stubDigest'}}
         with pytest.raises(PluginFailedException) as exc_info:
             self.run_plugin_with_args(workflow, reactor_config_map=reactor_config_map)
-        assert 'Unexpected parent image digest data' in str(exc_info)
+        assert 'Unexpected parent image digest data' in str(exc_info.value)
 
     @pytest.mark.parametrize('feature_flag', [True, False])
     @pytest.mark.parametrize('parent_tag', ['stubDigest', 'wrongDigest'])

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -472,7 +472,7 @@ class TestKojiPromote(object):
 
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert "plugin 'koji_promote' raised an exception: KeyError" in str(exc)
+        assert "plugin 'koji_promote' raised an exception: KeyError" in str(exc.value)
 
     def test_koji_promote_no_build_metadata(self, tmpdir, monkeypatch, os_env, reactor_config_map):  # noqa
         tasker, workflow = mock_environment(tmpdir,
@@ -496,7 +496,7 @@ class TestKojiPromote(object):
         runner = create_runner(tasker, workflow, reactor_config_map=reactor_config_map)
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert "plugin 'koji_promote' raised an exception: RuntimeError" in str(exc)
+        assert "plugin 'koji_promote' raised an exception: RuntimeError" in str(exc.value)
 
     @pytest.mark.parametrize(('isolated'), [
         False,

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -519,7 +519,7 @@ class TestKojiUpload(object):
 
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert "plugin 'koji_upload' raised an exception: KeyError" in str(exc)
+        assert "plugin 'koji_upload' raised an exception: KeyError" in str(exc.value)
 
     def test_koji_upload_no_build_metadata(self, tmpdir, monkeypatch, os_env, reactor_config_map):  # noqa
         tasker, workflow = mock_environment(tmpdir,

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -709,7 +709,7 @@ def test_orchestrate_build_cancelation(tmpdir):
 
     with pytest.raises(PluginFailedException) as exc:
         runner.run()
-    assert 'BuildCanceledException' in str(exc)
+    assert 'BuildCanceledException' in str(exc.value)
 
 
 @pytest.mark.parametrize(('clusters_x86_64'), (
@@ -795,12 +795,12 @@ def test_orchestrate_build_unknown_platform(tmpdir, reactor_config_map):  # noqa
     with pytest.raises(PluginFailedException) as exc:
         runner.run()
     if reactor_config_map:
-        assert "No clusters found for platform spam!" in str(exc)
+        assert "No clusters found for platform spam!" in str(exc.value)
     else:
         count = 0
-        if "No clusters found for platform x86_64!" in str(exc):
+        if "No clusters found for platform x86_64!" in str(exc.value):
             count += 1
-        if "No clusters found for platform spam!" in str(exc):
+        if "No clusters found for platform spam!" in str(exc.value):
             count += 1
         assert count > 0
 
@@ -988,7 +988,7 @@ def test_orchestrate_build_get_fs_task_id(tmpdir, task_id, error):
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
         workflow.build_result.is_failed()
-        assert error in str(exc)
+        assert error in str(exc.value)
 
     else:
         build_result = runner.run()
@@ -1467,8 +1467,8 @@ def test_set_build_image_raises(tmpdir, build, exc_str, bc, bc_cont, ims, ims_co
 
     with pytest.raises(PluginFailedException) as ex:
         runner.run()
-    assert "raised an exception: RuntimeError" in str(ex)
-    assert exc_str in str(ex)
+    assert "raised an exception: RuntimeError" in str(ex.value)
+    assert exc_str in str(ex.value)
 
 
 @pytest.mark.parametrize(('build', 'bc', 'bc_cont', 'ims', 'ims_cont',
@@ -1675,7 +1675,7 @@ def test_no_platforms(tmpdir):
     )
     with pytest.raises(PluginFailedException) as exc:
         runner.run()
-    assert 'No enabled platform to build on' in str(exc)
+    assert 'No enabled platform to build on' in str(exc.value)
 
 
 @pytest.mark.parametrize('version,warning,exception', (

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -605,7 +605,7 @@ class TestValidateBaseImage(object):
                                             inspect_only=False,
                                             workflow_callback=workflow_callback,
                                             check_platforms=True)
-            assert no_manifest_msg in str(exc)
+            assert no_manifest_msg in str(exc.value)
 
     def test_registry_undefined(self, caplog):
         def workflow_callback(workflow):
@@ -874,7 +874,7 @@ class TestValidateBaseImage(object):
                                             workflow_callback=workflow_callback,
                                             check_platforms=True,  # orchestrator
                                             )
-            assert 'Missing arches in manifest list for base image' in str(exc)
+            assert 'Missing arches in manifest list for base image' in str(exc.value)
         else:
             test_pull_base_image_plugin(LOCALHOST_REGISTRY, BASE_IMAGE,
                                         [], [], reactor_config_map=True,

--- a/tests/plugins/test_push_operator_manifest.py
+++ b/tests/plugins/test_push_operator_manifest.py
@@ -195,4 +195,4 @@ class TestPushOperatorManifests(object):
         runner = mock_env(tmpdir, docker_tasker, omps_push_fail=True)
         with pytest.raises(PluginFailedException) as exc:
             runner.run()
-        assert 'Failed to push operator manifests:' in str(exc)
+        assert 'Failed to push operator manifests:' in str(exc.value)

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -334,7 +334,7 @@ class TestSendMailPlugin(object):
         else:
             with pytest.raises(RuntimeError) as ex:
                 p._get_receivers_list()
-                assert str(ex) == 'No recipients found'
+                assert str(ex.value) == 'No recipients found'
 
     @pytest.mark.parametrize('success', (True, False))
     @pytest.mark.parametrize(('has_store_metadata_results', 'annotations', 'has_repositories',

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -133,7 +133,7 @@ def test_bad_inspect_data(tmpdir, docker_tasker, inspect, error):
     with pytest.raises(PluginFailedException) as exc:
         runner.run()
 
-    assert error in str(exc)
+    assert error in str(exc.value)
 
 
 @pytest.mark.parametrize(('floating_tags', 'unique_tags', 'primary_tags', 'expected'), [  # noqa

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,10 +1,9 @@
-flexmock
+flexmock>=0.10.3
 ordereddict
 responses>=0.9.0
 pypng
-pytest==4.0.*
-pytest-cov==2.6.*
-six>=1.10.0 # required by pytest-cov
+pytest>=4.1.0
+pytest-cov
 flake8
 koji
 requests-mock

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1015,7 +1015,7 @@ def test_workflow_docker_build_error_reports(steps_to_fail, step_reported):
 
     with pytest.raises(Exception) as exc:
         workflow.build_docker_image()
-    assert exc_string(step_reported) in str(exc)
+    assert exc_string(step_reported) in str(exc.value)
 
 
 class ExitUsesSource(ExitWatched):

--- a/tests/test_koji_util.py
+++ b/tests/test_koji_util.py
@@ -400,7 +400,7 @@ class TestGetKojiModuleBuild(object):
         if should_raise:
             with pytest.raises(Exception) as e:
                 get_koji_module_build(session, spec)
-            assert should_raise in str(e)
+            assert should_raise in str(e.value)
         else:
             self.mock_get_rpms(session)
             get_koji_module_build(session, spec)

--- a/tests/test_omps_util.py
+++ b/tests/test_omps_util.py
@@ -80,7 +80,7 @@ class TestOMPS(object):
             omps.push_archive(fb)
             assert exc.value.status_code == status_code
             assert exc.value.response == omps_res
-            assert '(validation errors: {})'.format(validation_info) in str(exc)
+            assert '(validation errors: {})'.format(validation_info) in str(exc.value)
 
     def test_push_archive_server_error(self, requests_mock):
         """Service running behind HAProxy may return 503 error without json.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -459,7 +459,7 @@ class TestInputPluginsRunner(object):
         flexmock(os, environ={})
         with pytest.raises(PluginFailedException) as e:
             InputPluginsRunner([{'name': 'auto', 'args': {}}])
-        assert 'No autousable input plugin' in str(e)
+        assert 'No autousable input plugin' in str(e.value)
 
     def test_autoinput_more_autousable(self):
         # mock env vars checked by both env and osv3 input plugins
@@ -467,8 +467,8 @@ class TestInputPluginsRunner(object):
                               'BUILD_JSON': 'd'})
         with pytest.raises(PluginFailedException) as e:
             InputPluginsRunner([{'name': 'auto', 'args': {}}])
-        assert 'More than one usable plugin with "auto" input' in str(e)
-        assert 'osv3, env' in str(e) or 'env, osv3' in str(e)
+        assert 'More than one usable plugin with "auto" input' in str(e.value)
+        assert 'osv3, env' in str(e.value) or 'env, osv3' in str(e.value)
 
     def test_autoinput_one_autousable(self):
         # mock env var for env input plugin

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -209,8 +209,8 @@ def test_push_image(temp_image_name, should_fail):
     if should_fail:
         with pytest.raises(RetryGeneratorException) as exc:
             output = t.push_image(temp_image_name, insecure=True)
-        assert "Failed to mock_method image" in str(exc)
-        assert "connection refused" in str(exc)
+        assert "Failed to mock_method image" in str(exc.value)
+        assert "connection refused" in str(exc.value)
     else:
         output = t.push_image(temp_image_name, insecure=True)
         assert output is not None
@@ -532,11 +532,11 @@ def test_login(tmpdir, dockerconfig_contents, should_raise):
         if 'auth' in dockerconfig_contents[LOCALHOST_REGISTRY]:
             with pytest.raises(ValueError) as exc:
                 t.login(LOCALHOST_REGISTRY, tmpdir_path)
-                assert "Failed to parse 'auth'" in str(exc)
+                assert "Failed to parse 'auth'" in str(exc.value)
         else:
             with pytest.raises(RuntimeError) as exc:
                 t.login(LOCALHOST_REGISTRY, tmpdir_path)
-                assert "Failed to extract a username" in str(exc)
+                assert "Failed to extract a username" in str(exc.value)
     else:
         if MOCK:
             (fake_api

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -239,7 +239,7 @@ def test_figure_out_build_file(tmpdir, contents, local_path, expected_path, expe
     else:
         with pytest.raises(Exception) as e:
             figure_out_build_file(tmpdir_path, local_path=local_path)
-        assert expected_exception in str(e)
+        assert expected_exception in str(e.value)
 
 
 @requires_internet
@@ -1547,7 +1547,7 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
     if will_raise:
         with pytest.raises(raise_exception) as e:
             get_inspect_for_image(image, image.registry, insecure)
-        assert error_msg in str(e)
+        assert error_msg in str(e.value)
 
     else:
         if found_versions and ('v2' in found_versions or 'v2_list' in found_versions):


### PR DESCRIPTION
* OSBS-7708

This script right here is the MVP:
```python
#!/usr/bin/env python3
import re
import sys
from pathlib import Path

PATTERN = (r'with pytest\.raises\(.*?\) as (\w+):'
           r'.*?str\(\1\b(?!\.value)')
FLAGS = re.DOTALL

PAT = re.compile(PATTERN, flags=FLAGS)
REPLACE_FN = lambda match: match.group() + '.value'

file = Path(sys.argv[1])

content = file.read_text()
fixed = PAT.sub(REPLACE_FN, content)

# for cases like these:
#   with pytest.raises(Exception) as e:
#       do_stuff()
#   assert 'a' in str(e)
#   assert 'b' in str(e)
while fixed != content:
    content = fixed
    fixed = PAT.sub(REPLACE_FN, content)

file.write_text(fixed)

```
It's ugly, kinda slow, and sometimes catches false positives, but it gets the job done :D

Note that [pytest no longer supports python 2 starting with version 5](https://docs.pytest.org/en/latest/py27-py34-deprecation.html), which is why I added a `tests/requirements-py2.txt` with an older pytest version.


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
