### PR TITLE
Source containers: don't report v2 schema 1 media type

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2017 Red Hat, Inc
+Copyright (c) 2017, 2019 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -384,6 +384,10 @@ def get_deep_manifest_list_inspection(workflow, fallback=NO_FALLBACK):
 
 def get_fail_on_digest_mismatch(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'fail_on_digest_mismatch', fallback)
+
+
+def get_source_container(workflow, fallback=NO_FALLBACK):
+    return get_value(workflow, 'source_container', fallback)
 
 
 class ClusterConfig(object):

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -479,19 +479,7 @@
                     "additionalProperties": false,
                     "required": ["cfg_path"]
                 },
-                "expected_media_types": {
-                    "description": "Expected media types to be found in registry",
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": ["application/json",
-                                 "application/vnd.docker.distribution.manifest.v1+json",
-                                 "application/vnd.docker.distribution.manifest.v2+json",
-                                 "application/vnd.docker.distribution.manifest.list.v2+json",
-                                 "application/vnd.oci.image.manifest.v1+json",
-                                 "application/vnd.oci.image.index.v1+json"]
-                    }
-                }
+                "expected_media_types": {"$ref": "#/definitions/media_types"}
             },
             "additionalProperties": false,
             "required": ["url"]
@@ -626,6 +614,17 @@
         "items": {
             "type": "string"
         }
+    },
+    "source_container": {
+        "description": "Properties relating to source containers",
+        "type": "object",
+        "properties": {
+          "limit_media_types": {
+            "description": "Do not report any media types other than these",
+            "allOf": [{"$ref": "#/definitions/media_types"}]
+          }
+        },
+        "additionalProperties": false
     }
   },
   "definitions": {
@@ -640,6 +639,19 @@
     "organization": {
         "description": "Registry organization",
         "type": "string"
+    },
+    "media_types": {
+      "description": "Media types to be found in registry",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": ["application/json",
+                   "application/vnd.docker.distribution.manifest.v1+json",
+                   "application/vnd.docker.distribution.manifest.v2+json",
+                   "application/vnd.docker.distribution.manifest.list.v2+json",
+                   "application/vnd.oci.image.manifest.v1+json",
+                   "application/vnd.oci.image.index.v1+json"]
+        }
     }
   },
   "required": ["version"]


### PR DESCRIPTION
Signed-off-by: Tim Waugh <twaugh@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
