### PR TITLE
Source containers: workaround inner workflow

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -31,7 +31,7 @@ from atomic_reactor.plugin import (
     PreBuildPluginsRunner,
     PrePublishPluginsRunner,
 )
-from atomic_reactor.source import get_source_instance_for
+from atomic_reactor.source import get_source_instance_for, DummySource
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
 from atomic_reactor.constants import (
     CONTAINER_DEFAULT_BUILD_METHOD,
@@ -325,7 +325,7 @@ class DockerBuildWorkflow(object):
     6. push it to registries
     """
 
-    def __init__(self, source, image, prebuild_plugins=None, prepublish_plugins=None,
+    def __init__(self, image, source=None, prebuild_plugins=None, prepublish_plugins=None,
                  postbuild_plugins=None, exit_plugins=None, plugin_files=None,
                  openshift_build_selflink=None, client_version=None,
                  buildstep_plugins=None, **kwargs):
@@ -342,7 +342,11 @@ class DockerBuildWorkflow(object):
         :param client_version: str, osbs-client version used to render build json
         :param buildstep_plugins: list of dicts, arguments for build-step plugins
         """
-        self.source = get_source_instance_for(source, tmpdir=tempfile.mkdtemp())
+        tmp_dir = tempfile.mkdtemp()
+        if source is None:
+            self.source = DummySource(None, None, tmpdir=tmp_dir)
+        else:
+            self.source = get_source_instance_for(source, tmpdir=tmp_dir)
         self.image = image
 
         self.prebuild_plugins_conf = prebuild_plugins

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ from tests.util import uuid_value
 from atomic_reactor.util import ImageName
 from atomic_reactor.core import ContainerTasker
 from atomic_reactor.constants import CONTAINER_DOCKERPY_BUILD_METHOD
+from atomic_reactor.inner import DockerBuildWorkflow
+from tests.constants import MOCK_SOURCE
 
 if MOCK:
     from tests.docker_mock import mock_docker
@@ -64,3 +66,8 @@ def reactor_config_map(request):
 @pytest.fixture(params=[True, False])
 def inspect_only(request):
     return request.param
+
+
+@pytest.fixture
+def workflow():
+    return DockerBuildWorkflow('test-image', source=MOCK_SOURCE)

--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -8,13 +8,12 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import unicode_literals, absolute_import
 
-from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_dockerfile import AddDockerfilePlugin
 from atomic_reactor.plugins.pre_add_labels_in_df import AddLabelsPlugin
 from atomic_reactor.util import df_parser
 from atomic_reactor.constants import INSPECT_CONFIG
-from tests.constants import MOCK_SOURCE, MOCK
+from tests.constants import MOCK
 from tests.stubs import StubInsideBuilder, StubSource
 if MOCK:
     from tests.docker_mock import mock_docker
@@ -26,7 +25,7 @@ def prepare(workflow, df_path):
     workflow.builder.set_df_path(df_path)
 
 
-def test_adddockerfile_plugin(tmpdir, docker_tasker):  # noqa
+def test_adddockerfile_plugin(tmpdir, docker_tasker, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -34,7 +33,6 @@ CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
@@ -56,7 +54,7 @@ CMD blabla"""
     assert df.content == expected_output
 
 
-def test_adddockerfile_todest(tmpdir, docker_tasker):  # noqa
+def test_adddockerfile_todest(tmpdir, docker_tasker, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -64,7 +62,6 @@ CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
@@ -87,7 +84,7 @@ CMD blabla"""
     assert df.content == expected_output
 
 
-def test_adddockerfile_nvr_from_labels(tmpdir, docker_tasker):  # noqa
+def test_adddockerfile_nvr_from_labels(tmpdir, docker_tasker, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -96,7 +93,6 @@ CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
@@ -112,7 +108,7 @@ CMD blabla"""
     assert "ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77" in df.content  # noqa
 
 
-def test_adddockerfile_nvr_from_labels2(tmpdir, docker_tasker):  # noqa
+def test_adddockerfile_nvr_from_labels2(tmpdir, docker_tasker, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -123,7 +119,6 @@ CMD blabla"""
     if MOCK:
         mock_docker()
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
     workflow.builder.set_inspection_data({INSPECT_CONFIG: {"Labels": {}}})
 
@@ -147,7 +142,7 @@ CMD blabla"""
     assert "ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77" in df.content  # noqa
 
 
-def test_adddockerfile_fails(tmpdir, docker_tasker, caplog):  # noqa
+def test_adddockerfile_fails(tmpdir, docker_tasker, caplog, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -155,7 +150,6 @@ CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
@@ -169,7 +163,7 @@ CMD blabla"""
     assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text
 
 
-def test_adddockerfile_final(tmpdir, docker_tasker):  # noqa
+def test_adddockerfile_final(tmpdir, docker_tasker, workflow):  # noqa
     df_content = """
 FROM fedora
 RUN yum install -y python-django
@@ -177,7 +171,6 @@ CMD blabla"""
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     prepare(workflow, df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -198,7 +198,7 @@ def mock_image_build_file(tmpdir, contents=None):
 def mock_workflow(tmpdir, dockerfile=DEFAULT_DOCKERFILE,
                   scratch=False, for_orchestrator=False):
     flexmock(util).should_receive('is_scratch_build').and_return(scratch)
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     mock_source = MockSource(tmpdir)
     setattr(workflow, 'builder', X())
     workflow.builder.source = mock_source

--- a/tests/plugins/test_add_help.py
+++ b/tests/plugins/test_add_help.py
@@ -12,14 +12,12 @@ import os
 import subprocess
 import pytest
 
-from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
 from atomic_reactor.util import df_parser
 from atomic_reactor import start_time as atomic_reactor_start_time
 
 from datetime import datetime as dt
-from tests.constants import MOCK_SOURCE
 from tests.stubs import StubInsideBuilder
 
 from textwrap import dedent
@@ -49,7 +47,7 @@ def generate_a_file(destpath, contents):
 
 
 @pytest.mark.parametrize('filename', ['help.md', 'other_file.md'])  # noqa
-def test_add_help_plugin(tmpdir, docker_tasker, filename):
+def test_add_help_plugin(tmpdir, docker_tasker, workflow, filename):
     df_content = dedent("""
         FROM fedora
         RUN yum install -y python-django
@@ -57,7 +55,6 @@ def test_add_help_plugin(tmpdir, docker_tasker, filename):
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)
@@ -94,12 +91,11 @@ def test_add_help_plugin(tmpdir, docker_tasker, filename):
 
 
 @pytest.mark.parametrize('filename', ['help.md', 'other_file.md'])  # noqa
-def test_add_help_no_help_file(request, tmpdir, docker_tasker, filename):
+def test_add_help_no_help_file(workflow, tmpdir, docker_tasker, filename):
     df_content = "FROM fedora"
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     runner = PreBuildPluginsRunner(
@@ -122,13 +118,12 @@ def test_add_help_no_help_file(request, tmpdir, docker_tasker, filename):
 @pytest.mark.parametrize('go_md2man_result', [
     'binary_missing', 'input_missing', 'other_os_error',
     'result_missing', 'fail', 'pass'])
-def test_add_help_md2man_error(request, tmpdir, docker_tasker, filename,
+def test_add_help_md2man_error(workflow, tmpdir, docker_tasker, filename,
                                go_md2man_result, caplog):
     df_content = "FROM fedora"
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)
@@ -230,7 +225,7 @@ def test_add_help_md2man_error(request, tmpdir, docker_tasker, filename,
 
 
 @pytest.mark.parametrize('filename', ['help.md', 'other_file.md'])  # noqa
-def test_add_help_generate_metadata(tmpdir, docker_tasker, filename):
+def test_add_help_generate_metadata(tmpdir, docker_tasker, workflow, filename):
     df_content = dedent("""\
         FROM fedora
         LABEL name='test' \\
@@ -240,7 +235,6 @@ def test_add_help_generate_metadata(tmpdir, docker_tasker, filename):
     df = df_parser(str(tmpdir))
     df.content = df_content
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = StubInsideBuilder().set_df_path(df.dockerfile_path)
 
     help_markdown_path = os.path.join(workflow.builder.df_dir, filename)

--- a/tests/plugins/test_add_yum_repo_by_url.py
+++ b/tests/plugins/test_add_yum_repo_by_url.py
@@ -41,7 +41,8 @@ def prepare(scratch=False):
     build_json = {'metadata': {'labels': {'scratch': scratch}}}
     flexmock(util).should_receive('get_build_json').and_return(build_json)
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": DOCKERFILE_GIT}, "test-image")
+    workflow = DockerBuildWorkflow(
+        "test-image", source={"provider": "git", "uri": DOCKERFILE_GIT})
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
     (flexmock(requests.Response, content=repocontent)

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -57,7 +57,7 @@ class MockInsideBuilder(object):
 
 
 def mock_workflow(tmpdir, source_containers_conf=None):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=MOCK_SOURCE)
     builder = MockInsideBuilder()
     source = MockSource(tmpdir)
     setattr(builder, 'source', source)

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -32,7 +32,7 @@ def mock_workflow():
     matter should provide their own.
     """
 
-    workflow = DockerBuildWorkflow(SOURCE, "mock:default_built")
+    workflow = DockerBuildWorkflow("mock:default_built", source=SOURCE)
     workflow.source = StubSource()
     builder = StubInsideBuilder().for_workflow(workflow)
     builder.set_df_path('/mock-path')

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -117,7 +117,7 @@ def prepare(tmpdir):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     setattr(workflow, 'builder', X())
     source = MockSource(tmpdir)
 

--- a/tests/plugins/test_check_and_set_rebuild.py
+++ b/tests/plugins/test_check_and_set_rebuild.py
@@ -60,7 +60,7 @@ class TestCheckRebuild(object):
             mock_docker()
         tasker = DockerTasker()
 
-        workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+        workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
         workflow.builder = MockInsideBuilder(tmpdir)
         workflow.builder.base_from_scratch = base_from_scratch
         workflow.builder.custom_base_image = custom_base

--- a/tests/plugins/test_compare_components.py
+++ b/tests/plugins/test_compare_components.py
@@ -71,7 +71,7 @@ class MockInsideBuilder(object):
 
 
 def mock_workflow(tmpdir):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=MOCK_SOURCE)
     setattr(workflow, 'builder', MockInsideBuilder())
     setattr(workflow, 'source', MockSource(tmpdir))
     setattr(workflow.builder, 'source', MockSource(tmpdir))

--- a/tests/plugins/test_compress.py
+++ b/tests/plugins/test_compress.py
@@ -45,7 +45,10 @@ class TestCompress(object):
             mock_docker()
 
         tasker = DockerTasker()
-        workflow = DockerBuildWorkflow({'provider': 'git', 'uri': 'asd'}, 'test-image')
+        workflow = DockerBuildWorkflow(
+            'test-image',
+            source={'provider': 'git', 'uri': 'asd'}
+        )
         workflow.builder = X()
         exp_img = os.path.join(str(tmpdir), 'img.tar')
 

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -16,13 +16,11 @@ from dockerfile_parse import DockerfileParser
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.build import InsideBuilder, BuildResult
 from atomic_reactor.util import ImageName, CommandResult
-from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
 
 from tests.docker_mock import mock_docker
 from flexmock import flexmock
 import pytest
-from tests.constants import MOCK_SOURCE
 
 
 def mock_docker_tasker(docker_tasker):
@@ -77,7 +75,7 @@ class MockInsideBuilder(object):
     False,
 ])
 @pytest.mark.parametrize('image_id', ['sha256:12345', '12345'])
-def test_build(docker_tasker, is_failed, image_id):
+def test_build(docker_tasker, workflow, is_failed, image_id):
     """
     tests docker build api plugin working
     """
@@ -88,7 +86,6 @@ def test_build(docker_tasker, is_failed, image_id):
     mock_docker_tasker(docker_tasker)
     flexmock(InsideBuilder).new_instances(fake_builder)
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     flexmock(CommandResult).should_receive('is_failed').and_return(is_failed)
     error = "error message"
     error_detail = "{u'message': u\"%s\"}" % error
@@ -112,7 +109,7 @@ def test_build(docker_tasker, is_failed, image_id):
         assert workflow.build_result.image_id.count(':') == 1
 
 
-def test_syntax_error(docker_tasker):
+def test_syntax_error(docker_tasker, workflow):
     """
     tests reporting of syntax errors
     """
@@ -133,7 +130,6 @@ def test_syntax_error(docker_tasker):
 
     fake_builder.tasker.build_image_from_path = raise_exc
     flexmock(InsideBuilder).new_instances(fake_builder)
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     with pytest.raises(PluginFailedException):
         workflow.build_docker_image()
 

--- a/tests/plugins/test_download_remote_source.py
+++ b/tests/plugins/test_download_remote_source.py
@@ -24,8 +24,10 @@ from atomic_reactor.plugins.pre_download_remote_source import (
 class TestDownloadRemoteSource(object):
     @responses.activate
     def test_download_remote_source(self, docker_tasker):
-        workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"},
-                                       TEST_IMAGE)
+        workflow = DockerBuildWorkflow(
+            TEST_IMAGE,
+            source={"provider": "git", "uri": "asd"},
+        )
         workflow.builder = StubInsideBuilder().for_workflow(workflow)
         filename = 'source.tar.gz'
         url = 'https://example.com/dir/{}'.format(filename)

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -43,7 +43,10 @@ def mock_dockerfile(tmpdir, has_label=True, label=True):
 
 
 def mock_workflow(tmpdir, for_orchestrator=False):
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"}
+    )
     workflow.source = StubSource()
     builder = StubInsideBuilder().for_workflow(workflow)
     builder.set_df_path(str(tmpdir))

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -294,7 +294,7 @@ def mock_koji_session(koji_proxyuser=None, koji_ssl_certs_dir=None,
 
 
 def mock_workflow(tmpdir):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     mock_source = MockSource(tmpdir)
     setattr(workflow, 'builder', X)
     workflow.builder.source = mock_source

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -83,7 +83,10 @@ class MockSource(StubSource):
 
 
 def mock_workflow(tmpdir, for_orchestrator=False, default_si=DEFAULT_SIGNING_INTENT):
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"}
+    )
     workflow.source = MockSource(str(tmpdir))
     builder = StubInsideBuilder().for_workflow(workflow)
     builder.set_df_path(str(tmpdir))

--- a/tests/plugins/test_fetch_worker.py
+++ b/tests/plugins/test_fetch_worker.py
@@ -81,7 +81,7 @@ class MockInsideBuilder(object):
 
 
 def mock_workflow(tmpdir):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=MOCK_SOURCE)
     setattr(workflow, 'builder', MockInsideBuilder())
     setattr(workflow, 'source', MockSource(tmpdir))
     setattr(workflow.builder, 'source', MockSource(tmpdir))

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -62,7 +62,7 @@ class MockBuilder(object):
 
 
 def mock_workflow(tmpdir, container_yaml):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     mock_source = MockSource(tmpdir)
     setattr(workflow, 'builder', MockBuilder())
     workflow.builder.source = mock_source

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -493,7 +493,10 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, flatpak_metadata
 
     config = CONFIGS[config_name]
 
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"}
+    )
     setattr(workflow, 'builder', X)
     X.df_path = write_docker_file(config, str(tmpdir))
     setattr(workflow.builder, 'tasker', docker_tasker)

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -308,7 +308,7 @@ def mock_environment(tmpdir, primary_images=None,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     base_image_id = '123456parent-id'
     setattr(workflow, '_base_image_inspect', {'Id': base_image_id})
     setattr(workflow, 'builder', StubInsideBuilder())

--- a/tests/plugins/test_hide_files.py
+++ b/tests/plugins/test_hide_files.py
@@ -236,7 +236,7 @@ class TestHideFilesPlugin(object):
         if MOCK:
             mock_docker()
         tasker = DockerTasker()
-        workflow = DockerBuildWorkflow(SOURCE, "test-image")
+        workflow = DockerBuildWorkflow("test-image", source=SOURCE)
         workflow.source = MockSource(df_path)
         workflow.builder = (StubInsideBuilder()
                             .for_workflow(workflow)

--- a/tests/plugins/test_import_image.py
+++ b/tests/plugins/test_import_image.py
@@ -66,7 +66,7 @@ def prepare(tmpdir, insecure_registry=None, namespace=None,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     setattr(workflow, 'builder', X())
     flexmock(workflow, build_process_failed=build_process_failed)
     setattr(workflow.builder, 'image_id', 'asd123')

--- a/tests/plugins/test_inject_parent_image.py
+++ b/tests/plugins/test_inject_parent_image.py
@@ -27,7 +27,6 @@ except ImportError:
     import koji as koji
 
 from atomic_reactor.core import DockerTasker
-from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_inject_parent_image import InjectParentImage
 from atomic_reactor.plugins.exit_remove_built_image import GarbageCollectionPlugin
@@ -36,7 +35,7 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig)
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
-from tests.constants import MOCK, MOCK_SOURCE
+from tests.constants import MOCK
 from osbs.utils import graceful_chain_del
 
 import copy
@@ -96,10 +95,9 @@ class MockInsideBuilder(object):
 
 
 @pytest.fixture()
-def workflow():
+def workflow(workflow):
     if MOCK:
         mock_docker()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = MockInsideBuilder()
     setattr(workflow.builder, 'base_image_inspect', {})
 

--- a/tests/plugins/test_koji.py
+++ b/tests/plugins/test_koji.py
@@ -108,7 +108,7 @@ def prepare():
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -244,7 +244,7 @@ def mock_environment(tmpdir, session=None, name=None,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     base_image_id = '123456parent-id'
 
     workflow.source = StubSource()

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -116,7 +116,7 @@ class MockInsideBuilder(InsideBuilder):
 def workflow():
     if MOCK:
         mock_docker()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     workflow.builder = MockInsideBuilder()
     base_inspect = {INSPECT_CONFIG: {'Labels': BASE_IMAGE_LABELS.copy()}}
     flexmock(workflow.builder, base_image_inspect=base_inspect)

--- a/tests/plugins/test_koji_promote.py
+++ b/tests/plugins/test_koji_promote.py
@@ -221,7 +221,7 @@ def mock_environment(tmpdir, session=None, name=None,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     base_image_id = '123456parent-id'
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)

--- a/tests/plugins/test_koji_tag_build.py
+++ b/tests/plugins/test_koji_tag_build.py
@@ -102,7 +102,7 @@ def mock_environment(tmpdir, session=None, build_process_failed=False,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=SOURCE)
     setattr(workflow, 'builder', X())
     setattr(workflow.builder, 'image_id', '123456imageid')
     setattr(workflow.builder, 'base_image', ImageName(repo='Fedora', tag='22'))

--- a/tests/plugins/test_koji_upload.py
+++ b/tests/plugins/test_koji_upload.py
@@ -262,7 +262,7 @@ def mock_environment(tmpdir, session=None, name=None,
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     base_image_id = '123456parent-id'
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -124,7 +124,7 @@ class fake_manifest_list(object):
 
 
 def mock_workflow(tmpdir, platforms=None):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=MOCK_SOURCE)
     builder = MockInsideBuilder()
     source = MockSource(tmpdir)
     setattr(builder, 'source', source)

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -121,7 +121,11 @@ def test_pull_base_image_special(add_another_parent, special_image, change_base,
         'name': PLUGIN_BUILD_ORCHESTRATE_KEY,
         'args': {'platforms': ['x86_64']},
     }]
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, special_image, buildstep_plugins=buildstep_plugin,)
+    workflow = DockerBuildWorkflow(
+        special_image,
+        source=MOCK_SOURCE,
+        buildstep_plugins=buildstep_plugin,
+    )
     builder = workflow.builder = MockBuilder()
     builder.parent_images = {}
     builder.set_base_image(special_image)
@@ -237,7 +241,11 @@ def test_pull_base_image_plugin(parent_registry, df_base, expected, not_expected
         'args': {'platforms': ['x86_64']},
     }]
     parent_images = parent_images or {ImageName.parse(df_base): None}
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image', buildstep_plugins=buildstep_plugin,)
+    workflow = DockerBuildWorkflow(
+        'test-image',
+        source=MOCK_SOURCE,
+        buildstep_plugins=buildstep_plugin,
+    )
     builder = workflow.builder = MockBuilder()
     builder.base_image = builder.original_base_image = ImageName.parse(df_base)
     builder.parent_images = parent_images
@@ -440,12 +448,11 @@ def test_pull_base_autorebuild(monkeypatch, reactor_config_map, inspect_only):  
     (docker.errors.NotFound, 25, False),
     (RuntimeError, 1, False),
 ])
-def test_retry_pull_base_image(exc, failures, should_succeed, reactor_config_map):
+def test_retry_pull_base_image(workflow, exc, failures, should_succeed, reactor_config_map):
     if MOCK:
         mock_docker(remember_images=True)
 
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = MockBuilder()
     workflow.builder.base_image = ImageName.parse('parent-image')
 
@@ -483,12 +490,11 @@ def test_retry_pull_base_image(exc, failures, should_succeed, reactor_config_map
 
 
 @pytest.mark.parametrize('library', [True, False])
-def test_try_with_library_pull_base_image(library, reactor_config_map):
+def test_try_with_library_pull_base_image(workflow, library, reactor_config_map):
     if MOCK:
         mock_docker(remember_images=True)
 
     tasker = DockerTasker(retry_times=0)
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = MockBuilder()
 
     if library:

--- a/tests/plugins/test_push_operator_manifest.py
+++ b/tests/plugins/test_push_operator_manifest.py
@@ -66,7 +66,10 @@ class MockSource(StubSource):
 
 
 def mock_workflow(tmpdir, for_orchestrator=False):
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"},
+    )
     workflow.source = MockSource(str(tmpdir))
     builder = StubInsideBuilder().for_workflow(workflow)
     builder.set_df_path(str(tmpdir))

--- a/tests/plugins/test_pyrpkg_fetch_artefacts.py
+++ b/tests/plugins/test_pyrpkg_fetch_artefacts.py
@@ -11,13 +11,12 @@ from __future__ import unicode_literals, absolute_import
 import pytest
 import os
 
-from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins import pre_pyrpkg_fetch_artefacts
 from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from atomic_reactor.util import ImageName
 from flexmock import flexmock
-from tests.constants import INPUT_IMAGE, MOCK_SOURCE
+from tests.constants import INPUT_IMAGE
 
 
 class Y(object):
@@ -31,11 +30,10 @@ class X(object):
     base_image = ImageName.parse('asd')
 
 
-def test_distgit_fetch_artefacts_plugin(tmpdir, docker_tasker):  # noqa
+def test_distgit_fetch_artefacts_plugin(tmpdir, docker_tasker, workflow):  # noqa
     command = 'fedpkg sources'
     expected_command = ['fedpkg', 'sources']
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = X()
     workflow.source = flexmock(path=str(tmpdir))
 
@@ -64,11 +62,10 @@ def test_distgit_fetch_artefacts_plugin(tmpdir, docker_tasker):  # noqa
     assert os.getcwd() == initial_dir
 
 
-def test_distgit_fetch_artefacts_failure(tmpdir, docker_tasker):  # noqa
+def test_distgit_fetch_artefacts_failure(tmpdir, docker_tasker, workflow):  # noqa
     command = 'fedpkg sources'
     expected_command = ['fedpkg', 'sources']
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.builder = X()
     workflow.source = flexmock(path=str(tmpdir))
 

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -59,8 +59,10 @@ class TestReactorConfigPlugin(object):
     def prepare(self):
         mock_docker()
         tasker = ContainerTasker()
-        workflow = DockerBuildWorkflow({'provider': 'git', 'uri': 'asd'},
-                                       TEST_IMAGE)
+        workflow = DockerBuildWorkflow(
+            TEST_IMAGE,
+            source={'provider': 'git', 'uri': 'asd'},
+        )
         workflow.builder = StubInsideBuilder()
         workflow.builder.tasker = tasker
         return tasker, workflow

--- a/tests/plugins/test_remove_built_image.py
+++ b/tests/plugins/test_remove_built_image.py
@@ -37,8 +37,10 @@ def mock_environment(base_image=None):
         mock_docker()
 
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"},
-                                   TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"},
+    )
     workflow.postbuild_results[TagAndPushPlugin.key] = True
     workflow.tag_conf.add_primary_image(TEST_IMAGE)
     workflow.push_conf.add_docker_registry(LOCALHOST_REGISTRY, insecure=True)

--- a/tests/plugins/test_remove_worker_metadata.py
+++ b/tests/plugins/test_remove_worker_metadata.py
@@ -81,7 +81,7 @@ class MockInsideBuilder(object):
 
 
 def mock_workflow(tmpdir):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=MOCK_SOURCE)
     setattr(workflow, 'builder', MockInsideBuilder())
     setattr(workflow, 'source', MockSource(tmpdir))
     setattr(workflow.builder, 'source', MockSource(tmpdir))

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -120,7 +120,11 @@ def workflow(tmpdir):
             'platforms': ODCS_COMPOSE_DEFAULT_ARCH_LIST
         },
     }]
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image', buildstep_plugins=buildstep_plugin, )
+    workflow = DockerBuildWorkflow(
+        'test-image',
+        source=MOCK_SOURCE,
+        buildstep_plugins=buildstep_plugin,
+    )
     workflow.builder = MockInsideBuilder(tmpdir)
     workflow.source = workflow.builder.source
     workflow._tmpdir = tmpdir

--- a/tests/plugins/test_resolve_module_compose.py
+++ b/tests/plugins/test_resolve_module_compose.py
@@ -88,7 +88,7 @@ class MockBuilder(object):
 
 
 def mock_workflow(tmpdir):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     mock_source = MockSource(tmpdir)
     setattr(workflow, 'builder', MockBuilder())
     workflow.builder.source = mock_source

--- a/tests/plugins/test_rpmqa.py
+++ b/tests/plugins/test_rpmqa.py
@@ -78,7 +78,7 @@ def test_rpmqa_plugin(caplog, docker_tasker, base_from_scratch, remove_container
         should_raise_error['remove_container'] = None
     mock_docker(should_raise_error=should_raise_error)
 
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
     workflow.builder.set_base_from_scratch(base_from_scratch)
@@ -108,7 +108,7 @@ def test_rpmqa_plugin_skip(docker_tasker):  # noqa
     Test skipping the plugin if workflow.image_components is already set
     """
     mock_docker()
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
 
@@ -129,7 +129,7 @@ def test_rpmqa_plugin_skip(docker_tasker):  # noqa
 
 def test_rpmqa_plugin_exception(docker_tasker):  # noqa
     mock_docker()
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
 
@@ -144,7 +144,7 @@ def test_rpmqa_plugin_exception(docker_tasker):  # noqa
 def test_dangling_volumes_removed(docker_tasker, caplog):
 
     mock_docker()
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
     workflow.builder.set_base_from_scratch(False)
@@ -171,7 +171,7 @@ def test_dangling_volumes_removed(docker_tasker, caplog):
 
 def test_empty_logs_retry(docker_tasker):  # noqa
     mock_docker()
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
     workflow.builder.set_base_from_scratch(False)
@@ -188,7 +188,7 @@ def test_empty_logs_retry(docker_tasker):  # noqa
 
 def test_empty_logs_failure(docker_tasker):  # noqa
     mock_docker()
-    workflow = DockerBuildWorkflow(SOURCE, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(TEST_IMAGE, source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder().for_workflow(workflow)
     workflow.builder.set_base_from_scratch(False)

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -71,7 +71,7 @@ class TestSquashPlugin(object):
     def setup_method(self, method):
         if MOCK:
             mock_docker()
-        self.workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+        self.workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
         self.workflow.builder = MockInsideBuilder()
         self.tasker = self.workflow.builder.tasker
 

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -123,7 +123,10 @@ def prepare(docker_registries=None, before_dockerfile=False,  # noqa
     flexmock(os)
     os.should_receive("environ").and_return(new_environ)  # pylint: disable=no-member
 
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, "test-image")
+    workflow = DockerBuildWorkflow(
+        "test-image",
+        source={"provider": "git", "uri": "asd"},
+    )
 
     if reactor_config_map:
         openshift_map = {

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -128,7 +128,10 @@ def test_tag_and_push_plugin(
                  login=lambda username, registry, dockercfg_path: {'Status': 'Login Succeeded'})
 
     tasker = DockerTasker(retry_times=0)
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"},
+    )
     workflow.tag_conf.add_primary_image(image_name)
     workflow.builder = StubInsideBuilder()
     workflow.builder.image_id = INPUT_IMAGE
@@ -373,7 +376,10 @@ def test_tag_and_push_plugin_oci(tmpdir, monkeypatch, source_oci_image_path, use
                                            current_platform)
 
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow({"provider": "git", "uri": "asd"}, TEST_IMAGE)
+    workflow = DockerBuildWorkflow(
+        TEST_IMAGE,
+        source={"provider": "git", "uri": "asd"},
+    )
     workflow.builder = StubInsideBuilder()
     workflow.builder.image_id = INPUT_IMAGE
     if source_oci_image_path and reactor_config_map:

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -63,7 +63,7 @@ def mock_workflow(tmpdir):
     if MOCK:
         mock_docker()
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
     mock_source = MockSource(tmpdir)
     setattr(workflow, 'builder', X)
     workflow.builder.source = mock_source

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -40,7 +40,7 @@ def prepare(df_path, inherited_user=''):
     if MOCK:
         mock_docker()
     tasker = DockerTasker()
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     workflow.source = StubSource()
     workflow.builder = (StubInsideBuilder()
                         .for_workflow(workflow)

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -378,7 +378,7 @@ def test_workflow_base_images():
     watch_buildstep = Watcher()
     watch_post = Watcher()
     watch_exit = Watcher()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=[{'name': 'pre_watched',
                                                       'args': {
                                                           'watcher': watch_pre
@@ -427,7 +427,7 @@ def test_workflow_compat(caplog):
 
     caplog.clear()
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    postbuild_plugins=[{'name': 'store_logs_to_file',
                                                        'args': {
                                                            'watcher': watch_exit
@@ -681,7 +681,7 @@ def test_plugin_errors(plugins, should_fail, should_log, caplog):
     flexmock(InsideBuilder).new_instances(fake_builder)
 
     caplog.clear()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    plugin_files=[this_file],
                                    **plugins)
 
@@ -730,7 +730,7 @@ def test_autorebuild_stop_prevents_build():
     watch_prepub = Watcher()
     watch_post = Watcher()
     watch_exit = Watcher()
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=[{'name': 'stopstopstop',
                                                       'args': {
                                                       }}],
@@ -818,7 +818,7 @@ def test_workflow_plugin_error(fail_at):
         # Typo in the parameter list?
         assert False
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=prebuild_plugins,
                                    buildstep_plugins=buildstep_plugins,
                                    prepublish_plugins=prepublish_plugins,
@@ -879,7 +879,7 @@ def test_workflow_docker_build_error():
     watch_post = Watcher()
     watch_exit = Watcher()
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=[{'name': 'pre_watched',
                                                       'args': {
                                                           'watcher': watch_pre
@@ -955,7 +955,7 @@ def test_workflow_docker_build_error_reports(steps_to_fail, step_reported):
     watch_post = construct_watcher('post')
     watch_exit = construct_watcher('exit')
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=[{'name': 'pre_watched',
                                                       'is_allowed_to_fail': False,
                                                       'args': {
@@ -1005,7 +1005,7 @@ def test_source_not_removed_for_exit_plugins():
     flexmock(InsideBuilder).new_instances(fake_builder)
     watch_exit = Watcher()
     watch_buildstep = Watcher()
-    workflow = DockerBuildWorkflow(SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=SOURCE,
                                    exit_plugins=[{'name': 'uses_source',
                                                   'args': {
                                                       'watcher': watch_exit,
@@ -1148,7 +1148,7 @@ def test_workflow_plugin_results(buildstep_plugin, buildstep_raises):
     prepublish_plugins = [{'name': 'pre_publish_value'}]
     exit_plugins = [{'name': 'exit_value'}]
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=prebuild_plugins,
                                    buildstep_plugins=buildstep_plugins,
                                    prepublish_plugins=prepublish_plugins,
@@ -1196,7 +1196,7 @@ def test_cancel_build(fail_at, caplog):
 
     caplog.clear()
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=[{'name': 'pre_watched',
                                                       'args': {
                                                           'watcher': watch_pre
@@ -1283,7 +1283,7 @@ def test_buildstep_alias(buildstep_alias, buildstep_plugin):
           docker_api: imagebuilder
         """)
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    prebuild_plugins=prebuild_plugins,
                                    buildstep_plugins=buildstep_plugins,
                                    prepublish_plugins=prepublish_plugins,
@@ -1328,7 +1328,7 @@ def test_show_version(has_version, caplog):
     if has_version:
         params['client_version'] = VERSION
 
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image', **params)
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE, **params)
     workflow.build_docker_image()
     expected_log_message = "build json was built by osbs-client {}".format(VERSION)
     assert any(
@@ -1346,7 +1346,7 @@ def test_layer_sizes():
     flexmock(InsideBuilder).new_instances(fake_builder)
     watch_exit = Watcher()
     watch_buildstep = Watcher()
-    workflow = DockerBuildWorkflow(SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=SOURCE,
                                    exit_plugins=[{'name': 'uses_source',
                                                   'args': {
                                                       'watcher': watch_exit,
@@ -1379,7 +1379,7 @@ def test_layer_sizes():
       {'name': PLUGIN_BUILD_ORCHESTRATE_KEY}], True)
 ])
 def test_workflow_is_orchestrator_build(buildstep_plugins, is_orchestrator):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    buildstep_plugins=buildstep_plugins)
     assert workflow.is_orchestrator_build() == is_orchestrator
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -63,7 +63,7 @@ def mock_workflow(tmpdir):
     if MOCK:
         mock_docker()
 
-    workflow = DockerBuildWorkflow(SOURCE, 'test-image')
+    workflow = DockerBuildWorkflow('test-image', source=SOURCE)
     setattr(workflow, 'builder', X())
     flexmock(DockerfileParser, content='df_content')
     setattr(workflow.builder, 'get_built_image_info', flexmock())
@@ -106,7 +106,7 @@ class X(object):
 
 
 def test_prebuild_plugin_failure(docker_tasker):  # noqa
-    workflow = DockerBuildWorkflow(SOURCE, "test-image")
+    workflow = DockerBuildWorkflow("test-image", source=SOURCE)
     setattr(workflow, 'builder', X())
     setattr(workflow.builder, 'image_id', "asd123")
     setattr(workflow.builder, 'base_image', ImageName(repo='fedora', tag='21'))

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -12,7 +12,8 @@ from atomic_reactor.source import (
     SourceConfig,
     GitSource,
     PathSource,
-    get_source_instance_for
+    get_source_instance_for,
+    DummySource,
 )
 import atomic_reactor.source
 from jsonschema import ValidationError
@@ -297,3 +298,14 @@ class TestSourceConfigSchemaValidation(object):
     def test_invalid_source_config_validation_error(self, tmpdir, yml_config):
         with pytest.raises(jsonschema.ValidationError):
             self._create_source_config(tmpdir, yml_config)
+
+
+def test_dummy_source_dockerfile():
+    """Test of DummySource used for source container builds
+
+    Test if fake Dockerfile was properly injected to meet expectations of
+    inner and core codebase
+    """
+    ds = DummySource(None, None)
+    assert ds.get()
+    assert os.path.exists(os.path.join(ds.get(), 'Dockerfile'))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -945,7 +945,7 @@ def test_is_isolated_build(build_json, isolated):
      ['arm64', 'ppce64le'])
 ])
 def test_get_orchestrator_platforms(inputs, results):
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image',
+    workflow = DockerBuildWorkflow('test-image', source=MOCK_SOURCE,
                                    buildstep_plugins=inputs)
     if results:
         assert sorted(get_orchestrator_platforms(workflow)) == sorted(results)
@@ -989,14 +989,13 @@ def test_df_parser_parent_env_arg(tmpdir):
     ['test_env=--option=first --option=second'],
     ['test_env_first'],
 ])
-def test_df_parser_parent_env_wf(tmpdir, caplog, env_arg):
+def test_df_parser_parent_env_wf(tmpdir, workflow, caplog, env_arg):
     df_content = dedent("""\
         FROM fedora
         ENV foo=bar
         LABEL label="foobar $test_env"
         """)
     env_conf = {INSPECT_CONFIG: {"Env": env_arg}}
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
     workflow.source = StubSource()
     workflow.builder = StubInsideBuilder()
     workflow.builder.set_inspection_data(env_conf)
@@ -1060,10 +1059,9 @@ def test_label_formatter(labels, test_string, expected):
 
     (['spam', 'bacon'], ['ignored', 'scorned'], [], ['spam', 'bacon'], []),
 ))
-def test_get_primary_and_floating_images(tag_conf, tag_annotation, expected_primary,
+def test_get_primary_and_floating_images(workflow, tag_conf, tag_annotation, expected_primary,
                                          expected_floating, expected_unique):
     template_image = ImageName.parse('registry.example.com/fedora')
-    workflow = DockerBuildWorkflow(MOCK_SOURCE, 'test-image')
 
     for tag in tag_conf:
         image_name = ImageName.parse(str(template_image))


### PR DESCRIPTION

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
