### PR TITLE
pre_bump_release: optionally set a release environment variable

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -179,6 +179,14 @@ class BumpReleasePlugin(PreBuildPlugin):
             raise RuntimeError('build already exists in Koji: {}-{}-{} ({})'
                                .format(component, version, release, build.get('id')))
 
+    def add_release_env_var(self, parser):
+        release_env_var = self.workflow.source.config.release_env_var
+        final_labels = Labels(parser.labels)
+        _, final_release = final_labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
+        if release_env_var:
+            release_line = "ENV {}={}".format(release_env_var, final_release)
+            parser.add_lines(release_line, at_start=True, all_stages=True)
+
     def run(self):
         """
         run the plugin
@@ -251,3 +259,5 @@ class BumpReleasePlugin(PreBuildPlugin):
         if self.reserve_build and not is_scratch_build():
             self.reserve_build_in_koji(component, version, release, release_label,
                                        dockerfile_labels)
+
+        self.add_release_env_var(parser)

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -165,6 +165,15 @@
         "demo"
       ]
     },
+    "set_release_env": {
+      "type": "string",
+      "description": "Name of an environment variable to set in the Dockerfile file with the release number",
+      "examples": [
+        "CONTAINER_RELEASE_NVR",
+        "IMAGE_RELEASE",
+        "OS_BUILD"
+      ]
+    },
     "version": {
       "type": "integer",
       "description": "Deprecated option kept for backwards compatibility. Should not be used",

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -54,6 +54,7 @@ class SourceConfig(object):
                 )
                 raise
 
+        self.release_env_var = self.data.get('set_release_env')
         self.autorebuild = self.data.get('autorebuild') or {}
         self.flatpak = self.data.get('flatpak')
         self.compose = self.data.get('compose')

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -52,7 +52,7 @@ class MockedClientSessionGeneral(object):
 
 
 class MockSource(object):
-    def __init__(self, tmpdir, add_timestamp=None):
+    def __init__(self, tmpdir, add_timestamp=None, release_env=None):
         self.dockerfile_path = str(tmpdir.join('Dockerfile'))
         self.path = str(tmpdir)
         self.commit_id = None
@@ -60,6 +60,7 @@ class MockSource(object):
             self.config = flexmock(autorebuild=dict(add_timestamp_to_release=add_timestamp))
         else:
             self.config = flexmock(autorebuild=dict())
+        setattr(self.config, 'release_env_var', release_env)
 
 
 class TestBumpRelease(object):
@@ -72,7 +73,8 @@ class TestBumpRelease(object):
                 reactor_config_map=False,
                 reserve_build=False,
                 is_auto=False,
-                add_timestamp=None):
+                add_timestamp=None,
+                release_env=None):
         if labels is None:
             labels = {}
 
@@ -81,7 +83,7 @@ class TestBumpRelease(object):
         setattr(workflow, 'plugin_workspace', {})
         setattr(workflow, 'reserved_build_id', None)
         setattr(workflow, 'reserved_token ', None)
-        setattr(workflow, 'source', MockSource(tmpdir, add_timestamp))
+        setattr(workflow, 'source', MockSource(tmpdir, add_timestamp, release_env))
         setattr(workflow, 'prebuild_results', {CheckAndSetRebuildPlugin.key: is_auto})
 
         df = tmpdir.join('Dockerfile')
@@ -252,6 +254,7 @@ class TestBumpRelease(object):
         (True, None),
         (False, None)
     ])
+    @pytest.mark.parametrize('release_env', ['TEST_RELEASE_VAR', None])
     @pytest.mark.parametrize('next_release, base_release, append', [
         ({'actual': '1', 'builds': [], 'expected': '1', 'scratch': False},
          None, False),
@@ -315,9 +318,11 @@ class TestBumpRelease(object):
     ])
     def test_increment_and_append(self, tmpdir, component, version, next_release, base_release,
                                   append, include_target, reserve_build, init_fails,
+                                  release_env,
                                   reactor_config_map):
         build_id = '123456'
         token = 'token_123456'
+
         class MockedClientSession(object):
             def __init__(self, hub, opts=None):
                 self.ca_path = None
@@ -370,7 +375,8 @@ class TestBumpRelease(object):
                               certs=True,
                               reactor_config_map=reactor_config_map,
                               reserve_build=reserve_build,
-                              append=append)
+                              append=append,
+                              release_env=release_env)
 
         new_environ = deepcopy(os.environ)
         new_environ["BUILD"] = dedent('''\
@@ -424,3 +430,7 @@ class TestBumpRelease(object):
         if reserve_build and reactor_config_map and not next_release['scratch']:
             assert plugin.workflow.reserved_build_id == build_id
             assert plugin.workflow.reserved_token == token
+
+        if release_env:
+            expected = "ENV {}={}\n".format(release_env, next_release['expected'])
+            assert expected in parser.lines


### PR DESCRIPTION
Fixes osbs-7244

Add code in pre_bump_release that checks if set_release_env is set in the container.yml, and if it is, adds an ENV variable of the same name with the value of the release to the Dockerfile.

documentation PR: https://github.com/containerbuildsystem/osbs-docs/pull/117

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
