### PR TITLE
koji_parent waits for build in building state to finish

### DIFF
--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -274,10 +274,11 @@ class KojiParentPlugin(PreBuildPlugin):
             build = self.koji_session.getBuild(nvr)
             if build:
                 self.log.info('Parent image Koji build found with id %s', build.get('id'))
-                if build['state'] != koji.BUILD_STATES['COMPLETE']:
+                if build['state'] == koji.BUILD_STATES['COMPLETE']:
+                    return build
+                elif build['state'] != koji.BUILD_STATES['BUILDING']:
                     exc_msg = ('Parent image Koji build for {} with id {} state is not COMPLETE.')
                     raise KojiParentBuildMissing(exc_msg.format(nvr, build.get('id')))
-                return build
             time.sleep(self.poll_interval)
         raise KojiParentBuildMissing('Parent image Koji build NOT found for {}!'.format(nvr))
 

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -56,12 +56,16 @@ KOJI_BUILD_ID = 123456789
 KOJI_BUILD_NVR = 'base-image-1.0-99'
 
 KOJI_STATE_COMPLETE = koji.BUILD_STATES['COMPLETE']
+KOJI_STATE_BUILDING = koji.BUILD_STATES['BUILDING']
 
 V2_LIST = get_manifest_media_type('v2_list')
 V2 = get_manifest_media_type('v2')
 KOJI_EXTRA = {'image': {'index': {'digests': {V2_LIST: 'stubDigest'}}}}
 
 KOJI_STATE_DELETED = koji.BUILD_STATES['DELETED']
+
+KOJI_BUILD_BUILDING = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_BUILDING,
+                       'extra': KOJI_EXTRA}
 
 KOJI_BUILD = {'nvr': KOJI_BUILD_NVR, 'id': KOJI_BUILD_ID, 'state': KOJI_STATE_COMPLETE,
               'extra': KOJI_EXTRA}
@@ -152,7 +156,7 @@ class TestKojiParent(object):
             .and_return(None)
             .and_return(None)
             .and_return(None)
-            .and_return(None)
+            .and_return(KOJI_BUILD_BUILDING)
             .and_return(KOJI_BUILD)
             .times(5))
 


### PR DESCRIPTION
* OSBS-8053

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
