### PR TITLE
get_or_create_imagestream: retry on conflict

### DIFF
--- a/atomic_reactor/plugins/post_import_image.py
+++ b/atomic_reactor/plugins/post_import_image.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015, 2019 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -9,6 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import unicode_literals, absolute_import
 
 from osbs.exceptions import OsbsResponseException
+from osbs.utils import retry_on_conflict
 
 from atomic_reactor.plugin import PostBuildPlugin, ExitPlugin
 from atomic_reactor.util import get_floating_images, ImageName
@@ -90,6 +91,7 @@ class ImportImagePlugin(ExitPlugin, PostBuildPlugin):
             self.process_tags()
             self.osbs.import_image(self.imagestream_name, tags=self.get_trackable_tags())
 
+    @retry_on_conflict
     def get_or_create_imagestream(self):
         try:
             self.imagestream = self.osbs.get_image_stream(self.imagestream_name)


### PR DESCRIPTION
409 responses seen in production:
```
{
  "kind":"Status",
  "apiVersion":"v1",
  "metadata":{},
  "status":"Failure",
  "message":"imagestreams.image.openshift.io \"[...]\" already exists",
  "reason":"AlreadyExists",
  "details": {
    "name":"[...]",
    "group":"image.openshift.io",
    "kind":"imagestreams"
  },
  "code":409
}
```

Signed-off-by: Tim Waugh <twaugh@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
