### PR TITLE
Handle different docker APIs wait method returns

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -852,7 +852,12 @@ class DockerTasker(CommonTasker):
         """
         logger.info("waiting for container '%s' to finish", container_id)
         logger.debug("container = '%s'", container_id)
-        response = self.d.wait(container_id)  # returns exit code as int
+        # docker < 3.0.0 wait methods return int representing the exit code
+        # docker >= 3.0.0 wait methods return dict representing the API response
+        response = self.d.wait(container_id)
+        if isinstance(response, dict):
+            response = response['StatusCode']
+
         logger.debug("container finished with exit code %s", response)
         return response
 

--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -75,14 +75,13 @@ class SourceContainerPlugin(BuildStepPlugin):
             volume_bindings=volume_bindings,
             command=command
         )
-        response = self.tasker.wait(container_id)
+        status_code = self.tasker.wait(container_id)
         output = self.tasker.logs(container_id, stream=False)
 
         self.log.debug("Build log:\n%s", "\n".join(output))
 
         self.tasker.cleanup_containers(container_id)
 
-        status_code = response['StatusCode']
         if status_code != 0:
             reason = (
                 "Source container build failed with error code {}. "

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -79,7 +79,7 @@ def test_running_build(tmpdir):
     workflow = mock_workflow(
         tmpdir, source_containers_conf=SOURCE_CONTAINERS_CONF)
     mocked_tasker = flexmock(workflow.builder.tasker)
-    mocked_tasker.should_receive('wait').and_return({'StatusCode': 0})
+    mocked_tasker.should_receive('wait').and_return(0)
     runner = BuildStepPluginsRunner(
         mocked_tasker,
         workflow,
@@ -125,7 +125,7 @@ def test_failed_build(tmpdir):
     workflow = mock_workflow(
         tmpdir, source_containers_conf=SOURCE_CONTAINERS_CONF)
     mocked_tasker = flexmock(workflow.builder.tasker)
-    mocked_tasker.should_receive('wait').and_return({'StatusCode': 1})
+    mocked_tasker.should_receive('wait').and_return(1)
     runner = BuildStepPluginsRunner(
         mocked_tasker,
         workflow,


### PR DESCRIPTION
Prior docker 3.0.0, the wait methods would return just the API response
status code. The behavior has changed to return a dict containing the
response data, including the status code.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
