### PR TITLE
Revert docker-py => docker requirements change

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,18 @@
 
 ## Environment preparation
 
+While Atomic Reactor depends on the `docker-py` python package, one of its dependencies (docker-squash) requires the `docker` package to be installed.  Although docker and docker-py have different names in pypi, they are just different versions of the same package, i.e., they are installed under the same namespace. Hence, when we install one of these packages after the other, pip will overwrite files from the first installed package with files from the second one.
+
+For now, Atomic Reactor does not support the `docker` python package, so we want to keep the `docker-py` installation in our environment. For that, you must install docker-squash (which pulls docker) before docker-py, so the former will be overwritten by the latter.
+
+Note that just changing the order of the lists in the requirements file [does not guarantee the packages will be installed in that order](https://pip.pypa.io/en/stable/reference/pip_install/#installation-order).
+
+To make sure `docker` will get pulled before docker-py (and then overwritten by it), we can install our dependencies with
+
 ```
-pip install -r requirements-devel.txt
+pip install docker-squash
 python setup.py develop
+pip install -r requirements-devel.txt
 ```
 
 For python 2 environments, you should activate tests related to dockpulp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker
+docker-py>=1.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11


### PR DESCRIPTION

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
