### PR TITLE
inject parent image has to enclose original_base_image

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -204,6 +204,15 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
                 custom_base_images.add(image_str)
                 self.custom_parent_image = True
             self.parents_ordered.append(image_str)
+
+            # we are setting values None, because we know parent but we don't
+            # have local copy yet
+            # if image is base image we want to keep image instance in key,
+            # so it is same as original_base_image instance
+            if self.original_base_image.to_str() == image_str:
+                self.parent_images[self.original_base_image] = None
+                continue
+
             self.parent_images[image_name] = None
 
         if len(custom_base_images) > 1:

--- a/atomic_reactor/plugins/pre_inject_parent_image.py
+++ b/atomic_reactor/plugins/pre_inject_parent_image.py
@@ -132,6 +132,7 @@ class InjectParentImage(PreBuildPlugin):
 
         if organization:
             self.workflow.builder.base_image.enclose(organization)
+            self.workflow.builder.original_base_image.enclose(organization)
             new_parent_image.enclose(organization)
 
         self._new_parent_image = new_parent_image.to_str()

--- a/tests/plugins/test_inject_parent_image.py
+++ b/tests/plugins/test_inject_parent_image.py
@@ -76,6 +76,7 @@ class MockInsideBuilder(object):
     def __init__(self):
         self.tasker = DockerTasker()
         self.base_image = ImageName(repo='fedora', tag='26')
+        self.original_base_image = ImageName(repo='fedora', tag='26')
         self.base_from_scratch = False
         self.custom_base_image = False
         self.image_id = 'image_id'


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
