### PR TITLE
Add pre-build fetch_sources plugin

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -104,6 +104,7 @@ PLUGIN_VERIFY_MEDIA_KEY = 'verify_media'
 PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY = 'export_operator_manifests'
 PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY = 'push_operator_manifests'
 PLUGIN_SOURCE_CONTAINER_KEY = 'source_container'
+PLUGIN_FETCH_SOURCES_KEY = 'fetch_sources'
 
 
 # some shared dict keys for build metadata that gets recorded with koji.

--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -1,0 +1,224 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import absolute_import
+
+import os
+import tempfile
+import time
+
+import requests
+from six.moves.urllib.parse import urlparse
+
+from atomic_reactor.constants import (
+    DEFAULT_DOWNLOAD_BLOCK_SIZE,
+    HTTP_BACKOFF_FACTOR,
+    HTTP_MAX_RETRIES,
+    PLUGIN_FETCH_SOURCES_KEY
+)
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import (
+    get_koji,
+    get_koji_path_info,
+    get_koji_session,
+    get_config,
+    NO_FALLBACK
+)
+from atomic_reactor.util import get_retrying_requests_session
+
+
+class FetchSourcesPlugin(PreBuildPlugin):
+    """Download sources that may be used in further steps to compose Source Containers"""
+    key = PLUGIN_FETCH_SOURCES_KEY
+    is_allowed_to_fail = False
+    DOWNLOAD_DIR = 'image_sources'
+
+    def __init__(
+        self, tasker, workflow, koji_build_id=None, koji_build_nvr=None, signing_intent=None,
+    ):
+        """
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param koji_build_id: int, container image koji build id
+        :param koji_build_nvr: str, container image koji build NVR
+        :param signing_intent: str, ODCS signing intent name
+        """
+        if not koji_build_id and not koji_build_nvr:
+            err_msg = ('{} expects either koji_build_id or koji_build_nvr to be defined'
+                       .format(self.__class__.__name__))
+            raise TypeError(err_msg)
+        type_errors = []
+        if koji_build_id is not None and not isinstance(koji_build_id, int):
+            type_errors.append('koji_build_id must be an int. Got {}'.format(type(koji_build_id)))
+        if koji_build_nvr is not None and not isinstance(koji_build_nvr, str):
+            type_errors.append('koji_build_nvr must be a str. Got {}'.format(type(koji_build_nvr)))
+        if type_errors:
+            raise TypeError(type_errors)
+
+        super(FetchSourcesPlugin, self).__init__(tasker, workflow)
+        self.koji_build = None
+        self.koji_build_id = koji_build_id
+        self.koji_build_nvr = koji_build_nvr
+        self.signing_intent = signing_intent
+        self.session = get_koji_session(self.workflow, NO_FALLBACK)
+
+    def run(self):
+        """
+        :return: dict, binary image koji build id and nvr, and path to directory with
+        downloaded sources
+        """
+        self.set_koji_image_build_data()
+        signing_intent = self.get_signing_intent()
+        koji_config = get_koji(self.workflow, {})
+        insecure = koji_config.get('insecure_download', False)
+        urls = self.get_srpm_urls(signing_intent['keys'], insecure=insecure)
+        sources_dir = self.download_sources(urls, insecure=insecure)
+        return {
+                'sources_for_koji_build_id': self.koji_build_id,
+                'sources_for_nvr': self.koji_build_nvr,
+                'image_sources_dir': sources_dir,
+        }
+
+    def download_sources(self, urls, insecure=False):
+        """Download sources content
+
+        Download content in the given URLs into a new temporary directory and
+        return a list with each downloaded artifact's path.
+
+        :param urls: int, Koji build id of the container image we want SRPMs for
+        :param insecure: bool, whether to perform TLS checks of urls
+        :return: str, paths to directory with downloaded sources
+        """
+        workdir = tempfile.mkdtemp()
+        dest_dir = os.path.join(workdir, self.DOWNLOAD_DIR)
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+
+        req_session = get_retrying_requests_session()
+        for url in urls:
+            parsed_url = urlparse(url)
+            dest_filename = os.path.basename(parsed_url.path)
+            dest_path = os.path.join(dest_dir, dest_filename)
+            self.log.debug('Downloading %s', url)
+
+            for attempt in range(HTTP_MAX_RETRIES + 1):
+                request = req_session.get(url, stream=True, verify=not insecure)
+                request.raise_for_status()
+                try:
+                    with open(dest_path, 'wb') as f:
+                        for chunk in request.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
+                            f.write(chunk)
+                    break
+                except (requests.exceptions.RequestException):
+                    if attempt < HTTP_MAX_RETRIES:
+                        time.sleep(HTTP_BACKOFF_FACTOR * (2 ** attempt))
+                    else:
+                        raise
+
+            self.log.debug('Download finished: %s', dest_path)
+
+        return dest_dir
+
+    def set_koji_image_build_data(self):
+        build_identifier = self.koji_build_nvr or self.koji_build_id
+
+        # strict means this raises a koji.GenericError informing no matching build was found in
+        # case the build does not exist
+        self.koji_build = self.session.getBuild(build_identifier, strict=True)
+
+        if self.koji_build_id and (self.koji_build_id != self.koji_build['build_id']):
+            err_msg = (
+                'koji_build_id {} does not match koji_build_nvr {} with id {}. '
+                'When specifying both an id and an nvr, they should point to the same image build'
+                .format(self.koji_build_id, self.koji_build_nvr, self.koji_build['build_id'])
+                )
+            raise ValueError(err_msg)
+
+        if not self.koji_build_id:
+            self.koji_build_id = self.koji_build['build_id']
+        if not self.koji_build_nvr:
+            self.koji_build_nvr = self.koji_build['nvr']
+
+    def assemble_srpm_url(self, base_url, srpm_filename, sign_key=None):
+        """Assemble the URL used to fetch an SRPM file
+
+        :param base_url: str, Koji root base URL with the given build artifacts
+        :param srpm_filename: str, name of the SRPM file
+        :param sign_key: str, key used to sign the SRPM, as listed in the signing intent
+        :return: list, strings with URLs pointing to SRPM files
+        """
+        url_components = [base_url, 'src', srpm_filename]
+        if sign_key:
+            url_components[1:1] = ['data', 'signed', sign_key]
+        return '/'.join(url_components)
+
+    def get_srpm_urls(self, sigkeys=None, insecure=False):
+        """Fetch SRPM download URLs for each image generated by a build
+
+        Build each possible SRPM URL and check if the URL is available,
+        respecting the signing intent preference order.
+
+        :param sigkeys: list, strings for keys which signed the srpms to be fetched
+        :return: list, strings with URLs pointing to SRPM files
+        """
+        if not sigkeys:
+            sigkeys = ['']
+
+        archives = self.session.listArchives(self.koji_build_id, type='image')
+        rpm_build_ids = {rpm['id']: rpm['build_id'] for archive in archives
+                         for rpm in self.session.listRPMs(imageID=archive['id'])}
+
+        srpm_build_paths = {}
+        path_info = get_koji_path_info(self.workflow, NO_FALLBACK)
+        for rpm_id, rpm_build_id in rpm_build_ids.items():
+            rpm_hdr = self.session.getRPMHeaders(rpm_id, headers=['SOURCERPM'])
+            srpm_filename = rpm_hdr['SOURCERPM']
+            if srpm_filename in srpm_build_paths:
+                continue
+            rpm_build = self.session.getBuild(rpm_build_id, strict=True)
+            base_url = path_info.build(rpm_build)
+            srpm_build_paths[srpm_filename] = base_url
+
+        srpm_urls = []
+        missing_srpms = []
+        req_session = get_retrying_requests_session()
+        for srpm_filename, base_url in srpm_build_paths.items():
+            for sigkey in sigkeys:
+                # koji uses lowercase for paths. We make sure the sigkey is in lower case
+                url_candidate = self.assemble_srpm_url(base_url, srpm_filename, sigkey.lower())
+                request = req_session.head(url_candidate, verify=not insecure)
+                if request.ok:
+                    srpm_urls.append(url_candidate)
+                    break
+                self.log.debug('%s not found for signing key "%s" at %s (returned %s)',
+                               srpm_filename, sigkey, url_candidate, request.status_code)
+
+            else:
+                missing_srpms.append(srpm_filename)
+
+        if missing_srpms:
+            raise RuntimeError('Could not find files signed by any of {} for these SRPMS: {}'
+                               .format(sigkeys, srpm_filename))
+
+        return srpm_urls
+
+    def get_signing_intent(self):
+        """Get the signing intent to be used to fetch files from Koji
+
+        :return: dict, signing intent object as per atomic_reactor/schemas/config.json
+        """
+        odcs_config = get_config(self.workflow).get_odcs_config()
+        if not self.signing_intent:
+            try:
+                self.signing_intent = self.koji_build['extra']['image']['odcs']['signing_intent']
+            except (KeyError, TypeError):
+                self.log.debug('Image koji build, %s(%s), does not define signing_intent.',
+                               self.koji_build_nvr, self.koji_build_id)
+                self.signing_intent = odcs_config.default_signing_intent
+
+        signing_intent = odcs_config.get_signing_intent_by_name(self.signing_intent)
+        return signing_intent

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -109,6 +109,11 @@
                 "description": "Reserve build id and NVR through Content Generator API. If set, requires koji > 1.17.0",
                 "type": "boolean",
                 "default": false
+            },
+            "insecure_download": {
+                "description": "Download data from koji insecurely",
+                "type": "boolean",
+                "default": false
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -1,0 +1,272 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import
+
+import io
+import os
+from textwrap import dedent
+
+import koji
+import pytest
+import requests
+from flexmock import flexmock
+
+from atomic_reactor import constants
+from atomic_reactor import util
+from atomic_reactor.inner import DockerBuildWorkflow
+from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
+from atomic_reactor.plugins.pre_fetch_sources import FetchSourcesPlugin
+from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
+                                                       WORKSPACE_CONF_KEY, ReactorConfig)
+from tests.constants import TEST_IMAGE
+from tests.stubs import StubInsideBuilder, StubSource
+
+
+KOJI_HUB = 'http://koji.com/hub'
+KOJI_ROOT = 'http://koji.localhost/kojiroot'
+KOJI_UPLOAD_TEST_WORKDIR = 'temp_workdir'
+KOJI_BUILD = {'build_id': 1, 'nvr': 'foobar-1-1', 'name': 'foobar', 'version': 1, 'release': 1}
+constants.HTTP_BACKOFF_FACTOR = 0
+
+DEFAULT_SIGNING_INTENT = 'empty'
+
+
+def mock_reactor_config(workflow, tmpdir, data=None, default_si=DEFAULT_SIGNING_INTENT):
+    if data is None:
+        data = dedent("""\
+            version: 1
+            koji:
+               hub_url: {}
+               root_url: {}
+               auth:
+                   ssl_certs_dir: not_needed_here
+            odcs:
+               signing_intents:
+               - name: invalid
+                 keys: ['notUsed']
+               - name: one
+                 keys: ['usedKey']
+               - name: multiple
+                 keys: ['notUsed', 'usedKey', 'notUsed2']
+               - name: unsigned
+                 keys: ['']
+               - name: empty
+                 keys: []
+               default_signing_intent: {}
+               api_url: invalid
+               auth:
+                   ssl_certs_dir: {}
+            """.format(KOJI_HUB, KOJI_ROOT, default_si, tmpdir))
+
+    workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
+
+    config = {}
+    if data:
+        tmpdir.join('cert').write('')
+        config = util.read_yaml(data, 'schemas/config.json')
+
+    workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] = ReactorConfig(config)
+
+
+class MockSource(StubSource):
+
+    def __init__(self, workdir):
+        super(MockSource, self).__init__()
+        self.workdir = workdir
+
+
+def mock_workflow(tmpdir, for_orchestrator=False, default_si=DEFAULT_SIGNING_INTENT):
+    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow.source = MockSource(str(tmpdir))
+    builder = StubInsideBuilder().for_workflow(workflow)
+    builder.set_df_path(str(tmpdir))
+    builder.tasker = flexmock()
+    workflow.builder = flexmock(builder)
+
+    if for_orchestrator:
+        workflow.buildstep_plugins_conf = [{'name': constants.PLUGIN_BUILD_ORCHESTRATE_KEY}]
+
+    mock_reactor_config(workflow, tmpdir, default_si=default_si)
+    return workflow
+
+
+def mock_env(tmpdir, docker_tasker, scratch=False, orchestrator=False, koji_build_id=None,
+             koji_build_nvr=None, default_si=DEFAULT_SIGNING_INTENT):
+    build_json = {'metadata': {'labels': {'scratch': scratch}}}
+    flexmock(util).should_receive('get_build_json').and_return(build_json)
+    workflow = mock_workflow(tmpdir, for_orchestrator=orchestrator, default_si=default_si)
+    plugin_conf = [{'name': FetchSourcesPlugin.key}]
+    plugin_conf[0]['args'] = {
+        'koji_build_id': koji_build_id,
+        'koji_build_nvr': koji_build_nvr
+        }
+
+    runner = PreBuildPluginsRunner(docker_tasker, workflow, plugin_conf)
+    return runner
+
+
+@pytest.fixture()
+def koji_session():
+    session = flexmock()
+    flexmock(session).should_receive('ssl_login').and_return(True)
+    flexmock(session).should_receive('listArchives').and_return([{'id': 1}, {'id': 2}])
+    flexmock(session).should_receive('listRPMs').with_args(imageID=1).and_return(
+        [{'id': 1, 'build_id': 1, 'nvr': 'foobar-1-1', 'arch': 'x86_64'}])
+    flexmock(session).should_receive('listRPMs').with_args(imageID=2).and_return(
+        [{'id': 2, 'build_id': 1, 'nvr': 'foobar-1-1', 'arch': 'aarch64'}])
+    (flexmock(session)
+     .should_receive('getRPMHeaders')
+     .and_return({'SOURCERPM': 'foobar-1-1.src.rpm'}))
+    flexmock(session).should_receive('getBuild').and_return(KOJI_BUILD)
+    flexmock(session).should_receive('krb_login').and_return(True)
+    flexmock(koji).should_receive('ClientSession').and_return(session)
+    return session
+
+
+def get_srpm_url(sign_key=None):
+    base = '{}/packages/{}/{}/{}'.format(KOJI_ROOT, KOJI_BUILD['name'], KOJI_BUILD['version'],
+                                         KOJI_BUILD['release'])
+    filename = '{}.src.rpm'.format(KOJI_BUILD['nvr'])
+    if not sign_key:
+        return '{}/src/{}'.format(base, filename)
+    else:
+        return '{}/data/signed/{}/src/{}'.format(base, sign_key, filename)
+
+
+def mock_koji_manifest_download(requests_mock, retries=0):
+    class MockBytesIO(io.BytesIO):
+        reads = 0
+
+        def read(self, *args, **kwargs):
+            if MockBytesIO.reads < retries:
+                MockBytesIO.reads += 1
+                raise requests.exceptions.ConnectionError
+
+            return super(MockBytesIO, self).read(*args, **kwargs)
+
+    sign_keys = ['', 'usedKey', 'notUsed']
+    bad_keys = ['notUsed']
+    urls = [get_srpm_url(k) for k in sign_keys]
+
+    for url in urls:
+        if any(k in url for k in bad_keys):
+            requests_mock.register_uri('HEAD', url, text='Not Found', status_code=404)
+        else:
+            requests_mock.register_uri('HEAD', url, content=b'')
+
+            def body_callback(request, context):
+                f = MockBytesIO(b"Source RPM")
+                return f
+            requests_mock.register_uri('GET', url, body=body_callback)
+
+
+class TestFetchSources(object):
+    @pytest.mark.parametrize('retries', (0, 1, constants.HTTP_MAX_RETRIES + 1))
+    @pytest.mark.parametrize('signing_intent', ('unsigned', 'empty', 'one', 'multiple', 'invalid'))
+    def test_fetch_soures(self, requests_mock, docker_tasker, koji_session, tmpdir, signing_intent,
+                          caplog, retries):
+        mock_koji_manifest_download(requests_mock, retries)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_id=1, default_si=signing_intent)
+        if signing_intent == 'invalid':
+            with pytest.raises(PluginFailedException) as exc:
+                runner.run()
+            msg = 'Could not find files signed by'
+            assert msg in str(exc.value)
+        elif retries > constants.HTTP_MAX_RETRIES:
+            with pytest.raises(PluginFailedException) as exc:
+                runner.run()
+            msg = "plugin 'fetch_sources' raised an exception:"
+            assert msg in str(exc.value)
+        else:
+            result = runner.run()
+            results = result[constants.PLUGIN_FETCH_SOURCES_KEY]
+            sources_dir = results['image_sources_dir']
+            orig_build_id = results['sources_for_koji_build_id']
+            orig_build_nvr = results['sources_for_nvr']
+            sources_list = os.listdir(sources_dir)
+            assert orig_build_id == 1
+            assert orig_build_nvr == 'foobar-1-1'
+            assert len(sources_list) == 1
+            assert sources_list[0] == '.'.join([KOJI_BUILD['nvr'], 'src', 'rpm'])
+            with open(os.path.join(sources_dir, sources_list[0]), 'rb') as f:
+                assert f.read() == b'Source RPM'
+            if signing_intent in ['unsigned, empty']:
+                assert get_srpm_url() in caplog.text
+            if signing_intent in ['one, multiple']:
+                assert get_srpm_url('usedKey') in caplog.text
+
+    @pytest.mark.parametrize('signing_intent', ('unsigned', 'empty', 'one', 'multiple', 'invalid'))
+    def test_koji_signing_intent(self, requests_mock, docker_tasker, koji_session, tmpdir,
+                                 signing_intent, caplog):
+        """Make sure fetch_sources plugin prefers the koji image build signing intent"""
+        extra = {'image': {'odcs': {'signing_intent': 'unsigned'}}}
+        KOJI_BUILD.update({'extra': extra})
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_id=1, default_si=signing_intent)
+        result = runner.run()
+        sources_dir = result[constants.PLUGIN_FETCH_SOURCES_KEY]['image_sources_dir']
+        sources_list = os.listdir(sources_dir)
+        assert len(sources_list) == 1
+        assert sources_list[0] == '.'.join([KOJI_BUILD['nvr'], 'src', 'rpm'])
+        with open(os.path.join(sources_dir, sources_list[0]), 'rb') as f:
+            assert f.read() == b'Source RPM'
+        assert get_srpm_url() in caplog.text
+        if signing_intent == 'invalid':
+            msg = 'Could not find files signed by'
+            assert msg not in caplog.text
+        if signing_intent in ['one, multiple']:
+            assert get_srpm_url('usedKey') not in caplog.text
+
+    def test_no_build_info(self, requests_mock, docker_tasker, koji_session, tmpdir):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker)
+        with pytest.raises(PluginFailedException) as exc:
+            runner.run()
+        msg = 'FetchSourcesPlugin expects either koji_build_id or koji_build_nvr to be defined'
+        assert msg in str(exc.value)
+
+    @pytest.mark.parametrize('build_id, build_nvr', (('1', None), (None, 1), ('1', 1)))
+    def test_build_info_with_wrong_type(self, requests_mock, docker_tasker, koji_session, tmpdir,
+                                        build_id, build_nvr):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_id=build_id, koji_build_nvr=build_nvr)
+        with pytest.raises(PluginFailedException) as exc:
+            runner.run()
+        id_msg = 'koji_build_id must be an int'
+        nvr_msg = 'koji_build_nvr must be a str'
+        if build_id:
+            assert id_msg in str(exc.value)
+        if build_nvr:
+            assert nvr_msg in str(exc.value)
+
+    def test_build_with_nvr(self, requests_mock, docker_tasker, koji_session, tmpdir):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_nvr='foobar-1-1')
+        result = runner.run()
+        sources_dir = result[constants.PLUGIN_FETCH_SOURCES_KEY]['image_sources_dir']
+        sources_list = os.listdir(sources_dir)
+        assert len(sources_list) == 1
+        assert os.path.basename(sources_list[0]) == '.'.join([KOJI_BUILD['nvr'], 'src', 'rpm'])
+
+    def test_id_and_nvr(self, requests_mock, docker_tasker, koji_session, tmpdir):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_nvr='foobar-1-1', koji_build_id=1)
+        result = runner.run()
+        sources_dir = result[constants.PLUGIN_FETCH_SOURCES_KEY]['image_sources_dir']
+        sources_list = os.listdir(sources_dir)
+        assert len(sources_list) == 1
+        assert os.path.basename(sources_list[0]) == '.'.join([KOJI_BUILD['nvr'], 'src', 'rpm'])
+
+    def test_id_and_nvr_mismatch(self, requests_mock, docker_tasker, koji_session, tmpdir):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_nvr='foobar-1-1', koji_build_id=2)
+        with pytest.raises(PluginFailedException) as exc:
+            runner.run()
+        msg = 'When specifying both an id and an nvr, they should point to the same image build'
+        assert msg in str(exc.value)


### PR DESCRIPTION

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
