### PR TITLE
Flatpak label enhancements

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -356,6 +356,16 @@ def get_flatpak_base_image(workflow, fallback=NO_FALLBACK):
         raise
 
 
+def get_flatpak_metadata(workflow, fallback=NO_FALLBACK):
+    flatpak = get_value(workflow, 'flatpak', {})
+    try:
+        return flatpak['metadata']
+    except KeyError:
+        if fallback != NO_FALLBACK:
+            return fallback
+        raise
+
+
 def get_package_comparison_exceptions(workflow):
     return set(get_config(workflow).conf.get('package_comparison_exceptions', []))
 

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -12,11 +12,12 @@ and turns it into a Flatpak application or runtime.
 
 from __future__ import absolute_import
 
-from flatpak_module_tools.flatpak_builder import FlatpakBuilder
+from flatpak_module_tools.flatpak_builder import FlatpakBuilder, FLATPAK_METADATA_ANNOTATIONS
 
 from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
 from atomic_reactor.plugin import PrePublishPlugin
 from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
+from atomic_reactor.plugins.pre_reactor_config import get_flatpak_metadata
 from atomic_reactor.rpm_util import parse_rpm_output
 from atomic_reactor.util import df_parser, get_exported_image_metadata
 
@@ -67,6 +68,7 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         """
         super(FlatpakCreateOciPlugin, self).__init__(tasker, workflow)
         self.builder = None
+        self.flatpak_metadata = get_flatpak_metadata(workflow, FLATPAK_METADATA_ANNOTATIONS)
 
     def _export_container(self, container_id):
         export_generator = self.tasker.export_container(container_id)
@@ -98,7 +100,8 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
 
         self.builder = FlatpakBuilder(source, self.workflow.source.workdir,
                                       'var/tmp/flatpak-build',
-                                      parse_manifest=parse_rpm_output)
+                                      parse_manifest=parse_rpm_output,
+                                      flatpak_metadata=self.flatpak_metadata)
 
         df_labels = df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels
         self.builder.add_labels(df_labels)

--- a/atomic_reactor/plugins/prepub_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/prepub_flatpak_create_oci.py
@@ -18,7 +18,7 @@ from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
 from atomic_reactor.plugin import PrePublishPlugin
 from atomic_reactor.plugins.pre_flatpak_create_dockerfile import get_flatpak_source_info
 from atomic_reactor.rpm_util import parse_rpm_output
-from atomic_reactor.util import get_exported_image_metadata
+from atomic_reactor.util import df_parser, get_exported_image_metadata
 
 
 # This converts the generator provided by the export() operation to a file-like
@@ -99,6 +99,9 @@ class FlatpakCreateOciPlugin(PrePublishPlugin):
         self.builder = FlatpakBuilder(source, self.workflow.source.workdir,
                                       'var/tmp/flatpak-build',
                                       parse_manifest=parse_rpm_output)
+
+        df_labels = df_parser(self.workflow.builder.df_path, workflow=self.workflow).labels
+        self.builder.add_labels(df_labels)
 
         tarred_filesystem, manifest = self._export_filesystem()
         self.log.info('filesystem tarfile written to %s', tarred_filesystem)

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -597,6 +597,11 @@
             "base_image": {
                 "description": "host image used to install packages when creating a Flatpak",
                 "type": "string"
+            },
+            "metadata": {
+                "description": "how to store Flatpak metadata in the image",
+                "type": "string",
+                "enum": ["annotations", "labels", "both"]
             }
         },
         "additionalProperties": false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docker-py
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
-flatpak-module-tools>=0.10.4
+flatpak-module-tools >= 0.11
 jsonschema==2.3.0  # to match available in RHEL/CentOS 7
 PyYAML
 six

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -273,7 +273,7 @@ RUNTIME_CONFIG = {
     'modules': {
         'flatpak-runtime': {
             'stream': 'f28',
-            'version': '20170629185228',
+            'version': '20170701152209',
             'metadata': FLATPAK_RUNTIME_MODULEMD,
             'rpms': [],  # We don't use this currently
         },
@@ -295,7 +295,7 @@ SDK_CONFIG = {
     'modules': {
         'flatpak-runtime': {
             'stream': 'f28',
-            'version': '20170629185228',
+            'version': '20170701152209',
             'metadata': FLATPAK_RUNTIME_MODULEMD,
             'rpms': [],  # We don't use this currently
         },


### PR DESCRIPTION
This PR implements two enhancements to label handing for Flatpaks:
 * Standard labels are propagated from the Dockerfile to the OCI image created by Flatpak (the Dockerfile is just used to create the filesystem tree for the OCI image)
 * A reactor config option is added so that Flatpak metadata (description, icons, install size, etc) can be stored as annotations, docker compatible labels, or both. Flatpak 1.6 will add the ability to download and install images with metadata in the labels, allowing storing in a registry without OCI compatibility.

Both capabilities require a new version of flatpak-module-tools, now on PyPI, and built for Fedora and EPEL.

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
