### PR TITLE
When submitting builds directly with osbs-client, koji task id and

### DIFF
--- a/atomic_reactor/plugins/pre_koji_delegate.py
+++ b/atomic_reactor/plugins/pre_koji_delegate.py
@@ -74,6 +74,8 @@ class KojiDelegatePlugin(PreBuildPlugin):
         koji_task_id = self.metadata.get('labels', {}).get('original-koji-task-id')
         if not koji_task_id:
             koji_task_id = self.metadata.get('labels', {}).get('koji-task-id')
+            if not koji_task_id:
+                koji_task_id = 0
 
         task_opts = {}
         for key in ('yum_repourls', 'git_branch', 'signing_intent', 'compose_ids'):

--- a/tests/plugins/test_koji_delegate.py
+++ b/tests/plugins/test_koji_delegate.py
@@ -176,6 +176,7 @@ class TestKojiDelegate(object):
         (12345, None),
         (12345, 67890),
         (None, 67890),
+        (None, None),
     ])
     @pytest.mark.parametrize(('triggered_task', 'task_open', 'task_priority'), [
         (12345, False, None),
@@ -217,7 +218,7 @@ class TestKojiDelegate(object):
                 if user_params.get('compose_ids'):
                     expect_opts['compose_ids'] = user_params.get('compose_ids')
                 if not expect_opts['triggered_after_koji_task']:
-                    expect_opts['triggered_after_koji_task'] = koji_task_id
+                    expect_opts['triggered_after_koji_task'] = koji_task_id or 0
 
                 assert expect_opts == task_opts
                 return 987654321


### PR DESCRIPTION
original task id doesn't exist, default to 0

* OSBS-8150

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
