### PR TITLE
Add `annotation` decorator to utils

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -420,6 +420,9 @@ class DockerBuildWorkflow(object):
         self.koji_source_source_url = None
         self.koji_source_manifest = None
 
+        # Plugins can store info here using the `@util.annotation` decorator
+        self.annotations = {}
+
         if client_version:
             logger.debug("build json was built by osbs-client %s", client_version)
 

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -198,11 +198,16 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         if whitelist:
             annotations['koji_task_annotations_whitelist'] = whitelist
 
-    def apply_build_result_annotations(self, annotations):
-        updates = self.workflow.build_result.annotations
+    def _update_annotations(self, annotations, updates):
         if updates:
             updates = {key: json.dumps(value) for key, value in updates.items()}
             annotations.update(updates)
+
+    def apply_build_result_annotations(self, annotations):
+        self._update_annotations(annotations, self.workflow.build_result.annotations)
+
+    def apply_plugin_annotations(self, annotations):
+        self._update_annotations(annotations, self.workflow.annotations)
 
     def run(self):
         metadata = get_build_json().get("metadata", {})
@@ -307,6 +312,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
 
         annotations.update(self.get_config_map())
 
+        self.apply_plugin_annotations(annotations)
         self.apply_build_result_annotations(annotations)
         self.set_koji_task_annotations_whitelist(annotations)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1596,6 +1596,9 @@ def annotation(*keys):
     The `run()` method of the plugin being annotated has to return a dict
     containing all of the specified keys.
 
+    The `store_metadata_in_osv3` plugin will automatically collect these
+    annotations and upload them to OpenShift.
+
     Example:
     >>> from atomic_reactor.plugin import BuildPlugin
 

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -902,3 +902,25 @@ def test_set_koji_annotations_whitelist(tmpdir, koji_conf):
         assert all(entry in whitelist for entry in koji_conf['task_annotations_whitelist'])
     else:
         assert 'koji_task_annotations_whitelist' not in annotations
+
+
+def test_plugin_annotations():
+    workflow = prepare()
+    workflow.annotations = {'foo': {'bar': 'baz'}, 'spam': ['eggs']}
+
+    runner = ExitPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': StoreMetadataInOSv3Plugin.key,
+            "args": {
+                "url": "http://example.com/"
+            }
+        }]
+    )
+
+    output = runner.run()
+    annotations = output[StoreMetadataInOSv3Plugin.key]["annotations"]
+
+    assert annotations['foo'] == '{"bar": "baz"}'
+    assert annotations['spam'] == '["eggs"]'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 flexmock>=0.10.3
 ordereddict
-responses>=0.9.0
+responses>=0.9.0,<0.10.8
 pypng
 pytest>=4.1.0
 pytest-cov


### PR DESCRIPTION
* OSBS-7828

Will be used to give names to function results, particularly the `run()`
methods of plugins.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
