### PR TITLE
Allow unicode NVRs as fetch_sources parameter

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -10,6 +10,8 @@ from __future__ import absolute_import
 import os
 import tempfile
 
+from six import string_types
+
 from atomic_reactor.constants import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import (
@@ -46,8 +48,9 @@ class FetchSourcesPlugin(PreBuildPlugin):
         type_errors = []
         if koji_build_id is not None and not isinstance(koji_build_id, int):
             type_errors.append('koji_build_id must be an int. Got {}'.format(type(koji_build_id)))
-        if koji_build_nvr is not None and not isinstance(koji_build_nvr, str):
-            type_errors.append('koji_build_nvr must be a str. Got {}'.format(type(koji_build_nvr)))
+        if koji_build_nvr is not None and not isinstance(koji_build_nvr, string_types):
+            type_errors.append('koji_build_nvr must be a str. Got {}'
+                               .format(type(koji_build_nvr)))
         if type_errors:
             raise TypeError(type_errors)
 

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -266,6 +266,15 @@ class TestFetchSources(object):
         if build_nvr:
             assert nvr_msg in str(exc.value)
 
+    @pytest.mark.parametrize('build_nvr', ('foobar-1-1', u'foobar-1-1'))
+    def test_build_info_with_unicode(self, requests_mock, docker_tasker, koji_session, tmpdir,
+                                     caplog, build_nvr):
+        mock_koji_manifest_download(requests_mock)
+        runner = mock_env(tmpdir, docker_tasker, koji_build_nvr=build_nvr)
+        runner.run()
+        nvr_msg = 'koji_build_nvr must be a str'
+        assert nvr_msg not in caplog.text
+
     def test_build_with_nvr(self, requests_mock, docker_tasker, koji_session, tmpdir):
         mock_koji_manifest_download(requests_mock)
         runner = mock_env(tmpdir, docker_tasker, koji_build_nvr='foobar-1-1')


### PR DESCRIPTION
This allows python 2 compatibility if an unicode is passed to the plugin
as the NVR param. This is useful whenever the plugin is called from a
module importing future's unicode_literals.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
