### PR TITLE
Revert "Get input files from relative path"

### DIFF
--- a/tests/plugins/test_input_osv3.py
+++ b/tests/plugins/test_input_osv3.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import print_function, unicode_literals, absolute_import
 import os
-import pkgutil
 import json
 import types
 from textwrap import dedent
@@ -341,18 +340,8 @@ class TestOSv3SourceContainerInputPlugin(object):
 
     @property
     def user_params(self):
-        # In a pip installation, get osbs-client input files navigating from
-        # $PIP_INSTALL_PATH/lib/python2.7/site-packages/osbs to $PIP_INSTALL_PATH/share/osbs.
-        # For an upstream osbs-client RPM package installation, get the files navigating from
-        # /usr/lib/python2.7/site-packages/osbs to /usr/share/osbs
-        osbs_loader = pkgutil.find_loader('osbs')
-        osbs_pkg_file = osbs_loader.get_filename()
-        osbs_pkg_path = os.path.dirname(osbs_pkg_file)
-        relpath_components = [os.pardir] * 4
-        relpath_components.append('share/osbs')
-        osbs_data_path = os.path.join(osbs_pkg_path, *relpath_components)
         return {
-            'build_json_dir': osbs_data_path,
+            'build_json_dir': '/usr/share/osbs/',
             'kind': USER_PARAMS_KIND_SOURCE_CONTAINER_BUILDS,
             'reactor_config_map': REACTOR_CONFIG_MAP,
             'sources_for_koji_build_nvr': 'test-1-123',


### PR DESCRIPTION
This reverts commit 08d863b2a272465f40e4445f737b8525d18f5e82.

This change is not general enough to work in different setups, such as
using a single virtual environment for the whole OSBS project installing
dependencies in development mode.



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
