### PR TITLE
Use BSI utility directly in buildroot image

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -7,33 +7,24 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import print_function, unicode_literals, absolute_import
 
+import subprocess
 import tempfile
 
-from atomic_reactor.build import BuildResult, ImageName
+from atomic_reactor.build import BuildResult
 from atomic_reactor.constants import PLUGIN_SOURCE_CONTAINER_KEY
 from atomic_reactor.plugin import BuildStepPlugin
-from atomic_reactor.plugins.pre_reactor_config import get_value
 
 
 class SourceContainerPlugin(BuildStepPlugin):
     """
     Build source container image using
     https://github.com/containers/BuildSourceImage
-
-    Image https://quay.io/repository/ctrs/bsi should be pushed to image stream
-    on OCP instance and image name must be specified in config
-    option `source_builder_image`
     """
 
     key = PLUGIN_SOURCE_CONTAINER_KEY
 
-    def get_builder_image(self):
-        source_containers_conf = get_value(self.workflow, 'source_containers', {})
-        return source_containers_conf.get('source_builder_image')
-
     def run(self):
         """Build image inside current environment.
-        It's expected this may run within (privileged) docker container.
 
         Returns:
             BuildResult
@@ -42,52 +33,22 @@ class SourceContainerPlugin(BuildStepPlugin):
         # TODO fail when source dir is empty
 
         image_output_dir = tempfile.mkdtemp()
-        image = self.get_builder_image()
-        if not image:
-            raise RuntimeError(
-                'Cannot build source containers, builder image is not '
-                'specified in configuration')
 
-        image = ImageName.parse(image)
+        cmd = ['bsi',
+               '-d',
+               'sourcedriver_rpm_dir',
+               '-s',
+               '{}'.format(source_data_dir),
+               '-o',
+               '{}'.format(image_output_dir)]
 
-        srpms_path = '/data/'
-        output_path = '/output/'
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as e:
+            self.log.error("BSI failed with output:\n%s", e.output)
+            return BuildResult(logs=e.output, fail_reason='BSI utility failed build source image')
 
-        volume_bindings = {
-            source_data_dir: {
-                'bind': srpms_path,
-                'mode': 'ro,Z',
-            },
-            image_output_dir: {
-                'bind': output_path,
-                'mode': 'rw,Z',
-            }
-        }
-
-        pulled_img = self.tasker.pull_image(image)
-
-        command = '-d sourcedriver_rpm_dir -s {srpms_path} -o {output_path}'.format(
-            srpms_path=srpms_path,
-            output_path=output_path,
-        )
-        container_id = self.tasker.run(
-            pulled_img,
-            volume_bindings=volume_bindings,
-            command=command
-        )
-        status_code = self.tasker.wait(container_id)
-        output = self.tasker.logs(container_id, stream=False)
-
-        self.log.debug("Build log:\n%s", "\n".join(output))
-
-        self.tasker.cleanup_containers(container_id)
-
-        if status_code != 0:
-            reason = (
-                "Source container build failed with error code {}. "
-                "See build logs for details".format(status_code)
-            )
-            return BuildResult(logs=output, fail_reason=reason)
+        self.log.debug("Build log:\n%s\n", output)
 
         return BuildResult(
             logs=output,

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -626,17 +626,6 @@
         "items": {
             "type": "string"
         }
-    },
-    "source_containers": {
-        "description": "Configuration options for building source container images",
-        "type": "object",
-        "properties": {
-            "source_builder_image": {
-                "description": "Image that will be used to build source container image (from https://github.com/containers/BuildSourceImage)",
-                "type": "string"
-            }
-        },
-        "additionalProperties": false
     }
   },
   "definitions": {


### PR DESCRIPTION
Instead of running the BSI image inside the buildroot image, run it
directly. This was done to release a source container image capable
atomic-reactor, and should change to use volumes and a BSI image in the
future.

The BSI utility must be installed in the buildroot $PATH under the name
'bsi'.

* https://github.com/containers/BuildSourceImage



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
