### PR TITLE
Allow fetching SRPMs from different koji instance

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -54,8 +54,16 @@ def get_value(workflow, name, fallback):
         raise
 
 
-def get_koji(workflow, fallback=NO_FALLBACK):
-    koji_map = get_value(workflow, 'koji', fallback)
+def get_koji(workflow, fallback=NO_FALLBACK, instance='default'):
+    default_instance = 'koji'
+    instances = {
+        'default': default_instance,
+        'sources': 'koji_for_sources'
+    }
+
+    instance = instances.get(instance, default_instance)
+
+    koji_map = get_value(workflow, instance, fallback)
 
     if 'auth' in koji_map:
         krb_principal = koji_map['auth'].get('krb_principal')
@@ -66,8 +74,8 @@ def get_koji(workflow, fallback=NO_FALLBACK):
     return koji_map
 
 
-def get_koji_session(workflow, fallback):
-    config = get_koji(workflow, fallback)
+def get_koji_session(workflow, fallback, instance='default'):
+    config = get_koji(workflow, fallback, instance)
 
     from atomic_reactor.koji_util import create_koji_session
 
@@ -83,8 +91,8 @@ def get_koji_session(workflow, fallback):
     return create_koji_session(config['hub_url'], auth_info, use_fast_upload)
 
 
-def get_koji_path_info(workflow, fallback):
-    config = get_koji(workflow, fallback)
+def get_koji_path_info(workflow, fallback, instance='default'):
+    config = get_koji(workflow, fallback, instance)
     from koji import PathInfo
 
     # Make sure koji root_url doesn't end with a slash since the url

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -44,90 +44,8 @@
       "description": "Path to directory with osbs.conf for communicating with workers",
       "type": "string"
     },
-    "koji": {
-        "description": "Koji instance",
-        "type": "object",
-        "properties": {
-            "hub_url": {
-                "description": "Koji hub's xmlrpc url",
-                "type": "string"
-            },
-            "root_url": {
-                "description": "Koji's root storage url",
-                "type": "string"
-            },
-            "auth": {
-                "description": "Authentication information",
-                "type": "object",
-                "anyOf": [
-                    {
-                        "properties": {
-                            "proxyuser": {"$ref": "#/definitions/proxyuser"},
-                            "ssl_certs_dir": {
-                                "description": "Path to directory with cert and ca files",
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": ["ssl_certs_dir"]
-                    },
-
-                    {
-                        "properties": {
-                            "proxyuser": {"$ref": "#/definitions/proxyuser"},
-                            "krb_cache_path": {
-                                "description": "Path to kerberos credential cache file",
-                                "type": "string"
-                            },
-                            "krb_principal": {
-                                "description": "Kerberos principal",
-                                "type": "string"
-                            },
-                            "krb_keytab_path": {
-                                "description": "Location of Kerberos keytab, e.g. FILE:<absolute_path>",
-                                "type": "string"
-                            }
-                        },
-                        "additionalProperties": false,
-                        "required": ["krb_principal", "krb_keytab_path"]
-                    },
-
-                    {
-                        "properties": {
-                            "proxyuser": {"$ref": "#/definitions/proxyuser"}
-                        },
-                        "additionalProperties": false
-                    }
-                ]
-            },
-            "use_fast_upload": {
-                "description": "Use Koji's fast upload API",
-                "type": "boolean",
-                "default": true
-            },
-            "reserve_build": {
-                "description": "Reserve build id and NVR through Content Generator API. If set, requires koji > 1.17.0",
-                "type": "boolean",
-                "default": false
-            },
-            "insecure_download": {
-                "description": "Download data from koji insecurely",
-                "type": "boolean",
-                "default": false
-            },
-            "delegate_task": {
-                "description": "Autorebuild will create new intermediate task, instead of using original task",
-                "type": "boolean",
-                "default": true
-            },
-            "delegated_task_priority": {
-                "description": "When delegate_build is enabled, delegated task will use this koji task priority, if not set it will use default koji priority",
-                "type": "integer"
-            }
-        },
-        "additionalProperties": false,
-        "required": ["hub_url", "root_url", "auth"]
-    },
+    "koji": {"$ref": "#/definitions/koji"},
+    "koji_for_sources": {"$ref": "#/definitions/koji"},
     "pulp": {
         "description": "Pulp registry instance (deprecated)",
         "type": "object",
@@ -640,6 +558,90 @@
     }
   },
   "definitions": {
+    "koji": {
+        "description": "Koji instance",
+        "type": "object",
+        "properties": {
+            "hub_url": {
+                "description": "Koji hub's xmlrpc url",
+                "type": "string"
+            },
+            "root_url": {
+                "description": "Koji's root storage url",
+                "type": "string"
+            },
+            "auth": {
+                "description": "Authentication information",
+                "type": "object",
+                "anyOf": [
+                    {
+                        "properties": {
+                            "proxyuser": {"$ref": "#/definitions/proxyuser"},
+                            "ssl_certs_dir": {
+                                "description": "Path to directory with cert and ca files",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["ssl_certs_dir"]
+                    },
+
+                    {
+                        "properties": {
+                            "proxyuser": {"$ref": "#/definitions/proxyuser"},
+                            "krb_cache_path": {
+                                "description": "Path to kerberos credential cache file",
+                                "type": "string"
+                            },
+                            "krb_principal": {
+                                "description": "Kerberos principal",
+                                "type": "string"
+                            },
+                            "krb_keytab_path": {
+                                "description": "Location of Kerberos keytab, e.g. FILE:<absolute_path>",
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": ["krb_principal", "krb_keytab_path"]
+                    },
+
+                    {
+                        "properties": {
+                            "proxyuser": {"$ref": "#/definitions/proxyuser"}
+                        },
+                        "additionalProperties": false
+                    }
+                ]
+            },
+            "use_fast_upload": {
+                "description": "Use Koji's fast upload API",
+                "type": "boolean",
+                "default": true
+            },
+            "reserve_build": {
+                "description": "Reserve build id and NVR through Content Generator API. If set, requires koji > 1.17.0",
+                "type": "boolean",
+                "default": false
+            },
+            "insecure_download": {
+                "description": "Download data from koji insecurely",
+                "type": "boolean",
+                "default": false
+            },
+            "delegate_task": {
+                "description": "Autorebuild will create new intermediate task, instead of using original task",
+                "type": "boolean",
+                "default": true
+            },
+            "delegated_task_priority": {
+                "description": "When delegate_build is enabled, delegated task will use this koji task priority, if not set it will use default koji priority",
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["hub_url", "root_url", "auth"]
+    },
     "enable": {
        "description": "Enable authentication",
        "type": "boolean"


### PR DESCRIPTION
* OSBS-8242

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
