### PR TITLE
New download_remote_source pre-build plugin

### DIFF
--- a/atomic_reactor/download.py
+++ b/atomic_reactor/download.py
@@ -1,0 +1,63 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+from __future__ import absolute_import
+
+import logging
+import os
+import time
+import requests
+from six.moves.urllib.parse import urlparse
+
+from atomic_reactor.util import get_retrying_requests_session
+from atomic_reactor.constants import (
+    DEFAULT_DOWNLOAD_BLOCK_SIZE,
+    HTTP_BACKOFF_FACTOR,
+    HTTP_MAX_RETRIES,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+def download_url(url, dest_dir, insecure=False, session=None):
+    """Download file from URL, handling retries
+
+    To download to a temporary directory, use:
+      f = download_url(url, tempfile.mkdtemp())
+
+    :param url: URL to download from
+    :param dest_dir: existing directory to create file in
+    :param insecure: bool, whether to perform TLS checks
+    :param session: optional existing requests session to use
+    :return: str, path of downloaded file
+    """
+
+    if session is None:
+        session = get_retrying_requests_session()
+
+    parsed_url = urlparse(url)
+    dest_filename = os.path.basename(parsed_url.path)
+    dest_path = os.path.join(dest_dir, dest_filename)
+    logger.debug('downloading %s', url)
+
+    for attempt in range(HTTP_MAX_RETRIES + 1):
+        response = session.get(url, stream=True, verify=not insecure)
+        response.raise_for_status()
+        try:
+            with open(dest_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
+                    f.write(chunk)
+            break
+        except requests.exceptions.RequestException:
+            if attempt < HTTP_MAX_RETRIES:
+                time.sleep(HTTP_BACKOFF_FACTOR * (2 ** attempt))
+            else:
+                raise
+
+    logger.debug('download finished: %s', dest_path)
+    return dest_path

--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -1,0 +1,50 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+Downloads and unpacks the source code archive from Cachito and sets appropriate build args.
+"""
+
+from __future__ import absolute_import
+
+import tarfile
+
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.download import download_url
+
+
+class DownloadRemoteSourcePlugin(PreBuildPlugin):
+    key = 'download_remote_source'
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow, remote_source_url,
+                 remote_source_build_args=None):
+        """
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param remote_source_url: URL to download source archive from
+        :param remote_source_build_args: dict of container build args
+                                         to be used when building the image
+        """
+        super(DownloadRemoteSourcePlugin, self).__init__(tasker, workflow)
+        self.url = remote_source_url
+        self.buildargs = remote_source_build_args or {}
+
+    def run(self):
+        """
+        Run the plugin.
+        """
+        # Download the source code archive
+        archive = download_url(self.url, self.workflow.source.workdir)
+
+        # Unpack the source code archive into the workdir
+        with tarfile.open(archive) as tf:
+            tf.extractall(self.workflow.source.workdir)
+
+        # Set build args
+        self.workflow.builder.buildargs.update(self.buildargs)
+
+        return archive

--- a/tests/plugins/test_download_remote_source.py
+++ b/tests/plugins/test_download_remote_source.py
@@ -1,0 +1,65 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import
+
+from io import BytesIO
+import os
+import responses
+import tarfile
+
+from atomic_reactor.inner import DockerBuildWorkflow
+from tests.constants import TEST_IMAGE
+from tests.stubs import StubInsideBuilder
+from atomic_reactor.plugins.pre_download_remote_source import (
+    DownloadRemoteSourcePlugin,
+)
+
+
+class TestDownloadRemoteSource(object):
+    @responses.activate
+    def test_download_remote_source(self, docker_tasker):
+        workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"},
+                                       TEST_IMAGE)
+        workflow.builder = StubInsideBuilder().for_workflow(workflow)
+        filename = 'source.tar.gz'
+        url = 'https://example.com/dir/{}'.format(filename)
+
+        # Make a compressed tarfile with a single file 'abc'
+        member = 'abc'
+        abc_content = b'def'
+        content = BytesIO()
+        with tarfile.open(mode='w:gz', fileobj=content) as tf:
+            ti = tarfile.TarInfo(name=member)
+            ti.size = len(abc_content)
+            tf.addfile(ti, fileobj=BytesIO(abc_content))
+
+        # GET from the url returns the compressed tarfile
+        responses.add(responses.GET, url, body=content.getvalue())
+
+        buildargs = {'spam': 'maps'}
+        plugin = DownloadRemoteSourcePlugin(docker_tasker, workflow,
+                                            remote_source_url=url,
+                                            remote_source_build_args=buildargs)
+        result = plugin.run()
+
+        # The return value should be the path to the downloaded archive itself
+        with open(result, 'rb') as f:
+            filecontent = f.read()
+
+        assert filecontent == content.getvalue()
+
+        # Expect a file 'abc' in the workdir
+        with open(os.path.join(workflow.source.workdir, member), 'rb') as f:
+            filecontent = f.read()
+
+        assert filecontent == abc_content
+
+        # Expect buildargs to have been set
+        for arg, value in buildargs.items():
+            assert workflow.builder.buildargs[arg] == value

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -16,6 +16,7 @@ import koji
 import pytest
 import requests
 from flexmock import flexmock
+import time
 
 from atomic_reactor import constants
 from atomic_reactor import util
@@ -150,6 +151,7 @@ def mock_koji_manifest_download(requests_mock, retries=0):
 
             return super(MockBytesIO, self).read(*args, **kwargs)
 
+    flexmock(time).should_receive('sleep')
     sign_keys = ['', 'usedKey', 'notUsed']
     bad_keys = ['notUsed']
     urls = [get_srpm_url(k) for k in sign_keys]
@@ -169,7 +171,7 @@ def mock_koji_manifest_download(requests_mock, retries=0):
 class TestFetchSources(object):
     @pytest.mark.parametrize('retries', (0, 1, constants.HTTP_MAX_RETRIES + 1))
     @pytest.mark.parametrize('signing_intent', ('unsigned', 'empty', 'one', 'multiple', 'invalid'))
-    def test_fetch_soures(self, requests_mock, docker_tasker, koji_session, tmpdir, signing_intent,
+    def test_fetch_sources(self, requests_mock, docker_tasker, koji_session, tmpdir, signing_intent,
                           caplog, retries):
         mock_koji_manifest_download(requests_mock, retries)
         runner = mock_env(tmpdir, docker_tasker, koji_build_id=1, default_si=signing_intent)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,69 @@
+"""
+Copyright (c) 2019 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import
+
+from io import BufferedReader, BytesIO
+import os
+import requests
+import responses
+import tempfile
+import time
+
+import pytest
+from flexmock import flexmock
+
+from atomic_reactor.util import get_retrying_requests_session
+from atomic_reactor.download import download_url
+
+
+class TestDownloadUrl(object):
+    @responses.activate
+    def test_happy_path(self):
+        url = 'https://example.com/path/file'
+        dest_dir = tempfile.mkdtemp()
+        content = b'abc'
+        reader = BufferedReader(BytesIO(content), buffer_size=1)
+        responses.add(responses.GET, url, body=reader)
+        result = download_url(url, dest_dir)
+
+        assert os.path.basename(result) == 'file'
+        with open(result, 'rb') as f:
+            assert f.read() == content
+
+    def test_connection_failure(self):
+        url = 'https://example.com/path/file'
+        dest_dir = tempfile.mkdtemp()
+        session = get_retrying_requests_session()
+        (flexmock(session)
+         .should_receive('get')
+         .and_raise(requests.exceptions.RetryError))
+        with pytest.raises(requests.exceptions.RetryError):
+            download_url(url, dest_dir, session=session)
+
+    def test_streaming_failure(self):
+        url = 'https://example.com/path/file'
+        dest_dir = tempfile.mkdtemp()
+        session = get_retrying_requests_session()
+        # get response shows successful connection
+        response = flexmock()
+        (response
+         .should_receive('raise_for_status'))
+        # but streaming from the response fails
+        (response
+         .should_receive('iter_content')
+         .and_raise(requests.exceptions.RequestException))
+        # get on the session should return our mock response
+        (flexmock(session)
+         .should_receive('get')
+         .and_return(response))
+        # Speed through the retries
+        (flexmock(time)
+         .should_receive('sleep'))
+        with pytest.raises(requests.exceptions.RequestException):
+            download_url(url, dest_dir, session=session)


### PR DESCRIPTION
This plugin downloads and unpacks the source code archive from Cachito, and sets the appropriate build args.

To do:
- [x] factor out download-URL-with-retries
- [x] add basic plugin
- [x] add plugin tests
- [x] add integration for build args

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
