### PR TITLE
Don't hide files for FROM scratch layer

### DIFF
--- a/atomic_reactor/plugins/pre_hide_files.py
+++ b/atomic_reactor/plugins/pre_hide_files.py
@@ -12,7 +12,7 @@ import os
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import get_hide_files
 from atomic_reactor.util import df_parser
-from atomic_reactor.constants import INSPECT_CONFIG
+from atomic_reactor.constants import INSPECT_CONFIG, SCRATCH_FROM
 
 
 class HideFilesPlugin(PreBuildPlugin):
@@ -91,6 +91,10 @@ class HideFilesPlugin(PreBuildPlugin):
         add_end_lines = []
 
         parent_image_id = from_structure['value'].split(' ', 1)[0]
+
+        if parent_image_id == SCRATCH_FROM:
+            return
+
         inspect = self.workflow.builder.parent_image_inspect(parent_image_id)
         inherited_user = inspect.get(INSPECT_CONFIG).get('User', '')
 

--- a/tests/plugins/test_hide_files.py
+++ b/tests/plugins/test_hide_files.py
@@ -138,6 +138,22 @@ class TestHideFilesPlugin(object):
             """),
             "inherited_user"
         ),
+
+        (
+            dedent("""\
+                FROM scratch
+                RUN yum install -y python-flask
+                USER custom_docker_user
+                CMD /bin/bash
+            """),
+            dedent("""\
+                FROM scratch
+                RUN yum install -y python-flask
+                USER custom_docker_user
+                CMD /bin/bash
+            """),
+            "inherited_user"
+        ),
     ])
     def test_hide_files(self, tmpdir, df_content, expected_df, inherited_user):
         df = df_parser(str(tmpdir))


### PR DESCRIPTION
* OSBS-8324

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
