### PR TITLE
add floating tags push plugin

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -106,6 +106,7 @@ PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY = 'push_operator_manifests'
 PLUGIN_SOURCE_CONTAINER_KEY = 'source_container'
 PLUGIN_FETCH_SOURCES_KEY = 'fetch_sources'
 PLUGIN_KOJI_DELEGATE_KEY = 'koji_delegate'
+PLUGIN_PUSH_FLOATING_TAGS_KEY = 'push_floating_tags'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.

--- a/atomic_reactor/manifest_util.py
+++ b/atomic_reactor/manifest_util.py
@@ -1,0 +1,232 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals, absolute_import
+import json
+import requests
+from copy import deepcopy
+
+from atomic_reactor.plugin import PluginFailedException
+from atomic_reactor.plugins.pre_reactor_config import get_registries
+from atomic_reactor.util import (registry_hostname, RegistrySession, ManifestDigest,
+                                 get_manifest_media_type)
+from atomic_reactor.constants import (MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
+                                      MEDIA_TYPE_OCI_V1_INDEX)
+
+
+class ManifestUtil(object):
+    manifest_media_types = (
+        MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+        MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+        MEDIA_TYPE_OCI_V1,
+        MEDIA_TYPE_OCI_V1_INDEX
+    )
+
+    def __init__(self, workflow, registries, log):
+        self.push_conf = workflow.push_conf
+        self.registries = get_registries(workflow, deepcopy(registries or {}))
+        self.worker_registries = {}
+        self.log = log
+
+    def valid_media_type(self, media_type):
+        return media_type in self.manifest_media_types
+
+    def sort_annotations(self, all_annotations):
+        sorted_digests = {}
+        all_platforms = set(all_annotations)
+
+        for plat, annotation in all_annotations.items():
+            for digest in annotation['digests']:
+                hostname = registry_hostname(digest['registry'])
+                media_type = get_manifest_media_type(digest['version'])
+                if not self.valid_media_type(media_type):
+                    continue
+
+                platforms = sorted_digests.setdefault(hostname, {})
+                repos = platforms.setdefault(plat, [])
+                repos.append(digest)
+
+        sources = {}
+        for registry in self.registries:
+            hostname = registry_hostname(registry)
+            platforms = sorted_digests.get(hostname, {})
+
+            if set(platforms) != all_platforms:
+                raise RuntimeError("Missing platforms for registry {}: found {}, expected {}"
+                                   .format(registry, sorted(platforms), sorted(all_platforms)))
+
+            selected_digests = {}
+            for p, repos in platforms.items():
+                selected_digests[p] = sorted(repos, key=lambda d: d['repository'])[0]
+
+            sources[registry] = selected_digests
+
+        return sources
+
+    def get_manifest(self, session, repository, ref):
+        """
+        Downloads a manifest from a registry. ref can be a digest, or a tag.
+        """
+        self.log.debug("%s: Retrieving manifest for %s:%s", session.registry, repository, ref)
+
+        headers = {
+            'Accept': ', '.join(self.manifest_media_types)
+        }
+
+        url = '/v2/{}/manifests/{}'.format(repository, ref)
+        response = session.get(url, headers=headers)
+        response.raise_for_status()
+        return (response.content,
+                response.headers['Docker-Content-Digest'],
+                response.headers['Content-Type'],
+                int(response.headers['Content-Length']))
+
+    def link_blob_into_repository(self, session, digest, source_repo, target_repo):
+        """
+        Links ("mounts" in Docker Registry terminology) a blob from one repository in a
+        registry into another repository in the same registry.
+        """
+        self.log.debug("%s: Linking blob %s from %s to %s",
+                       session.registry, digest, source_repo, target_repo)
+
+        # Check that it exists in the source repository
+        url = "/v2/{}/blobs/{}".format(source_repo, digest)
+        result = session.head(url)
+        if result.status_code == requests.codes.NOT_FOUND:
+            self.log.debug("%s: blob %s, not present in %s, skipping",
+                           session.registry, digest, source_repo)
+            # Assume we don't need to copy it - maybe it's a foreign layer
+            return
+        result.raise_for_status()
+
+        url = "/v2/{}/blobs/uploads/?mount={}&from={}".format(target_repo, digest, source_repo)
+        result = session.post(url, data='')
+        result.raise_for_status()
+
+        if result.status_code != requests.codes.CREATED:
+            # A 202-Accepted would mean that the source blob didn't exist and
+            # we're starting an upload - but we've checked that above
+            raise RuntimeError("Blob mount had unexpected status {}".format(result.status_code))
+
+    def link_manifest_references_into_repository(self, session, manifest, media_type,
+                                                 source_repo, target_repo):
+        """
+        Links all the blobs referenced by the manifest from source_repo into target_repo.
+        """
+
+        if source_repo == target_repo:
+            return
+
+        parsed = json.loads(manifest.decode('utf-8'))
+
+        references = []
+        if media_type in (MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_OCI_V1):
+            references.append(parsed['config']['digest'])
+            for l in parsed['layers']:
+                references.append(l['digest'])
+        else:
+            # manifest list support could be added here, but isn't needed currently, since
+            # we never copy a manifest list as a whole between repositories
+            raise RuntimeError("Unhandled media-type {}".format(media_type))
+
+        for digest in references:
+            self.link_blob_into_repository(session, digest, source_repo, target_repo)
+
+    def store_manifest_in_repository(self, session, manifest, media_type,
+                                     source_repo, target_repo, ref=None):
+        """
+        Stores the manifest into target_repo, possibly tagging it. This may involve
+        copying referenced blobs from source_repo.
+        """
+
+        if not ref:
+            raise RuntimeError("Either a digest or tag must be specified as ref")
+
+        self.link_manifest_references_into_repository(session, manifest, media_type,
+                                                      source_repo, target_repo)
+
+        url = '/v2/{}/manifests/{}'.format(target_repo, ref)
+        headers = {'Content-Type': media_type}
+        response = session.put(url, data=manifest, headers=headers)
+        response.raise_for_status()
+
+    def get_registry_session(self, registry):
+        registry_conf = self.registries[registry]
+
+        insecure = registry_conf.get('insecure', False)
+        secret_path = registry_conf.get('secret')
+
+        return RegistrySession(registry, insecure=insecure,
+                               dockercfg_path=secret_path,
+                               access=('pull', 'push'))
+
+    def add_tag_and_manifest(self, session, image_manifest, media_type, manifest_digest,
+                             source_repo, configured_tags):
+        push_conf_registry = self.push_conf.add_docker_registry(session.registry,
+                                                                insecure=session.insecure)
+        for image in configured_tags:
+            target_repo = image.to_str(registry=False, tag=False)
+            self.store_manifest_in_repository(session, image_manifest, media_type,
+                                              source_repo, target_repo, ref=image.tag)
+
+            # add a tag for any plugins running later that expect it
+            push_conf_registry.digests[image.tag] = manifest_digest
+
+    def tag_manifest_into_registry(self, session, digest, source_repo, configured_tags):
+        """
+        Tags the manifest identified by worker_digest into session.registry with all the
+        configured_tags
+        """
+        self.log.info("%s: Tagging manifest", session.registry)
+
+        image_manifest, _, media_type, _ = self.get_manifest(session, source_repo, digest)
+        if media_type == MEDIA_TYPE_DOCKER_V2_SCHEMA2:
+            digests = ManifestDigest(v1=digest)
+        elif media_type == MEDIA_TYPE_OCI_V1:
+            digests = ManifestDigest(oci=digest)
+        else:
+            raise RuntimeError("Unexpected media type {} found in source_repo: {}"
+                               .format(media_type, source_repo))
+
+        self.add_tag_and_manifest(session, image_manifest, media_type, digests, source_repo,
+                                  configured_tags)
+
+    def build_list(self, manifests):
+        """
+        Builds a manifest list or OCI image out of the given manifests
+        """
+
+        media_type = manifests[0]['media_type']
+        if (not all(m['media_type'] == media_type for m in manifests)):
+            raise PluginFailedException('worker manifests have inconsistent types: {}'
+                                        .format(manifests))
+
+        if media_type == MEDIA_TYPE_DOCKER_V2_SCHEMA2:
+            list_type = MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST
+        elif media_type == MEDIA_TYPE_OCI_V1:
+            list_type = MEDIA_TYPE_OCI_V1_INDEX
+        else:
+            raise PluginFailedException('worker manifests have unsupported type: {}'
+                                        .format(media_type))
+
+        return list_type, json.dumps({
+                "schemaVersion": 2,
+                "mediaType": list_type,
+                "manifests": sorted([
+                    {
+                        "mediaType": media_type,
+                        "size": m['size'],
+                        "digest": m['digest'],
+                        "platform": {
+                            "architecture": m['architecture'],
+                            "os": "linux"
+                        }
+                    } for m in manifests
+                ], key=lambda entry: entry['platform']['architecture']),
+        }, indent=4, sort_keys=True, separators=(',', ': '))

--- a/atomic_reactor/manifest_util.py
+++ b/atomic_reactor/manifest_util.py
@@ -196,6 +196,7 @@ class ManifestUtil(object):
 
         self.add_tag_and_manifest(session, image_manifest, media_type, digests, source_repo,
                                   configured_tags)
+        return image_manifest, media_type, digests
 
     def build_list(self, manifests):
         """

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -22,7 +22,7 @@ from atomic_reactor.plugins.build_orchestrate_build import (get_worker_build_inf
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
 from atomic_reactor.util import (OSBSLogs, get_parent_image_koji_data, get_manifest_media_version,
-                                 ManifestDigest)
+                                 is_manifest_list)
 from atomic_reactor.plugins.pre_reactor_config import get_openshift_session
 
 try:
@@ -234,9 +234,9 @@ class KojiImportPlugin(ExitPlugin):
         floating_tags = [image.tag for image in floating_images]
         unique_tags = [image.tag for image in unique_images]
 
-        manifest_list_data = self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY, {})
-        manifest_digest = manifest_list_data.get("manifest_digest")
-        if manifest_digest and isinstance(manifest_digest, ManifestDigest):
+        manifest_data = self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY, {})
+        if manifest_data and is_manifest_list(manifest_data.get("media_type")):
+            manifest_digest = manifest_data.get("manifest_digest")
             index = {}
             index['tags'] = tags
             index['floating_tags'] = floating_tags

--- a/atomic_reactor/plugins/exit_push_floating_tags.py
+++ b/atomic_reactor/plugins/exit_push_floating_tags.py
@@ -1,0 +1,94 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import unicode_literals, absolute_import
+
+import json
+
+from atomic_reactor.constants import PLUGIN_PUSH_FLOATING_TAGS_KEY, PLUGIN_GROUP_MANIFESTS_KEY
+from atomic_reactor.manifest_util import ManifestUtil
+from atomic_reactor.plugin import ExitPlugin
+from atomic_reactor.util import get_floating_images, get_unique_images
+
+
+class PushFloatingTagsPlugin(ExitPlugin):
+    """
+    Push floating tags to registry
+    """
+
+    key = PLUGIN_PUSH_FLOATING_TAGS_KEY
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow, registries=None):
+        """
+        constructor
+
+        :param tasker: DockerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param registries: dict, keys are docker registries, values are dicts containing
+                           per-registry parameters.
+                           Params:
+                            * "secret" optional string - path to the secret, which stores
+                              login and password for remote registry
+        """
+        super(PushFloatingTagsPlugin, self).__init__(tasker, workflow)
+        self.manifest_util = ManifestUtil(workflow, registries, self.log)
+
+    def add_floating_tags(self, session, manifest_list_data, floating_images):
+        manifest_json = manifest_list_data.get("manifest_list", {})
+        manifest_digest = manifest_list_data.get("manifest_digest", {})
+        list_type = json.loads(manifest_json)["mediaType"]
+
+        for image in floating_images:
+            target_repo = image.to_str(registry=False, tag=False)
+            # We have to call store_manifest_in_repository directly for each
+            # referenced manifest, since each one should be a new tag that requires uploading
+            # the manifest again
+            self.log.debug("storing %s as %s", target_repo, image.tag)
+            self.manifest_util.store_manifest_in_repository(session, manifest_json, list_type,
+                                                            target_repo, target_repo, ref=image.tag)
+        # And store the manifest list in the push_conf
+        push_conf_registry = self.workflow.push_conf.add_docker_registry(session.registry,
+                                                                         insecure=session.insecure)
+        for image in floating_images:
+            push_conf_registry.digests[image.tag] = manifest_digest
+        registry_image = get_unique_images(self.workflow)[0]
+
+        return registry_image.get_repo(explicit_namespace=False), manifest_digest
+
+    def run(self):
+        """
+        Run the plugin.
+        """
+        if self.workflow.build_process_failed:
+            self.log.info('Build failed, skipping %s', PLUGIN_PUSH_FLOATING_TAGS_KEY)
+            return
+
+        floating_tags = get_floating_images(self.workflow)
+        if not floating_tags:
+            self.log.info('No floating images to tag, skippping %s', PLUGIN_PUSH_FLOATING_TAGS_KEY)
+            return
+
+        #  can't run in the worker build
+        if not self.workflow.is_orchestrator_build():
+            self.log.warning('%s cannot be used by a worker builder', PLUGIN_PUSH_FLOATING_TAGS_KEY)
+            return
+
+        manifest_data = self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY)
+        if not manifest_data or not manifest_data.get("manifest_digest"):
+            self.log.info('No manifest digest available, skipping %s',
+                          PLUGIN_PUSH_FLOATING_TAGS_KEY)
+            return
+
+        digests = dict()
+
+        for registry in self.manifest_util.registries:
+            session = self.manifest_util.get_registry_session(registry)
+            repo, digest = self.add_floating_tags(session, manifest_list_data, floating_tags)
+            digests[repo] = digest
+        return digests

--- a/atomic_reactor/plugins/exit_verify_media_types.py
+++ b/atomic_reactor/plugins/exit_verify_media_types.py
@@ -18,7 +18,7 @@ from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_VERIFY_
                                       MEDIA_TYPE_OCI_V1_INDEX)
 
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.util import get_manifest_digests, get_platforms
+from atomic_reactor.util import get_manifest_digests, get_platforms, is_manifest_list
 from atomic_reactor.plugins.pre_reactor_config import (get_registries,
                                                        get_platform_to_goarch_mapping)
 from copy import deepcopy
@@ -98,7 +98,8 @@ class VerifyMediaTypesPlugin(ExitPlugin):
 
         :return: bool, expect manifest list only?
         """
-        if not self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY):
+        manifest_results = self.workflow.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY)
+        if not manifest_results or not is_manifest_list(manifest_results.get("media_type")):
             self.log.debug('Cannot check if only manifest list digest should be returned '
                            'because group manifests plugin did not run')
             return False

--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -12,19 +12,15 @@ tags.
 
 
 from __future__ import unicode_literals, absolute_import
-import json
-import requests
-from copy import deepcopy
 
-from atomic_reactor.plugin import PostBuildPlugin, PluginFailedException
-from atomic_reactor.plugins.pre_reactor_config import (get_group_manifests,
-                                                       get_platform_descriptors,
-                                                       get_registries)
-from atomic_reactor.util import (RegistrySession, registry_hostname, ManifestDigest,
-                                 get_manifest_media_type)
-from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY, MEDIA_TYPE_DOCKER_V2_SCHEMA2,
-                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST, MEDIA_TYPE_OCI_V1,
-                                      MEDIA_TYPE_OCI_V1_INDEX)
+import json
+
+from atomic_reactor.plugin import PostBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import get_platform_descriptors, get_group_manifests
+from atomic_reactor.util import (ManifestDigest, get_manifest_media_type,
+                                 get_primary_images, get_unique_images)
+from atomic_reactor.manifest_util import ManifestUtil
+from atomic_reactor.constants import PLUGIN_GROUP_MANIFESTS_KEY, MEDIA_TYPE_OCI_V1_INDEX
 
 # The plugin requires that the worker builds have already pushed their images into
 # each registry that we want the final tags to end up in. There is code here to
@@ -37,12 +33,6 @@ from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY, MEDIA_TYPE_DOC
 class GroupManifestsPlugin(PostBuildPlugin):
     is_allowed_to_fail = False
     key = PLUGIN_GROUP_MANIFESTS_KEY
-    manifest_media_types = [
-        MEDIA_TYPE_DOCKER_V2_SCHEMA2,
-        MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
-        MEDIA_TYPE_OCI_V1,
-        MEDIA_TYPE_OCI_V1_INDEX
-    ]
 
     def __init__(self, tasker, workflow, registries=None, group=True, goarch=None):
         """
@@ -76,137 +66,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             goarch_from_pd[platform['platform']] = platform['architecture']
         self.goarch = goarch_from_pd
 
-        self.registries = get_registries(self.workflow, deepcopy(registries or {}))
-        self.worker_registries = {}
-
-    def get_manifest(self, session, repository, ref):
-        """
-        Downloads a manifest from a registry. ref can be a digest, or a tag.
-        """
-        self.log.debug("%s: Retrieving manifest for %s:%s", session.registry, repository, ref)
-
-        headers = {
-            'Accept': ', '.join(self.manifest_media_types)
-        }
-
-        url = '/v2/{}/manifests/{}'.format(repository, ref)
-        response = session.get(url, headers=headers)
-        response.raise_for_status()
-        return (response.content,
-                response.headers['Docker-Content-Digest'],
-                response.headers['Content-Type'],
-                int(response.headers['Content-Length']))
-
-    def link_blob_into_repository(self, session, digest, source_repo, target_repo):
-        """
-        Links ("mounts" in Docker Registry terminology) a blob from one repository in a
-        registry into another repository in the same registry.
-        """
-        self.log.debug("%s: Linking blob %s from %s to %s",
-                       session.registry, digest, source_repo, target_repo)
-
-        # Check that it exists in the source repository
-        url = "/v2/{}/blobs/{}".format(source_repo, digest)
-        result = session.head(url)
-        if result.status_code == requests.codes.NOT_FOUND:
-            self.log.debug("%s: blob %s, not present in %s, skipping",
-                           session.registry, digest, source_repo)
-            # Assume we don't need to copy it - maybe it's a foreign layer
-            return
-        result.raise_for_status()
-
-        url = "/v2/{}/blobs/uploads/?mount={}&from={}".format(target_repo, digest, source_repo)
-        result = session.post(url, data='')
-        result.raise_for_status()
-
-        if result.status_code != requests.codes.CREATED:
-            # A 202-Accepted would mean that the source blob didn't exist and
-            # we're starting an upload - but we've checked that above
-            raise RuntimeError("Blob mount had unexpected status {}".format(result.status_code))
-
-    def link_manifest_references_into_repository(self, session, manifest, media_type,
-                                                 source_repo, target_repo):
-        """
-        Links all the blobs referenced by the manifest from source_repo into target_repo.
-        """
-
-        if source_repo == target_repo:
-            return
-
-        parsed = json.loads(manifest.decode('utf-8'))
-
-        references = []
-        if media_type in (MEDIA_TYPE_DOCKER_V2_SCHEMA2, MEDIA_TYPE_OCI_V1):
-            references.append(parsed['config']['digest'])
-            for l in parsed['layers']:
-                references.append(l['digest'])
-        else:
-            # manifest list support could be added here, but isn't needed currently, since
-            # we never copy a manifest list as a whole between repositories
-            raise RuntimeError("Unhandled media-type {}".format(media_type))
-
-        for digest in references:
-            self.link_blob_into_repository(session, digest, source_repo, target_repo)
-
-    def store_manifest_in_repository(self, session, manifest, media_type,
-                                     source_repo, target_repo, digest=None, tag=None):
-        """
-        Stores the manifest into target_repo, possibly tagging it. This may involve
-        copying referenced blobs from source_repo.
-        """
-
-        if tag:
-            self.log.debug("%s: Tagging manifest (or list) from %s as %s:%s",
-                           session.registry, source_repo, target_repo, tag)
-            ref = tag
-        elif digest:
-            self.log.debug("%s: Storing manifest (or list) %s from %s in %s",
-                           session.registry, digest, source_repo, target_repo)
-            ref = digest
-        else:
-            raise RuntimeError("Either digest or tag must be specified")
-
-        self.link_manifest_references_into_repository(session, manifest, media_type,
-                                                      source_repo, target_repo)
-
-        url = '/v2/{}/manifests/{}'.format(target_repo, ref)
-        headers = {'Content-Type': media_type}
-        response = session.put(url, data=manifest, headers=headers)
-        response.raise_for_status()
-
-    def build_list(self, manifests):
-        """
-        Builds a manifest list or OCI image out of the given manifests
-        """
-
-        media_type = manifests[0]['media_type']
-        if (not all(m['media_type'] == media_type for m in manifests)):
-            raise PluginFailedException('worker manifests have inconsistent types: {}'
-                                        .format(manifests))
-
-        if media_type == MEDIA_TYPE_DOCKER_V2_SCHEMA2:
-            list_type = MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST
-        elif media_type == MEDIA_TYPE_OCI_V1:
-            list_type = MEDIA_TYPE_OCI_V1_INDEX
-        else:
-            raise PluginFailedException('worker manifests have unsupported type: {}'
-                                        .format(media_type))
-
-        return list_type, json.dumps({
-                "schemaVersion": 2,
-                "mediaType": list_type,
-                "manifests": sorted([
-                    {
-                        "mediaType": media_type,
-                        "size": m['size'],
-                        "digest": m['digest'],
-                        "platform": {
-                            "architecture": m['architecture'],
-                            "os": "linux"
-                        }
-                    } for m in manifests
-                ], key=lambda entry: entry['platform']['architecture']),
-        }, indent=4, sort_keys=True, separators=(',', ': '))
+        self.manifest_util = ManifestUtil(self.workflow, registries, self.log)
 
     def group_manifests_and_tag(self, session, worker_digests):
         """
@@ -223,9 +83,10 @@ class GroupManifestsPlugin(PostBuildPlugin):
             repository = worker_image['repository']
             digest = worker_image['digest']
             media_type = get_manifest_media_type(worker_image['version'])
-            if media_type not in self.manifest_media_types:
+            if media_type not in self.manifest_util.manifest_media_types:
                 continue
-            content, _, media_type, size = self.get_manifest(session, repository, digest)
+            content, _, media_type, size = self.manifest_util.get_manifest(session, repository,
+                                                                           digest)
 
             manifests.append({
                 'content': content,
@@ -236,7 +97,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
                 'architecture': self.goarch.get(platform, platform),
             })
 
-        list_type, list_json = self.build_list(manifests)
+        list_type, list_json = self.manifest_util.build_list(manifests)
         self.log.info("%s: Created manifest, Content-Type=%s\n%s", session.registry,
                       list_type, list_json)
 
@@ -248,19 +109,20 @@ class GroupManifestsPlugin(PostBuildPlugin):
             # We have to call store_manifest_in_repository directly for each
             # referenced manifest, since they potentially come from different repos
             for manifest in manifests:
-                self.store_manifest_in_repository(session,
-                                                  manifest['content'],
-                                                  manifest['media_type'],
-                                                  manifest['repository'],
-                                                  target_repo,
-                                                  digest=manifest['digest'])
-            self.store_manifest_in_repository(session, list_json, list_type,
-                                              target_repo, target_repo, tag=image.tag)
+                self.manifest_util.store_manifest_in_repository(session,
+                                                                manifest['content'],
+                                                                manifest['media_type'],
+                                                                manifest['repository'],
+                                                                target_repo,
+                                                                ref=manifest['digest'])
+            self.manifest_util.store_manifest_in_repository(session, list_json, list_type,
+                                                            target_repo, target_repo, ref=image.tag)
         # Get the digest of the manifest list using one of the tags
         registry_image = self.workflow.tag_conf.unique_images[0]
-        _, digest_str, _, _ = self.get_manifest(session,
-                                                registry_image.to_str(registry=False, tag=False),
-                                                registry_image.tag)
+        _, digest_str, _, _ = self.manifest_util.get_manifest(session,
+                                                              registry_image.to_str(registry=False,
+                                                                                    tag=False),
+                                                              registry_image.tag)
 
         if list_type == MEDIA_TYPE_OCI_V1_INDEX:
             digest = ManifestDigest(oci_index=digest_str)
@@ -276,34 +138,6 @@ class GroupManifestsPlugin(PostBuildPlugin):
         self.log.info("%s: Manifest list digest is %s", session.registry, digest_str)
         return registry_image.get_repo(explicit_namespace=False), digest
 
-    def tag_manifest_into_registry(self, session, worker_digest):
-        """
-        Tags the manifest identified by worker_digest into session.registry with all the
-        configured tags found in workflow.tag_conf.
-        """
-        self.log.info("%s: Tagging manifest", session.registry)
-
-        digest = worker_digest['digest']
-        source_repo = worker_digest['repository']
-
-        image_manifest, _, media_type, _ = self.get_manifest(session, source_repo, digest)
-        if media_type == MEDIA_TYPE_DOCKER_V2_SCHEMA2:
-            digests = ManifestDigest(v1=digest)
-        elif media_type == MEDIA_TYPE_OCI_V1:
-            digests = ManifestDigest(oci=digest)
-        else:
-            raise RuntimeError("Unexpected media type found in worker repository: {}"
-                               .format(media_type))
-
-        push_conf_registry = self.workflow.push_conf.add_docker_registry(session.registry,
-                                                                         insecure=session.insecure)
-        for image in self.workflow.tag_conf.images:
-            target_repo = image.to_str(registry=False, tag=False)
-            self.store_manifest_in_repository(session, image_manifest, media_type,
-                                              source_repo, target_repo, tag=image.tag)
-
-            # add a tag for any plugins running later that expect it
-            push_conf_registry.digests[image.tag] = digests
 
     def sort_annotations(self):
         """
@@ -318,50 +152,12 @@ class GroupManifestsPlugin(PostBuildPlugin):
         if len(all_platforms) == 0:
             raise RuntimeError("No worker builds found, cannot group them")
 
-        sorted_digests = {}
-
-        for plat, annotation in all_annotations.items():
-            for digest in annotation['digests']:
-                hostname = registry_hostname(digest['registry'])
-                media_type = get_manifest_media_type(digest['version'])
-                if media_type not in self.manifest_media_types:
-                    continue
-
-                platforms = sorted_digests.setdefault(hostname, {})
-                repos = platforms.setdefault(plat, [])
-                repos.append(digest)
-
-        sources = {}
-        for registry in self.registries:
-            hostname = registry_hostname(registry)
-            platforms = sorted_digests.get(hostname, {})
-
-            if set(platforms) != all_platforms:
-                raise RuntimeError("Missing platforms for registry {}: found {}, expected {}"
-                                   .format(registry, sorted(platforms), sorted(all_platforms)))
-
-            selected_digests = {}
-            for p, repos in platforms.items():
-                selected_digests[p] = sorted(repos, key=lambda d: d['repository'])[0]
-
-            sources[registry] = selected_digests
-
-        return sources
-
-    def get_registry_session(self, registry):
-        registry_conf = self.registries[registry]
-
-        insecure = registry_conf.get('insecure', False)
-        secret_path = registry_conf.get('secret')
-
-        return RegistrySession(registry, insecure=insecure,
-                               dockercfg_path=secret_path,
-                               access=('pull', 'push'))
+        return self.manifest_util.sort_annotations(all_annotations)
 
     def run(self):
         digests = dict()
         for registry, source in self.sort_annotations().items():
-            session = self.get_registry_session(registry)
+            session = self.manifest_util.get_registry_session(registry)
 
             if self.group:
                 repo, digest = self.group_manifests_and_tag(session, source)
@@ -372,7 +168,11 @@ class GroupManifestsPlugin(PostBuildPlugin):
                 if len(source) != 1:
                     raise RuntimeError('Without grouping only one source is expected')
                 for digest in source.values():
-                    self.tag_manifest_into_registry(session, digest)
+                    source_digest = digest['digest']
+                    source_repo = digest['repository']
+                    self.manifest_util.tag_manifest_into_registry(session, source_digest,
+                                                                  source_repo,
+                                                                  self.workflow.tag_conf.images)
                     found = True
                 if not found:
                     raise ValueError('Failed to find any platform')

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -804,6 +804,10 @@ class ManifestDigest(dict):
             return self.get(attr, None)
 
 
+def is_manifest_list(version):
+    return version == MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST or version == MEDIA_TYPE_OCI_V1_INDEX
+
+
 def get_manifest_media_type(version):
     try:
         return ManifestDigest.content_type[version]

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -615,6 +615,8 @@ def test_group_manifests(tmpdir, schema_version, test_name, group, foreign_layer
             unique_images = get_unique_images(workflow)
             for image in primary_images + unique_images:
                 assert image.tag in tags
+            for image in get_floating_images(workflow):
+                assert image.tag not in tags
         else:
             assert not result_digest
             assert not tags

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1702,7 +1702,9 @@ class TestKojiImport(object):
                                             session=session,
                                             docker_registry=True,
                                             add_tag_conf_primaries=not is_scratch)
-        group_manifest_result = {'myproject/hello-world': digest} if digest else {}
+        group_manifest_result = {}
+        if digest:
+            group_manifest_result = {'manifest_digest': digest}
         workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = group_manifest_result
         orchestrate_plugin = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         orchestrate_plugin[WORKSPACE_KEY_BUILD_INFO]['x86_64'] = BuildInfo()
@@ -1828,8 +1830,8 @@ class TestKojiImport(object):
                     'crane.example.com/foo@sha256:v2',
                 ]
 
-        list_digests = {'myproject/hello-world': ManifestDigest(v2_list='sha256:manifest-list')}
-        workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = list_digests
+        workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = {}
+
         orchestrate_plugin = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         orchestrate_plugin[WORKSPACE_KEY_BUILD_INFO]['x86_64'] = BuildInfo()
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -54,7 +54,9 @@ from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE,
                                       PARENT_IMAGES_KOJI_BUILDS, BASE_IMAGE_BUILD_ID_KEY,
                                       PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
                                       PLUGIN_VERIFY_MEDIA_KEY, PARENT_IMAGE_BUILDS_KEY,
-                                      PARENT_IMAGES_KEY, OPERATOR_MANIFESTS_ARCHIVE)
+                                      PARENT_IMAGES_KEY, OPERATOR_MANIFESTS_ARCHIVE,
+                                      MEDIA_TYPE_DOCKER_V2_SCHEMA2,
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
 from tests.constants import SOURCE, MOCK
 from tests.flatpak import MODULEMD_AVAILABLE, setup_flatpak_source_info
 from tests.stubs import StubInsideBuilder, StubSource
@@ -1660,7 +1662,9 @@ class TestKojiImport(object):
                     'crane.example.com/foo:tag',
                     'crane.example.com/foo@sha256:bar',
                 ]
-        workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = {}
+        workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = {
+            "media_type": MEDIA_TYPE_DOCKER_V2_SCHEMA2
+        }
         orchestrate_plugin = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         if digest:
             build_info = BuildInfo(digests=[digest])
@@ -1702,9 +1706,12 @@ class TestKojiImport(object):
                                             session=session,
                                             docker_registry=True,
                                             add_tag_conf_primaries=not is_scratch)
-        group_manifest_result = {}
+        group_manifest_result = {"media_type": MEDIA_TYPE_DOCKER_V2_SCHEMA2}
         if digest:
-            group_manifest_result = {'manifest_digest': digest}
+            group_manifest_result = {
+                'media_type': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+                'manifest_digest': digest
+            }
         workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = group_manifest_result
         orchestrate_plugin = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         orchestrate_plugin[WORKSPACE_KEY_BUILD_INFO]['x86_64'] = BuildInfo()

--- a/tests/plugins/test_push_floating_tags.py
+++ b/tests/plugins/test_push_floating_tags.py
@@ -1,0 +1,456 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import print_function, unicode_literals, absolute_import
+import pytest
+import json
+import hashlib
+import re
+import responses
+from tempfile import mkdtemp
+import os
+from six import binary_type, text_type
+
+from tests.constants import SOURCE, MOCK, DOCKER0_REGISTRY
+from tests.stubs import StubInsideBuilder
+
+from atomic_reactor.core import DockerTasker
+from atomic_reactor.build import BuildResult
+from atomic_reactor.plugin import ExitPluginsRunner
+from atomic_reactor.inner import DockerBuildWorkflow, TagConf
+from atomic_reactor.util import ImageName, registry_hostname, ManifestDigest
+from atomic_reactor.plugins.exit_push_floating_tags import PushFloatingTagsPlugin
+from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin, WORKSPACE_CONF_KEY,
+                                                       ReactorConfig)
+from atomic_reactor.constants import PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_BUILD_ORCHESTRATE_KEY
+
+
+if MOCK:
+    from tests.docker_mock import mock_docker
+
+
+def to_bytes(value):
+    if isinstance(value, binary_type):
+        return value
+    else:
+        return value.encode('utf-8')
+
+
+def to_text(value):
+    if isinstance(value, text_type):
+        return value
+    else:
+        return text_type(value, 'utf-8')
+
+
+def make_digest(blob):
+    # Abbreviate the hexdigest for readability of debugging output if things fail
+    return 'sha256:' + hashlib.sha256(to_bytes(blob)).hexdigest()[0:10]
+
+
+class MockRegistry(object):
+    """
+    This class mocks a subset of the v2 Docker Registry protocol
+    """
+    def __init__(self, registry):
+        self.hostname = registry_hostname(registry)
+        self.repos = {}
+        self._add_pattern(responses.PUT, r'/v2/(.*)/manifests/([^/]+)',
+                          self._put_manifest)
+
+    def get_repo(self, name):
+        return self.repos.setdefault(name, {
+            'blobs': {},
+            'manifests': {},
+            'tags': {},
+        })
+
+    def add_manifest(self, name, ref, manifest):
+        repo = self.get_repo(name)
+        digest = make_digest(manifest)
+        repo['manifests'][digest] = manifest
+        if ref.startswith('sha256:'):
+            assert ref == digest
+        else:
+            repo['tags'][ref] = digest
+        return digest
+
+    def get_manifest(self, name, ref):
+        repo = self.get_repo(name)
+        if not ref.startswith('sha256:'):
+            ref = repo['tags'][ref]
+        return repo['manifests'][ref]
+
+    def _add_pattern(self, method, pattern, callback):
+        pat = re.compile(r'^https://' + self.hostname + pattern + '$')
+
+        def do_it(req):
+            status, headers, body = callback(req, *(pat.match(req.url).groups()))
+            if method == responses.HEAD:
+                return status, headers, ''
+            else:
+                return status, headers, body
+
+        responses.add_callback(method, pat, do_it, match_querystring=True)
+
+    def _put_manifest(self, req, name, ref):
+        try:
+            json.loads(to_text(req.body))
+        except ValueError:
+            return (400, {}, {'error': 'BAD_MANIFEST'})
+
+        self.add_manifest(name, ref, req.body)
+        return (200, {}, '')
+
+
+def mock_registries(registries, config, primary_images=None, manifest_results=None,
+                    schema_version='v2'):
+    """
+    Creates MockRegistries objects and fills them in based on config, which specifies
+    which registries should be prefilled (as if by workers) with platform-specific
+    manifests, and with what tags.
+    """
+    reg_map = {}
+    for reg in registries:
+        reg_map[reg] = MockRegistry(reg)
+
+    worker_builds = {}
+
+    for platform, regs in config.items():
+        digests = []
+
+        for reg, tags in regs.items():
+            registry = reg_map[reg]
+            manifest = {'schemaVersion': 2}
+
+            if schema_version == 'v2':
+                manifest['mediaType'] = 'application/vnd.docker.distribution.manifest.v2+json'
+            elif schema_version == 'oci':
+                manifest['mediaType'] = 'application/vnd.oci.image.manifest.v1+json'
+
+            for t in tags:
+                name, tag = t.split(':')
+                manifest_bytes = to_bytes(json.dumps(manifest))
+                digest = registry.add_manifest(name, tag, manifest_bytes)
+                digests.append({
+                    'registry': reg,
+                    'repository': name,
+                    'tag': tag,
+                    'digest': digest,
+                    'version': schema_version
+                })
+                digests.append({
+                    'registry': reg,
+                    'repository': name,
+                    'tag': tag,
+                    'digest': 'not-used',
+                    'version': 'v1'
+                })
+
+        worker_builds[platform] = {
+            'digests': digests
+        }
+
+    if primary_images and manifest_results:
+        for _, registry in reg_map.items():
+            for image in primary_images:
+                name, tag = image.split(':')
+                repo = registry.get_repo(name)
+                manifest_digest = manifest_results["manifest_digest"]
+                repo["manifests"][manifest_digest.default] = manifest_results["manifest_list"]
+                repo["tags"][tag] = manifest_digest.default
+
+    return reg_map, {
+        'worker-builds': worker_builds,
+        'repositories': {'primary': primary_images or [], 'floating': []}
+    }
+
+
+def mock_environment(tmpdir, primary_images=None, floating_images=None, manifest_results=None,
+                     annotations=None):
+    if MOCK:
+        mock_docker()
+    tasker = DockerTasker()
+    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    base_image_id = '123456parent-id'
+    setattr(workflow, '_base_image_inspect', {'Id': base_image_id})
+    setattr(workflow, 'builder', StubInsideBuilder())
+    setattr(workflow.builder, 'image_id', '123456imageid')
+    setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='22'))
+    setattr(workflow.builder, 'source', StubInsideBuilder())
+    setattr(workflow.builder, 'built_image_info', {'ParentId': base_image_id})
+    setattr(workflow.builder.source, 'dockerfile_path', None)
+    setattr(workflow.builder.source, 'path', None)
+    setattr(workflow, 'tag_conf', TagConf())
+    if primary_images:
+        for image in primary_images:
+            if '-' in ImageName.parse(image).tag:
+                workflow.tag_conf.add_primary_image(image)
+        workflow.tag_conf.add_unique_image(primary_images[0])
+
+    if floating_images:
+        workflow.tag_conf.add_floating_images(floating_images)
+
+    workflow.build_result = BuildResult(image_id='123456', annotations=annotations or {})
+    workflow.postbuild_results = {}
+    if manifest_results:
+        workflow.postbuild_results[PLUGIN_GROUP_MANIFESTS_KEY] = manifest_results
+
+    return tasker, workflow
+
+
+REGISTRY_V2 = 'registry_v2.example.com'
+OTHER_V2 = 'registry.example.com:5001'
+
+
+V2_RESULTS = {
+    "manifest_digest": ManifestDigest(v2_list="sha256:11c3ecdbfa"),
+    "manifest_list": json.dumps({
+        "manifests": [
+            {
+                "digest": "sha256:9dc3bbcd6c",
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux"
+                },
+                "size": 306
+            },
+            {
+                "digest": "sha256:cd619643ae",
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "platform": {
+                    "architecture": "powerpc",
+                    "os": "linux"
+                },
+                "size": 306
+            }
+        ],
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "schemaVersion": 2
+    }, indent=4, sort_keys=True, separators=(',', ': '))
+}
+OCI_RESULTS = {
+    "manifest_digest": ManifestDigest(oci_index="sha256:cf4d07b24d"),
+    "manifest_list": json.dumps({
+        "manifests": [
+            {
+                "digest": "sha256:62cef32411",
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "platform": {
+                    "architecture": "amd64",
+                    "os": "linux"
+                },
+                "size": 279
+            },
+            {
+                "digest": "sha256:c1c380151b",
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "platform": {
+                    "architecture": "powerpc",
+                    "os": "linux"
+                },
+                "size": 279
+            }
+        ],
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "schemaVersion": 2
+    }, indent=4, sort_keys=True, separators=(',', ': '))
+}
+
+
+@pytest.mark.parametrize(('test_name',
+                          'registries', 'manifest_results', 'schema_version',
+                          'floating_tags',
+                          'workers', 'expected_exception'), [
+    ("simple_v2",
+     [REGISTRY_V2, OTHER_V2], V2_RESULTS, 'v2',
+     ['namespace/httpd:2.4-1'],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    ("simple_oci",
+     [REGISTRY_V2, OTHER_V2], OCI_RESULTS, 'oci',
+     ['namespace/httpd:2.4-1'],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    ("multi_v2",
+     [REGISTRY_V2, OTHER_V2], V2_RESULTS, 'v2',
+     ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     None),
+    ("No tags",
+     [REGISTRY_V2, OTHER_V2], V2_RESULTS, 'v2',
+     None,
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     'No floating images to tag, skippping push_floating_tags'),
+    ("called_from_worker",
+     [REGISTRY_V2, OTHER_V2], V2_RESULTS, 'v2',
+     ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
+     {},
+     'push_floating_tags cannot be used by a worker builder'),
+    ("No_results",
+     [REGISTRY_V2, OTHER_V2], None, 'oci',
+     ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
+     {
+         'ppc64le': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
+         },
+         'x86_64': {
+             REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
+         }
+     },
+     'No manifest digest available, skipping push_floating_tags'),
+])
+@responses.activate  # noqa
+def test_floating_tags_push(tmpdir, test_name, registries, manifest_results, schema_version,
+                            floating_tags, workers, expected_exception, reactor_config_map,
+                            caplog):
+    if MOCK:
+        mock_docker()
+
+    primary_images = ['namespace/httpd:2.4', 'namespace/httpd:primary']
+
+    goarch = {
+        'ppc64le': 'powerpc',
+        'x86_64': 'amd64',
+    }
+
+    all_registry_conf = {
+        REGISTRY_V2: {'version': 'v2', 'insecure': True},
+        OTHER_V2: {'version': 'v2', 'insecure': False},
+    }
+
+    temp_dir = mkdtemp(dir=str(tmpdir))
+    with open(os.path.join(temp_dir, ".dockercfg"), "w+") as dockerconfig:
+        dockerconfig_contents = {
+            REGISTRY_V2: {
+                "username": "user", "password": DOCKER0_REGISTRY
+            }
+        }
+        dockerconfig.write(json.dumps(dockerconfig_contents))
+        dockerconfig.flush()
+        all_registry_conf[REGISTRY_V2]['secret'] = temp_dir
+
+    registry_conf = {
+        k: v for k, v in all_registry_conf.items() if k in registries
+    }
+
+    plugins_conf = [{
+        'name': PushFloatingTagsPlugin.key,
+        'args': {
+            'registries': registry_conf,
+        },
+    }]
+
+    mocked_registries, annotations = mock_registries(registry_conf, workers,
+                                                     primary_images=primary_images,
+                                                     manifest_results=manifest_results,
+                                                     schema_version=schema_version)
+    tasker, workflow = mock_environment(tmpdir, primary_images=primary_images,
+                                        floating_images=floating_tags,
+                                        manifest_results=manifest_results,
+                                        annotations=annotations)
+
+    if workers:
+        workflow.buildstep_plugins_conf = [{'name': PLUGIN_BUILD_ORCHESTRATE_KEY}]
+
+    if reactor_config_map:
+        registries_list = []
+
+        for docker_uri in registry_conf:
+            reg_ver = registry_conf[docker_uri]['version']
+            reg_secret = None
+            if 'secret' in registry_conf[docker_uri]:
+                reg_secret = registry_conf[docker_uri]['secret']
+
+            new_reg = {}
+            if reg_secret:
+                new_reg['auth'] = {'cfg_path': reg_secret}
+            else:
+                new_reg['auth'] = {'cfg_path': str(temp_dir)}
+            new_reg['url'] = 'https://' + docker_uri + '/' + reg_ver
+
+            registries_list.append(new_reg)
+
+        platform_descriptors_list = []
+        for platform in goarch:
+            new_plat = {
+                'platform': platform,
+                'architecture': goarch[platform],
+            }
+            platform_descriptors_list.append(new_plat)
+
+        workflow.plugin_workspace[ReactorConfigPlugin.key] = {}
+        workflow.plugin_workspace[ReactorConfigPlugin.key][WORKSPACE_CONF_KEY] =\
+            ReactorConfig({'version': 1,
+                           'registries': registries_list,
+                           'platform_descriptors': platform_descriptors_list})
+
+    runner = ExitPluginsRunner(tasker, workflow, plugins_conf)
+    results = runner.run()
+    plugin_result = results[PushFloatingTagsPlugin.key]
+
+    if expected_exception is None:
+        primary_name, primary_tag = primary_images[0].split(':')
+        for registry in registry_conf:
+            target_registry = mocked_registries[registry]
+            primary_manifest_list = target_registry.get_manifest(primary_name, primary_tag)
+
+            for image in floating_tags:
+                name, tag = image.split(':')
+
+                assert tag in target_registry.get_repo(name)['tags']
+                assert target_registry.get_manifest(name, tag) == primary_manifest_list
+
+        # Check that plugin returns ManifestDigest object
+        assert isinstance(plugin_result, dict)
+        # Check that plugin returns correct list of repos
+        actual_repos = sorted(plugin_result.keys())
+        expected_repos = sorted(set([x.get_repo() for x in workflow.tag_conf.images]))
+        assert expected_repos == actual_repos
+    else:
+        assert not plugin_result
+        assert expected_exception in caplog.text

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -268,7 +268,7 @@ class TestVerifyImageTypes(object):
                            auth=mock_auth, verify=False)
                 .and_return(v2_list_response))
 
-        digests = {'digest': None} if group else {}
+        digests = {'manifest_digest': {'oci_index': None}} if group else {}
         prebuild_results = {PLUGIN_CHECK_AND_SET_PLATFORMS_KEY: platforms}
         postbuild_results = {PLUGIN_GROUP_MANIFESTS_KEY: digests}
 

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -268,7 +268,9 @@ class TestVerifyImageTypes(object):
                            auth=mock_auth, verify=False)
                 .and_return(v2_list_response))
 
-        digests = {'manifest_digest': {'oci_index': None}} if group else {}
+        digests = {'media_type': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST}
+        if not group:
+            digests = {'media_type': MEDIA_TYPE_DOCKER_V2_SCHEMA2}
         prebuild_results = {PLUGIN_CHECK_AND_SET_PLATFORMS_KEY: platforms}
         postbuild_results = {PLUGIN_GROUP_MANIFESTS_KEY: digests}
 


### PR DESCRIPTION
Add a plugin that runs after koji_import and adds floating tags to the existing manifest lists
produced by group_manifests.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- (n/a) New feature can be disabled from a configuration file  -- would be too invasive
