### PR TITLE
pre_bump_release, pre_add_labels_in_df: relocate setting release variable

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -189,14 +189,6 @@ class BumpReleasePlugin(PreBuildPlugin):
             raise RuntimeError('build already exists in Koji: {}-{}-{} ({})'
                                .format(component, version, release, build.get('id')))
 
-    def add_release_env_var(self, parser):
-        release_env_var = self.workflow.source.config.release_env_var
-        final_labels = Labels(parser.labels)
-        _, final_release = final_labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
-        if release_env_var:
-            release_line = "ENV {}={}".format(release_env_var, final_release)
-            parser.add_lines(release_line, at_start=True, all_stages=True)
-
     def get_source_build_nvr(self, scratch=False):
         source_result = self.workflow.prebuild_results[PLUGIN_FETCH_SOURCES_KEY]
         koji_build_nvr = source_result['sources_for_nvr']
@@ -298,5 +290,3 @@ class BumpReleasePlugin(PreBuildPlugin):
         if self.reserve_build and not is_scratch_build():
             self.reserve_build_in_koji(component, version, release, release_label,
                                        dockerfile_labels)
-
-        self.add_release_env_var(parser)

--- a/tests/plugins/test_bump_release.py
+++ b/tests/plugins/test_bump_release.py
@@ -41,7 +41,7 @@ class MockedClientSessionGeneral(object):
 
 
 class MockSource(object):
-    def __init__(self, tmpdir, add_timestamp=None, release_env=None):
+    def __init__(self, tmpdir, add_timestamp=None):
         self.dockerfile_path = str(tmpdir.join('Dockerfile'))
         self.path = str(tmpdir)
         self.commit_id = None
@@ -49,7 +49,6 @@ class MockSource(object):
             self.config = flexmock(autorebuild=dict(add_timestamp_to_release=add_timestamp))
         else:
             self.config = flexmock(autorebuild=dict())
-        setattr(self.config, 'release_env_var', release_env)
 
 
 class TestBumpRelease(object):
@@ -63,7 +62,6 @@ class TestBumpRelease(object):
                 reserve_build=False,
                 is_auto=False,
                 add_timestamp=None,
-                release_env=None,
                 fetch_source=False):
         if labels is None:
             labels = {}
@@ -73,7 +71,7 @@ class TestBumpRelease(object):
         setattr(workflow, 'plugin_workspace', {})
         setattr(workflow, 'reserved_build_id', None)
         setattr(workflow, 'reserved_token ', None)
-        setattr(workflow, 'source', MockSource(tmpdir, add_timestamp, release_env))
+        setattr(workflow, 'source', MockSource(tmpdir, add_timestamp))
         setattr(workflow, 'prebuild_results', {CheckAndSetRebuildPlugin.key: is_auto})
         if fetch_source:
             workflow.prebuild_results[PLUGIN_FETCH_SOURCES_KEY] = {
@@ -248,7 +246,6 @@ class TestBumpRelease(object):
         (True, None),
         (False, None)
     ])
-    @pytest.mark.parametrize('release_env', ['TEST_RELEASE_VAR', None])
     @pytest.mark.parametrize('next_release, base_release, append', [
         ({'actual': '1', 'builds': [], 'expected': '1', 'scratch': False},
          None, False),
@@ -312,7 +309,6 @@ class TestBumpRelease(object):
     ])
     def test_increment_and_append(self, tmpdir, component, version, next_release, base_release,
                                   append, include_target, reserve_build, init_fails,
-                                  release_env,
                                   reactor_config_map):
         build_id = '123456'
         token = 'token_123456'
@@ -369,8 +365,7 @@ class TestBumpRelease(object):
                               certs=True,
                               reactor_config_map=reactor_config_map,
                               reserve_build=reserve_build,
-                              append=append,
-                              release_env=release_env)
+                              append=append)
 
         new_environ = deepcopy(os.environ)
         new_environ["BUILD"] = dedent('''\
@@ -424,10 +419,6 @@ class TestBumpRelease(object):
         if reserve_build and reactor_config_map and not next_release['scratch']:
             assert plugin.workflow.reserved_build_id == build_id
             assert plugin.workflow.reserved_token == token
-
-        if release_env:
-            expected = "ENV {}={}\n".format(release_env, next_release['expected'])
-            assert expected in parser.lines
 
     @pytest.mark.parametrize('reserve_build, init_fails', [
         (True, RuntimeError),

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -14,18 +14,18 @@ from atomic_reactor.util import ImageName
 
 
 # Stubs for commonly-mocked classes
+class StubConfig(object):
+    image_build_method = None
+    release_env_var = None
+
 
 class StubSource(object):
     dockerfile_path = None
     path = ''
-    config = None
+    config = StubConfig()
 
     def get_vcs_info(self):
         return None
-
-
-class StubConfig(object):
-    image_build_method = None
 
 
 class StubTagConf(object):


### PR DESCRIPTION
Move setting the release environment variable out of pre_bump_release that is only called from the orchestrator and into pre_add_labels_in_df that is called by workers and orchestrator.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
