### PR TITLE
Skip yum repo-url restrictions for scratch builds

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -314,7 +314,7 @@
         }
     },
     "yum_repo_allowed_domains": {
-        "description": "Domains allowed to use when fetching yum repo files",
+        "description": "Domains allowed when fetching yum repo files. If not specified, no restrictions will be applied. The restriction does not apply to scratch builds",
         "type": "array",
         "items": {
             "type": "string"


### PR DESCRIPTION
Allow users to try custom yum repositories for scratch builds. This can
be useful for debugging purposes.

* OSBS-7972

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
