### PR TITLE
Disallow building source container from source container image build,

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -115,6 +115,18 @@ class FetchSourcesPlugin(PreBuildPlugin):
                 )
             raise ValueError(err_msg)
 
+        build_types = self.koji_build['extra']['typeinfo']
+        if 'image' not in build_types:
+            types_list = sorted(build_types.keys())
+            err_msg = ('koji build {} is {} build, source container '
+                       'build needs image build'.format(self.koji_build['nvr'], types_list))
+            raise ValueError(err_msg)
+
+        elif 'sources_for_nvr' in self.koji_build['extra']['image']:
+            err_msg = ('koji build {} is source container build, source container can not '
+                       'use source container build image'.format(self.koji_build['nvr']))
+            raise ValueError(err_msg)
+
         if not self.koji_build_id:
             self.koji_build_id = self.koji_build['build_id']
         if not self.koji_build_nvr:


### PR DESCRIPTION
and also disallow any other than 'image' build type

* OSBS-8319

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
