### PR TITLE
add timestamp to explicitly specified release for autorebuilds

### DIFF
--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -63,6 +63,10 @@
         "from_latest": {
           "description": "Whether to rebuild from the latest commit",
           "type": "boolean"
+        },
+        "add_timestamp_to_release": {
+          "description": "Whether to append timestamp to explicitly specified release for autorebuilds",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -543,7 +543,7 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, breakage):
         files = inspector.list_files()
         assert sorted(files) == config['expected_contents']
 
-        components = {c['name'] for c in workflow.image_components}
+        components = {c['name'] for c in workflow.image_components}  # noqa:E501; pylint: disable=not-an-iterable
         for n in config['expected_components']:
             assert n in components
         for n in config['unexpected_components']:


### PR DESCRIPTION
* OSBS-7803

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
