### PR TITLE
Small fix for Koji metadata docs

### DIFF
--- a/docs/koji.md
+++ b/docs/koji.md
@@ -93,8 +93,8 @@ In each buildroot, the extra.osbs key is used to define a map that contains thes
 - `build_id` (string): the build ID which resulted in the buildroot currently running atomic-reactor (**currently incorrect**)
 - `builder_image_id` (string): the docker pull-by-digest specification for the buildroot currently running atomic-reactor
 - `koji` (dict): a dictionary containing the following items
-- `name` (string): the koji name-nvr of the build
-- `builder_image_id` (dict): the docker digests of the build if availble or an empty dict otherwise.
+  - `build_name` (string): the koji name-nvr of the build
+  - `builder_image_id` (dict): the docker digests of the build if availble or an empty dict otherwise.
 
 # Type-specific output metadata:
 


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
