### PR TITLE
Fetch unsigned SRPMs if no ODCS config is provided

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -186,6 +186,10 @@ class FetchSourcesPlugin(PreBuildPlugin):
         :return: dict, signing intent object as per atomic_reactor/schemas/config.json
         """
         odcs_config = get_config(self.workflow).get_odcs_config()
+        if odcs_config is None:
+            self.log.warning('No ODCS configuration available. Allowing unsigned SRPMs')
+            return {'keys': None}
+
         if not self.signing_intent:
             try:
                 self.signing_intent = self.koji_build['extra']['image']['odcs']['signing_intent']


### PR DESCRIPTION
When no ODCS configuration is provided in the reactor config map, we
assume unsigned signing intent.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
