### PR TITLE
pulp: remove pulp support from resolve_composes

### DIFF
--- a/atomic_reactor/odcs_util.py
+++ b/atomic_reactor/odcs_util.py
@@ -51,13 +51,11 @@ class ODCSClient(object):
                       modular_koji_tags=None):
         """Start a new ODCS compose
 
-        :param source_type: str, the type of compose to request (tag, module, pulp)
+        :param source_type: str, the type of compose to request (tag, module)
         :param source: str, if source_type "tag" is used, the name of the Koji tag
                        to use when retrieving packages to include in compose;
                        if source_type "module", white-space separated NAME-STREAM or
                        NAME-STREAM-VERSION list of modules to include in compose;
-                       if source_type "pulp", white-space separated list of context-sets
-                       to include in compose
         :param packages: list<str>, packages which should be included in a compose. Only
                          relevant when source_type "tag" is used.
         :param sigkeys: list<str>, IDs of signature keys. Only packages signed by one of

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -82,7 +82,7 @@
           }
         },
         "pulp_repos": {
-          "description": "whether to build pulp composes",
+          "description": "whether to build pulp composes (deprecated)",
           "type": "boolean"
         },
         "modules": {
@@ -109,7 +109,7 @@
           "type": "boolean"
         },
         "include_unpublished_pulp_repos": {
-          "description": "include unpublished repos in pulp input content-sets",
+          "description": "include unpublished repos in pulp input content-sets (deprecated)",
           "type": "boolean"
         },
         "multilib_method": {


### PR DESCRIPTION
part of osbs-5098

Remove support for pulp from resolve_composes.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

part of #1270 

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
