### PR TITLE
Use groupified OCP API

### DIFF
--- a/docs/build_json.md
+++ b/docs/build_json.md
@@ -13,7 +13,7 @@ If you want to take advantage of _inner_ part logic of Atomic Reactor, you can d
     "provider": "git"
   },
   "image": "my-test-image",
-  "openshift_build_selflink": "/oapi/v1/namespaces/default/builds/build-20150826112654-1",
+  "openshift_build_selflink": "/apis/build.openshift.io/v1/namespaces/default/builds/build-20150826112654-1",
   "prebuild_plugins": [
     {
       "args": {


### PR DESCRIPTION
oapi is deprecated and will be removed in OCP4

* OSBS-5497

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
