### PR TITLE
pass buildargs to build container

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -181,6 +181,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         self.df_dir = build_file_dir
         self._df_path = None
         self.original_df = None
+        self.buildargs = {}  # --buildargs for container build
 
         # If the Dockerfile will be entirely generated from the container.yaml
         # (in the Flatpak case, say), then a plugin needs to create the Dockerfile

--- a/atomic_reactor/plugins/build_docker_api.py
+++ b/atomic_reactor/plugins/build_docker_api.py
@@ -40,7 +40,7 @@ class DockerApiPlugin(BuildStepPlugin):
 
         allow_repo_dir_in_dockerignore(builder.df_dir)
         logs_gen = self.tasker.build_image_from_path(builder.df_dir,
-                                                     builder.image)
+                                                     builder.image, buildargs=builder.buildargs)
 
         self.log.debug('build is submitted, waiting for it to finish')
         try:

--- a/atomic_reactor/plugins/build_imagebuilder.py
+++ b/atomic_reactor/plugins/build_imagebuilder.py
@@ -44,7 +44,13 @@ class ImagebuilderPlugin(BuildStepPlugin):
             kwargs.update(encoding_params)
 
         allow_repo_dir_in_dockerignore(builder.df_dir)
-        ib_process = subprocess.Popen(['imagebuilder', '-t', image, builder.df_dir], **kwargs)
+
+        process_args = ['imagebuilder', '-t', image, builder.df_dir]
+        for buildarg, buildargval in builder.buildargs.items():
+            process_args.append('-build-arg')
+            process_args.append('%s="%s"' % (buildarg, buildargval))
+
+        ib_process = subprocess.Popen(process_args, **kwargs)
 
         self.log.debug('imagebuilder build has begun; waiting for it to finish')
         output = []

--- a/tests/plugins/test_docker_api.py
+++ b/tests/plugins/test_docker_api.py
@@ -26,7 +26,7 @@ from tests.constants import MOCK_SOURCE
 
 
 def mock_docker_tasker(docker_tasker):
-    def simplegen(x, y):
+    def simplegen(x, y, buildargs=None):
         yield "some\u2018".encode('utf-8')
 
     (flexmock(docker_tasker.tasker.d.wrapped)
@@ -49,6 +49,7 @@ class MockInsideBuilder(object):
         self.failed = failed
         self.df_path = 'some'
         self.df_dir = 'some'
+        self.buildargs = {}
 
     @property
     def source(self):

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -67,6 +67,7 @@ class StubInsideBuilder(object):
         self.parents_ordered = []
         self.tasker = None
         self.original_df = None
+        self.buildargs = {}
 
         self._inspection_data = None
         self._parent_inspection_data = {}

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -343,12 +343,14 @@ def test_get_image_info_by_name_tag_in_name_nonexisten(temp_image_name, docker_t
 def test_build_image_from_path(tmpdir, temp_image_name, docker_tasker):
     if MOCK:
         mock_docker()
+    buildargs = {'testarg1': 'testvalue1', 'testarg2': 'testvalue2'}
 
     tmpdir_path = str(tmpdir.realpath())
     clone_git_repo(DOCKERFILE_GIT, tmpdir_path)
     df = tmpdir.join("Dockerfile")
     assert df.check()
-    response = docker_tasker.build_image_from_path(tmpdir_path, temp_image_name, use_cache=True)
+    response = docker_tasker.build_image_from_path(tmpdir_path, temp_image_name,
+                                                   use_cache=True, buildargs=buildargs)
     list(response)
     assert response is not None
     assert docker_tasker.image_exists(temp_image_name)
@@ -359,8 +361,10 @@ def test_build_image_from_path(tmpdir, temp_image_name, docker_tasker):
 def test_build_image_from_git(temp_image_name, docker_tasker):
     if MOCK:
         mock_docker()
+    buildargs = {'testarg1': 'testvalue1', 'testarg2': 'testvalue2'}
 
-    response = docker_tasker.build_image_from_git(DOCKERFILE_GIT, temp_image_name, use_cache=True)
+    response = docker_tasker.build_image_from_git(DOCKERFILE_GIT, temp_image_name,
+                                                  use_cache=True, buildargs=buildargs)
     list(response)
     assert response is not None
     assert docker_tasker.image_exists(temp_image_name)


### PR DESCRIPTION
* OSBS-8134

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
