### PR TITLE
Refactor staticmethod to classmethod

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -88,11 +88,12 @@ class BuildResult(object):
         self._labels = labels
         self._skip_layer_squash = skip_layer_squash
 
-    @staticmethod
-    def make_remote_image_result(annotations=None, labels=None):
+    @classmethod
+    def make_remote_image_result(cls, annotations=None, labels=None):
         """Instantiate BuildResult for image not built locally."""
-        return BuildResult(image_id=BuildResult.REMOTE_IMAGE,
-                           annotations=annotations, labels=labels)
+        return cls(
+            image_id=cls.REMOTE_IMAGE, annotations=annotations, labels=labels
+        )
 
     @property
     def logs(self):


### PR DESCRIPTION
Static methods should be avoided and this is nice example of how classmethod should look like

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
