### PR TITLE
new koji_delegate plugin

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -105,7 +105,7 @@ PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY = 'export_operator_manifests'
 PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY = 'push_operator_manifests'
 PLUGIN_SOURCE_CONTAINER_KEY = 'source_container'
 PLUGIN_FETCH_SOURCES_KEY = 'fetch_sources'
-
+PLUGIN_KOJI_DELEGATE_KEY = 'koji_delegate'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -404,6 +404,7 @@ class DockerBuildWorkflow(object):
         # info about pre-declared build, build-id and token
         self.reserved_build_id = None
         self.reserved_token = None
+        self.triggered_after_koji_task = None
 
         if client_version:
             logger.debug("build json was built by osbs-client %s", client_version)
@@ -471,10 +472,6 @@ class DockerBuildWorkflow(object):
             postbuild_runner = PostBuildPluginsRunner(self.builder.tasker, self,
                                                       self.postbuild_plugins_conf,
                                                       plugin_files=self.plugin_files)
-            exit_runner = ExitPluginsRunner(self.builder.tasker, self,
-                                            self.exit_plugins_conf,
-                                            keep_going=True,
-                                            plugin_files=self.plugin_files)
             # time to run pre-build plugins, so they can access cloned repo
             logger.info("running pre-build plugins")
             try:
@@ -540,11 +537,11 @@ class DockerBuildWorkflow(object):
         finally:
             # We need to make sure all exit plugins are executed
             signal.signal(signal.SIGTERM, lambda *args: None)
-            if exit_runner is None:
-                exit_runner = ExitPluginsRunner(self.builder.tasker, self,
-                                                self.exit_plugins_conf,
-                                                keep_going=True,
-                                                plugin_files=self.plugin_files)
+
+            exit_runner = ExitPluginsRunner(self.builder.tasker, self,
+                                            self.exit_plugins_conf,
+                                            keep_going=True,
+                                            plugin_files=self.plugin_files)
             try:
                 exit_runner.run(keep_going=True)
             except PluginFailedException as ex:

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -303,6 +303,9 @@ class KojiImportPlugin(ExitPlugin):
             raise RuntimeError('git source required')
 
         extra = {'image': {'autorebuild': is_rebuild(self.workflow)}}
+        if self.workflow.triggered_after_koji_task:
+            extra['image']['triggered_after_koji_task'] = self.workflow.triggered_after_koji_task
+
         koji_task_id = metadata.get('labels', {}).get('koji-task-id')
         if koji_task_id is not None:
             self.log.info("build configuration created by Koji Task ID %s",

--- a/atomic_reactor/plugins/input_osv3.py
+++ b/atomic_reactor/plugins/input_osv3.py
@@ -26,7 +26,8 @@ from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY,
                                       PLUGIN_KOJI_TAG_BUILD_KEY,
                                       PLUGIN_KOJI_UPLOAD_PLUGIN_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY,
-                                      PLUGIN_SENDMAIL_KEY)
+                                      PLUGIN_SENDMAIL_KEY,
+                                      PLUGIN_KOJI_DELEGATE_KEY)
 
 
 class OSv3InputPlugin(InputPlugin):
@@ -80,6 +81,8 @@ class OSv3InputPlugin(InputPlugin):
     def remove_koji_plugins(self):
         koji_map = self.get_value('koji', {})
         if not koji_map.get('hub_url'):
+            self.remove_plugin('prebuild_plugins', PLUGIN_KOJI_DELEGATE_KEY,
+                               'no koji hub available')
             # bump_release is removed in PluginsConfiguration if no release value
             self.remove_plugin('prebuild_plugins', PLUGIN_BUMP_RELEASE_KEY,
                                'no koji hub available')

--- a/atomic_reactor/plugins/pre_koji_delegate.py
+++ b/atomic_reactor/plugins/pre_koji_delegate.py
@@ -1,0 +1,132 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals, absolute_import
+
+import os
+import json
+import koji
+
+from atomic_reactor.plugin import PreBuildPlugin, BuildCanceledException
+from atomic_reactor.plugins.pre_reactor_config import (get_koji_session, get_koji, NO_FALLBACK,
+                                                       get_openshift_session)
+from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
+from atomic_reactor.constants import PLUGIN_KOJI_DELEGATE_KEY
+from atomic_reactor.util import get_build_json
+
+
+class KojiDelegatePlugin(PreBuildPlugin):
+    """
+    When autorebuild is enabled, delegate feature is enabled and
+    triggered_after_koji_task is not provided,
+    will submit new koji task for autorebuild, and cancel current build.
+    In all other cases plugin won't do anything
+    """
+
+    key = PLUGIN_KOJI_DELEGATE_KEY
+    is_allowed_to_fail = False  # We really want to stop the process
+
+    def __init__(self, tasker, workflow, triggered_after_koji_task=None):
+        """
+        constructor
+
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param triggered_after_koji_task: int, original koji task for autorebuild,
+            provided only when this plugin creates new koji task for autorebuild
+        """
+        # call parent constructor
+        super(KojiDelegatePlugin, self).__init__(tasker, workflow)
+
+        koji_setting = get_koji(self.workflow, NO_FALLBACK)
+        self.delegate_enabled = koji_setting.get('delegate_task', True)
+        self.task_priority = koji_setting.get('delegated_task_priority', None)
+        self.triggered_after_koji_task = triggered_after_koji_task
+        self.metadata = get_build_json().get("metadata", {})
+        self.kojisession = get_koji_session(self.workflow, NO_FALLBACK)
+        self.osbs = None
+
+    def cancel_build(self):
+        """
+        cancel current build
+        """
+        build_name = self.metadata.get("name")
+        if build_name:
+            self.osbs.cancel_build(build_name)
+
+    def delegate_task(self):
+        """
+        create new koji task for autorebuild
+        """
+        user_params = os.environ['USER_PARAMS']
+        user_data = json.loads(user_params)
+
+        git_uri = user_data.get('git_uri')
+        git_ref = user_data.get('git_ref')
+        source = "%s#%s" % (git_uri, git_ref)
+        container_target = user_data.get('koji_target')
+
+        koji_task_id = self.metadata.get('labels', {}).get('original-koji-task-id')
+        if not koji_task_id:
+            koji_task_id = self.metadata.get('labels', {}).get('koji-task-id')
+
+        task_opts = {}
+        for key in ('yum_repourls', 'git_branch', 'signing_intent', 'compose_ids'):
+            if key in user_data:
+                if user_data[key]:
+                    task_opts[key] = user_data[key]
+        task_opts['triggered_after_koji_task'] = int(koji_task_id)
+
+        task_id = self.kojisession.buildContainer(source, container_target, task_opts,
+                                                  priority=self.task_priority)
+
+        self.log.info('Created intermediate task: %s', task_id)
+
+    def run(self):
+        """
+        run the plugin
+        """
+        if self.delegate_enabled:
+            # will be used in koji_import
+            self.workflow.triggered_after_koji_task = self.triggered_after_koji_task
+
+        koji_task_id = self.metadata.get('labels', {}).get('koji-task-id')
+        task_info = self.kojisession.getTaskInfo(koji_task_id, request=True)
+        task_running = koji.TASK_STATES[task_info['state']] == 'OPEN'
+
+        # we don't want to plugin continue when:
+        # delegate_task isn't enabled
+        # build isn't autorebuild
+        # triggered_after_koji_task was provided, but task is running,
+        # reason for this is, when we once enable delegating, after first autorebuild
+        # buildConfig will already have triggered_after_koji_task in user_params
+        # so when koji-task-id for build is running task, that means it is that new
+        # already delegated task
+        if not self.delegate_enabled:
+            self.log.info("delegate_task not enabled, skipping plugin")
+            return
+        elif not is_rebuild(self.workflow):
+            self.log.info("not autorebuild, skipping plugin")
+            return
+        elif (self.triggered_after_koji_task and task_running):
+            self.log.info("koji task already delegated, skipping plugin")
+            return
+
+        self.osbs = get_openshift_session(self.workflow, NO_FALLBACK)
+
+        self.delegate_task()
+
+        # we will remove all exit plugins, as we don't want any of them running,
+        # mainly sendmail
+        self.workflow.exit_plugins_conf = []
+        # we will cancel build and raise exception,
+        # without canceling build build would end up as failed build, and we don't want
+        # to have this build as failed but cancelled so it doesn't inerfere with real failed builds
+        self.cancel_build()
+        self.log.info('Build was delegated, will cancel itself')
+        raise BuildCanceledException("Build was canceled")

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -114,6 +114,15 @@
                 "description": "Download data from koji insecurely",
                 "type": "boolean",
                 "default": false
+            },
+            "delegate_task": {
+                "description": "Autorebuild will create new intermediate task, instead of using original task",
+                "type": "boolean",
+                "default": true
+            },
+            "delegated_task_priority": {
+                "description": "When delegate_build is enabled, delegated task will use this koji task priority, if not set it will use default koji priority",
+                "type": "integer"
             }
         },
         "additionalProperties": false,

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -42,6 +42,7 @@ and fall back to `build.extra.image` when the former is not available.
 Data which is placed here includes:
 
 - `build.extra.image.autorebuild` (boolean): true if this build was triggered automatically; false otherwise
+- `build.extra.image.triggered_after_koji_task` (int): only defined for autorebuilds, specifies original Koji task ID for autorebuild
 - `build.extra.image.isolated` (boolean): true if this build was an isolated build; false otherwise
 - `build.extra.image.help` (string or null): filename of the markdown help file in the repository if this build has a markdown help converted to man page; null otherwise
 - `build.extra.container_koji_task_id` (int): Koji task ID which created the BuildConfig for this OpenShift Build -- note that this location is technically incorrect but remains as-is for compatibility with existing software

--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -25,6 +25,7 @@ from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY,
                                       PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
                                       PLUGIN_KOJI_TAG_BUILD_KEY,
                                       PLUGIN_KOJI_UPLOAD_PLUGIN_KEY,
+                                      PLUGIN_KOJI_DELEGATE_KEY,
                                       PLUGIN_RESOLVE_COMPOSES_KEY,
                                       PLUGIN_SENDMAIL_KEY)
 import pytest
@@ -167,6 +168,7 @@ def test_remove_everything():
         'prebuild_plugins': [
             {'name': 'before', },
             {'name': PLUGIN_BUMP_RELEASE_KEY, },
+            {'name': PLUGIN_KOJI_DELEGATE_KEY, },
             {'name': PLUGIN_FETCH_MAVEN_KEY, },
             {'name': PLUGIN_DISTGIT_FETCH_KEY, },
             {'name': PLUGIN_DOCKERFILE_CONTENT_KEY, },

--- a/tests/plugins/test_koji_delegate.py
+++ b/tests/plugins/test_koji_delegate.py
@@ -1,0 +1,240 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals, absolute_import
+
+import os
+from copy import deepcopy
+from textwrap import dedent
+from flexmock import flexmock
+import pytest
+import json
+import koji as koji
+
+from atomic_reactor.plugin import BuildCanceledException
+from atomic_reactor.plugins.pre_koji_delegate import KojiDelegatePlugin
+from atomic_reactor.plugins.pre_check_and_set_rebuild import CheckAndSetRebuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
+                                                       WORKSPACE_CONF_KEY,
+                                                       ReactorConfig)
+from osbs.api import OSBS
+
+
+class MockSource(object):
+    def __init__(self, tmpdir):
+        self.dockerfile_path = str(tmpdir.join('Dockerfile'))
+        self.path = str(tmpdir)
+        self.commit_id = None
+        self.config = flexmock(autorebuild=dict())
+
+
+class TestKojiDelegate(object):
+    def prepare(self,
+                tmpdir,
+                is_auto=False,
+                triggered_after_koji_task=None,
+                delegate_task=False,
+                delegated_priority=None):
+
+        workflow = flexmock()
+        setattr(workflow, 'builder', flexmock())
+        setattr(workflow, 'plugin_workspace', {})
+        setattr(workflow, 'reserved_build_id', None)
+        setattr(workflow, 'reserved_token ', None)
+        setattr(workflow, 'triggered_after_koji_task', None)
+        setattr(workflow, 'source', MockSource(tmpdir))
+        setattr(workflow, 'prebuild_results', {CheckAndSetRebuildPlugin.key: is_auto})
+
+        df = tmpdir.join('Dockerfile')
+        df.write('FROM base\n')
+        setattr(workflow.builder, 'df_path', str(df))
+
+        kwargs = {
+            'tasker': None,
+            'workflow': workflow,
+        }
+        if triggered_after_koji_task:
+            kwargs['triggered_after_koji_task'] = triggered_after_koji_task
+        koji_map = {
+            'hub_url': '',
+            'root_url': '',
+            'auth': {},
+            'reserve_build': False,
+            'delegate_task': delegate_task,
+        }
+        openshift_map = {
+            'url': '',
+            'insecure': False,
+            'auth': {'enable': True}
+        }
+        if delegated_priority:
+            koji_map['delegated_task_priority'] = delegated_priority
+
+        workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
+        workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] =\
+            ReactorConfig({'version': 1, 'koji': koji_map, 'openshift': openshift_map})
+
+        plugin = KojiDelegatePlugin(**kwargs)
+        return plugin
+
+    @pytest.mark.parametrize(('delegate_task', 'is_auto', 'triggered_task', 'task_open'), [
+        (False, False, None, False),
+        (False, True, None, False),
+        (False, False, None, True),
+        (False, True, None, True),
+        (False, False, 12345, False),
+        (False, True, 12345, False),
+        (False, False, 12345, True),
+        (False, True, 12345, True),
+
+        (True, False, None, False),
+        (True, False, None, True),
+        (True, False, 12345, False),
+        (True, False, 12345, True),
+
+        (True, True, 12345, True),
+    ])
+    def test_skip_delegate_build(self, tmpdir, caplog, delegate_task, is_auto, triggered_task,
+                                 task_open):
+        class MockedClientSession(object):
+            def __init__(self, hub, opts=None):
+                pass
+
+            def getBuild(self, build_info):
+                return None
+
+            def krb_login(self, *args, **kwargs):
+                return True
+
+            def getTaskInfo(self, task_id, request=False):
+                if task_open:
+                    return {'state': koji.TASK_STATES['OPEN']}
+                else:
+                    return {'state': koji.TASK_STATES['CLOSED']}
+
+        session = MockedClientSession('')
+        flexmock(koji, ClientSession=session)
+
+        new_environ = deepcopy(os.environ)
+        new_environ["BUILD"] = dedent('''\
+            {
+              "metadata": {
+                "name": "auto-123456",
+                "labels": {"koji-task-id": 12345}
+              }
+            }
+            ''')
+        flexmock(os)
+        os.should_receive("environ").and_return(new_environ)  # pylint: disable=no-member
+
+        plugin = self.prepare(tmpdir, is_auto=is_auto, delegate_task=delegate_task,
+                              triggered_after_koji_task=triggered_task)
+        plugin.run()
+        if delegate_task:
+            assert plugin.workflow.triggered_after_koji_task == triggered_task
+        else:
+            assert plugin.workflow.triggered_after_koji_task is None
+
+        if not delegate_task:
+            assert "delegate_task not enabled, skipping plugin" in caplog.text
+        elif not is_auto:
+            assert "not autorebuild, skipping plugin" in caplog.text
+        elif triggered_task and task_open:
+            assert "koji task already delegated, skipping plugin" in caplog.text
+
+    @pytest.mark.parametrize('user_params', [
+        {'git_ref': 'test_ref',
+         'git_uri': 'test_uri',
+         'git_branch': 'test_branch'},
+
+        {'git_ref': 'test_ref',
+         'git_uri': 'test_uri',
+         'git_branch': 'test_branch',
+         'yum_repourls': ['yum_url1', 'yum_url2'],
+         'signing_intent': 'test_intent',
+         'compose_ids': [1, 2, 3]},
+    ])
+    @pytest.mark.parametrize(('koji_task_id', 'original_koji_task_id'), [
+        (12345, None),
+        (12345, 67890),
+        (None, 67890),
+    ])
+    @pytest.mark.parametrize(('triggered_task', 'task_open', 'task_priority'), [
+        (12345, False, None),
+        (None, True, 30),
+        (None, False, 60),
+    ])
+    def test_delegate_build(self, tmpdir, caplog, user_params, koji_task_id, original_koji_task_id,
+                            triggered_task, task_open, task_priority):
+        class MockedClientSession(object):
+            def __init__(self, hub, opts=None):
+                pass
+
+            def getBuild(self, build_info):
+                return None
+
+            def krb_login(self, *args, **kwargs):
+                return True
+
+            def getTaskInfo(self, task_id, request=False):
+                if task_open:
+                    return {'state': koji.TASK_STATES['OPEN']}
+                else:
+                    return {'state': koji.TASK_STATES['CLOSED']}
+
+            def buildContainer(self, source, container_target,  task_opts, priority=None):
+                expect_source = "%s#%s" % (user_params.get('git_uri'), user_params.get('git_ref'))
+                assert source == expect_source
+                assert container_target == user_params.get('koji_target')
+                assert priority == task_priority
+
+                expect_opts = {
+                    'git_branch': user_params.get('git_branch'),
+                    'triggered_after_koji_task': original_koji_task_id,
+                }
+                if user_params.get('yum_repourls'):
+                    expect_opts['yum_repourls'] = user_params.get('yum_repourls')
+                if user_params.get('signing_intent'):
+                    expect_opts['signing_intent'] = user_params.get('signing_intent')
+                if user_params.get('compose_ids'):
+                    expect_opts['compose_ids'] = user_params.get('compose_ids')
+                if not expect_opts['triggered_after_koji_task']:
+                    expect_opts['triggered_after_koji_task'] = koji_task_id
+
+                assert expect_opts == task_opts
+                return 987654321
+
+        session = MockedClientSession('')
+        flexmock(koji, ClientSession=session)
+
+        build_name = "auto-123456"
+        new_environ = deepcopy(os.environ)
+        build_json = {
+            "metadata": {
+                "name": build_name,
+                "labels": {"koji-task-id": koji_task_id}
+            }
+        }
+        if original_koji_task_id:
+            build_json['metadata']['labels']['original-koji-task-id'] = original_koji_task_id
+        new_environ["BUILD"] = json.dumps(build_json)
+        new_environ["USER_PARAMS"] = json.dumps(user_params)
+
+        flexmock(os)
+        os.should_receive("environ").and_return(new_environ)  # pylint: disable=no-member
+        flexmock(OSBS).should_receive('cancel_build').with_args(build_name).once()
+
+        plugin = self.prepare(tmpdir, is_auto=True, delegate_task=True,
+                              delegated_priority=task_priority,
+                              triggered_after_koji_task=triggered_task)
+
+        with pytest.raises(BuildCanceledException):
+            plugin.run()
+
+        assert 'Created intermediate task: 987654321' in caplog.text
+        assert 'Build was delegated, will cancel itself' in caplog.text


### PR DESCRIPTION
*OSBS-8150

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
