### PR TITLE
pulp: remove PulpRegistries from innner.py and pulp_registries from TagConf

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -71,7 +71,6 @@ TOOLS_USED = (
     {"pkg_name": "docker_squash"},
     {"pkg_name": "atomic_reactor"},
     {"pkg_name": "osbs", "display_name": "osbs-client"},
-    {"pkg_name": "dockpulp"},
 )
 
 DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024  # 10Mb

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -211,23 +211,6 @@ class Registry(object):
         self.insecure = insecure
 
 
-class PulpRegistry(Registry):
-    """ pulp & crane """
-    def __init__(self, name, crane_uri, insecure=False):
-        """
-        :param name: str, pulp's rest api is specified in dockpulp's config, we refer only by name
-        :param crane_uri: str, read-only docker registry api access point
-        :param insecure: bool
-        """
-        super(PulpRegistry, self).__init__(crane_uri, insecure=insecure)
-        self.name = name
-
-        # True if we've synced an image to the pulp repository using the
-        # docker protocol - and thus can support retrieving manifests
-        # via the v2 api.
-        self.server_side_sync = False
-
-
 class DockerRegistry(Registry):
     """ v2 docker registry """
     def __init__(self, uri, insecure=False):
@@ -243,13 +226,12 @@ class DockerRegistry(Registry):
 
 class PushConf(object):
     """
-    configuration of remote registries: docker-registry or pulp
+    configuration of remote registries: docker-registry
     """
 
     def __init__(self):
         self._registries = {
             "docker": [],
-            "pulp": {},  # name -> PulpRegistry
         }
 
     def add_docker_registry(self, registry_uri, insecure=False):
@@ -262,24 +244,6 @@ class PushConf(object):
     def remove_docker_registry(self, docker_registry):
         self._registries["docker"].remove(docker_registry)
 
-    def add_pulp_registry(self, name, crane_uri, server_side_sync=True):
-        if crane_uri is None:
-            raise RuntimeError("registry URI cannot be None")
-
-        old_registry = self._registries["pulp"].get(name)
-        if old_registry is not None:
-            if crane_uri != old_registry.uri:
-                raise RuntimeError("Conflicting Pulp registries with name: %s" % name)
-            # Merge
-            if server_side_sync:
-                old_registry.server_side_sync = True
-            return old_registry
-
-        r = PulpRegistry(name, crane_uri)
-        r.server_side_sync = server_side_sync
-        self._registries["pulp"][name] = r
-        return r
-
     @property
     def has_some_docker_registry(self):
         return len(self.docker_registries) > 0
@@ -289,12 +253,8 @@ class PushConf(object):
         return self._registries["docker"]
 
     @property
-    def pulp_registries(self):
-        return [registry for registry in self._registries["pulp"].values()]
-
-    @property
     def all_registries(self):
-        return self.docker_registries + self.pulp_registries
+        return self.docker_registries
 
 
 class FSWatcher(threading.Thread):

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -27,7 +27,7 @@ from atomic_reactor.build import BuildResult
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_arrangement_version, get_koji,
-                                                       get_odcs, get_pulp,
+                                                       get_odcs,
                                                        get_prefer_schema1_digest, get_smtp,
                                                        get_source_registry, get_sources_command,
                                                        get_artifacts_allowed_domains,
@@ -338,10 +338,6 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         odcs_map = get_odcs(self.workflow, odcs_fallback)
         self.config_kwargs['odcs_url'] = odcs_map['api_url']
         self.config_kwargs['odcs_insecure'] = odcs_map.get('insecure', False)
-
-        pulp_fallback = {'name': self.config_kwargs.get('pulp_registry_name')}
-        pulp_map = get_pulp(self.workflow, pulp_fallback)
-        self.config_kwargs['pulp_registry_name'] = pulp_map['name']
 
         smtp_fallback = {
             'host': self.config_kwargs.get('smtp_host'),

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -242,9 +242,7 @@ class KojiImportPlugin(ExitPlugin):
             repositories = self.workflow.build_result.annotations['repositories']['unique']
             repo = ImageName.parse(repositories[0]).to_str(registry=False, tag=False)
             # group_manifests added the registry, so this should be valid
-            registries = self.workflow.push_conf.pulp_registries
-            if not registries:
-                registries = self.workflow.push_conf.all_registries
+            registries = self.workflow.push_conf.all_registries
             for registry in registries:
                 manifest_list_digest = manifest_list_digests[repo]
                 pullspec = "{0}/{1}@{2}".format(registry.uri, repo, manifest_list_digest.default)

--- a/atomic_reactor/plugins/exit_koji_promote.py
+++ b/atomic_reactor/plugins/exit_koji_promote.py
@@ -343,12 +343,7 @@ class KojiPromotePlugin(ExitPlugin):
 
         :param digests: dict, image -> digests
         """
-        if self.workflow.push_conf.pulp_registries:
-            # If pulp was used, only report pulp images
-            registries = self.workflow.push_conf.pulp_registries
-        else:
-            # Otherwise report all the images we pushed
-            registries = self.workflow.push_conf.all_registries
+        registries = self.workflow.push_conf.all_registries
 
         output_images = []
         for registry in registries:

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -19,7 +19,6 @@ from atomic_reactor.constants import (PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
                                       PLUGIN_KOJI_PROMOTE_PLUGIN_KEY,
                                       PLUGIN_KOJI_UPLOAD_PLUGIN_KEY,
                                       PLUGIN_ADD_FILESYSTEM_KEY,
-                                      PLUGIN_BUILD_ORCHESTRATE_KEY,
                                       PLUGIN_GROUP_MANIFESTS_KEY,
                                       PLUGIN_VERIFY_MEDIA_KEY,
                                       SCRATCH_FROM)
@@ -89,17 +88,8 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
     def _get_registries(self):
         """
         Return a list of registries that this build updated
-
-        For orchestrator it should attempt to filter out non-pulp registries, on worker - return
-        all registries
         """
-        if self.workflow.buildstep_result.get(PLUGIN_BUILD_ORCHESTRATE_KEY):
-            registries = self.workflow.push_conf.pulp_registries
-            if not registries:
-                registries = self.workflow.push_conf.all_registries
-            return registries
-        else:
-            return self.workflow.push_conf.all_registries
+        return self.workflow.push_conf.all_registries
 
     def get_repositories(self):
         # usually repositories formed from NVR labels

--- a/atomic_reactor/plugins/exit_verify_media_types.py
+++ b/atomic_reactor/plugins/exit_verify_media_types.py
@@ -37,9 +37,6 @@ class VerifyMediaTypesPlugin(ExitPlugin):
         # Work out the name of the image to pull
         if not self.workflow.tag_conf.unique_images:
             raise ValueError("no unique image set, impossible to verify media types")
-        if self.workflow.push_conf.pulp_registries:
-            self.log.info("pulp registry configure, verify_media_types should not run")
-            return
         image = self.workflow.tag_conf.unique_images[0]
 
         registries = deepcopy(get_registries(self.workflow, {}))

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -93,10 +93,6 @@ def get_koji_path_info(workflow, fallback):
     return PathInfo(topdir=root_url)
 
 
-def get_pulp(workflow, fallback=NO_FALLBACK):
-    return get_value(workflow, 'pulp', fallback)
-
-
 def get_odcs(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'odcs', fallback)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -153,10 +153,6 @@ class ImageName(object):
             result = '{0}/{1}'.format('library', result)
         return result
 
-    @property
-    def pulp_repo(self):
-        return self.to_str(registry=False, tag=False).replace("/", "-")
-
     def enclose(self, organization):
         if self.namespace == organization:
             return

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -68,12 +68,6 @@ koji:
         krb_principal: krb_principal
         krb_keytab_path: /tmp/krb_keytab
 
-pulp:
-    name: my-pulp
-    auth:
-        password: testpasswd
-        username: testuser
-
 odcs:
     api_url: https://odcs.example.com/api/1
     auth:
@@ -155,7 +149,6 @@ sources_command: "fedpkg sources"
 
 required_secrets:
 - kojisecret
-- pulpsecret
 - odcssecret
 - v2-registry-dockercfg
 

--- a/tests/files/example-koji-metadata-ppc64le.json
+++ b/tests/files/example-koji-metadata-ppc64le.json
@@ -93,10 +93,6 @@
           "name": "osbs-client"
         },
         {
-          "version": "1.42",
-          "name": "dockpulp"
-        },
-        {
           "version": "1.12.6",
           "name": "docker"
         }

--- a/tests/files/example-koji-metadata-x86_64.json
+++ b/tests/files/example-koji-metadata-x86_64.json
@@ -93,10 +93,6 @@
           "name": "osbs-client"
         },
         {
-          "version": "1.42",
-          "name": "dockpulp"
-        },
-        {
           "version": "1.12.6",
           "name": "docker"
         }

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -321,8 +321,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         reactor_dict['odcs'] = {'api_url': 'odcs_url'}
         expected_kwargs['odcs_insecure'] = False
         expected_kwargs['odcs_url'] = reactor_dict['odcs']['api_url']
-        reactor_dict['pulp'] = {'name': 'pulp_name'}
-        expected_kwargs['pulp_registry_name'] = reactor_dict['pulp']['name']
         reactor_dict['prefer_schema1_digest'] = False
         expected_kwargs['prefer_schema1_digest'] = reactor_dict['prefer_schema1_digest']
         reactor_dict['smtp'] = {
@@ -386,7 +384,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         expected_kwargs['artifacts_allowed_domains'] = ''
         expected_kwargs['smtp_to_pkgowner'] = None
         expected_kwargs['prefer_schema1_digest'] = None
-        expected_kwargs['pulp_registry_name'] = None
 
     with open(os.path.join(str(tmpdir), 'osbs.conf'), 'w') as f:
         for plat_clusters in clusters.values():

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -512,7 +512,7 @@ class TestReactorConfigPlugin(object):
 
     @pytest.mark.parametrize('fallback', (True, False, None))
     @pytest.mark.parametrize('method', [
-        'koji', 'pulp', 'odcs', 'smtp', 'arrangement_version',
+        'koji', 'odcs', 'smtp', 'arrangement_version',
         'artifacts_allowed_domains', 'yum_repo_allowed_domains', 'image_labels',
         'image_label_info_url_format', 'image_equal_labels', 'fail_on_digest_mismatch',
         'openshift', 'group_manifests', 'platform_descriptors', 'prefer_schema1_digest',

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -468,21 +468,6 @@ class TestVerifyImageTypes(object):
         assert "no unique image set, impossible to verify media types" in str(exc.value)
 
     @responses.activate
-    def test_verify_fail_pulp_image(self, caplog):
-        """
-        If pulp is enabled, this plugin shouldn't run
-        """
-        workflow = self.workflow()
-        workflow.push_conf.add_pulp_registry('pulp', crane_uri='crane.example.com',
-                                             server_side_sync=False)
-        tasker = MockerTasker()
-
-        plugin = VerifyMediaTypesPlugin(tasker, workflow)
-        results = plugin.run()
-        assert not results
-        assert "pulp registry configure, verify_media_types should not run" in caplog.text
-
-    @responses.activate
     def test_verify_fail_no_build(self):
         """
         Build was unsuccessful, return an empty list

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -362,6 +362,7 @@ def test_workflow(caplog):
     assert dockerfile_used_entry in caplog.messages
     assert 'build has finished successfully' in caplog.text
 
+
 def test_workflow_base_images():
     """
     Test workflow for base images
@@ -1335,28 +1336,6 @@ def test_show_version(has_version, caplog):
         for record in caplog.records
         if record.levelno == logging.DEBUG
     ) == has_version
-
-
-def test_add_pulp_registry():
-    push_conf = atomic_reactor.inner.PushConf()
-
-    push_conf.add_pulp_registry("example.com", "http://example.com", False)
-    assert push_conf.pulp_registries[0].name == "example.com"
-    assert push_conf.pulp_registries[0].uri == "http://example.com"
-    assert not push_conf.pulp_registries[0].server_side_sync
-
-    push_conf.add_pulp_registry("example.com", "http://example.com", True)
-    assert push_conf.pulp_registries[0].server_side_sync
-    push_conf.add_pulp_registry("example.com", "http://example.com", False)
-    assert push_conf.pulp_registries[0].server_side_sync
-
-    with pytest.raises(RuntimeError):
-        push_conf.add_pulp_registry("example2.com", None, False)
-    with pytest.raises(RuntimeError):
-        push_conf.add_pulp_registry("example.com", "http://example2.com", False)
-
-    push_conf.add_pulp_registry("registry2.example.com", "http://registry2.example.com", True)
-    assert len(push_conf.pulp_registries) == 2
 
 
 def test_layer_sizes():


### PR DESCRIPTION
Remove the last remnants of pulp support from atomic_reactor

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Part of #1270 

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
