### PR TITLE
Use podman as testing container engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,38 @@ env:
       OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=2
+      ENGINE=docker
     - ACTION=bandit
       OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=3
+      ENGINE=docker
     - ACTION=pylint
       OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=2
+      ENGINE=docker
     - ACTION=pylint
       OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=3
+      ENGINE=docker
     - OS=centos
       OS_VERSION=7
       PYTHON_VERSION=2
+      ENGINE=docker
     - OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=2
+      ENGINE=docker
     - OS=fedora
       OS_VERSION=29
       PYTHON_VERSION=3
+      ENGINE=docker
     - OS=fedora
       OS_VERSION=30
       PYTHON_VERSION=3
+      ENGINE=docker
 install:
   - pip install coveralls
 script:


### PR DESCRIPTION
Add an ENGINE env var to set the container engine to be used to run the
test suite. Set podman as the default engine and keep the CI running on
docker.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
