### PR TITLE
Treat 401 as 404 with get_manifest

### DIFF
--- a/atomic_reactor/auth.py
+++ b/atomic_reactor/auth.py
@@ -92,6 +92,10 @@ class HTTPBearerAuth(AuthBase):
         retry_response = response.connection.send(retry_request, **kwargs)
         retry_response.history.append(response)
         retry_response.request = retry_request
+        # when quay returns 401 even after we have token,
+        # repository doesn't exist at all, so we will treat it as 404
+        if retry_response.status_code == requests.codes.unauthorized:
+            retry_response.status_code = requests.codes.not_found
 
         return retry_response
 

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -171,7 +171,7 @@ class PullBaseImagePlugin(PreBuildPlugin):
             try:
                 manifest_digest_response = digests_dict['v2']
             except KeyError:
-                raise RuntimeError('Could not extract manifest list or '
+                raise RuntimeError('Unable to fetch manifest list or '
                                    'v2 schema 2 digest for {}'.format(image_str))
 
             digest_dict = get_checksums(BytesIO(manifest_digest_response.content), ['sha256'])

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -598,7 +598,7 @@ class TestValidateBaseImage(object):
                                         check_platforms=True)
             assert log_message in caplog.text
         else:
-            no_manifest_msg = 'Could not extract manifest list or v2 schema 2 digest'
+            no_manifest_msg = 'Unable to fetch manifest list or v2 schema 2 digest'
             with pytest.raises(PluginFailedException) as exc:
                 test_pull_base_image_plugin(LOCALHOST_REGISTRY, BASE_IMAGE,
                                             [], [], reactor_config_map=True,


### PR DESCRIPTION
* OSBS-8217

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
