### PR TITLE
Update documentation about buildstep plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -150,8 +150,16 @@ These are run after we have everything ready for build
    * Status: enabled
    * Builds image inside current environment, using docker api
 
- * **orchestrate_build**
+ * **imagebuilder**
+   * Status: enabled
+   * Builds image inside current environment, using [imagebuilder](https://github.com/openshift/imagebuilder)
+
+ * **buildah_bud**
    * Status: not yet enabled
+   * Builds image inside current environment, using [buildah bud](https://github.com/containers/buildah/blob/master/docs/buildah-bud.md)
+
+ * **orchestrate_build**
+   * Status: enabled
    * Builds image in remote environment
 
 ### Pre-publish and post-build plugins


### PR DESCRIPTION
Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
