### PR TITLE
Raise Timeout error when registry is unavailable

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -16,7 +16,7 @@ import os
 import re
 import sys
 import requests
-from requests.exceptions import SSLError, HTTPError, RetryError, Timeout
+from requests.exceptions import SSLError, HTTPError, RetryError
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 import shutil
@@ -928,7 +928,7 @@ def get_manifest(image, registry_session, version):
     media_type = get_manifest_media_type(version)
     try:
         response = query_registry(registry_session, image, digest=None, version=version)
-    except (HTTPError, RetryError, Timeout) as ex:
+    except (HTTPError, RetryError) as ex:
         if ex.response.status_code == requests.codes.not_found:
             saved_not_found = ex
         # If the registry has a v2 manifest that can't be converted into a v1


### PR DESCRIPTION
Requests Timeout errors do not have response objects attached. Do not
try to parse their status code for error handling. Just raise the error
instead.

* OSBS-7928

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
