### PR TITLE
fetch_sources: log which RPM is being processed

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -166,6 +166,7 @@ class FetchSourcesPlugin(PreBuildPlugin):
 
         srpm_build_paths = {}
         for rpm_id, rpm_build_id in rpm_build_ids.items():
+            self.log.debug('Resolving SRPM for RPM ID: %s', rpm_id)
             rpm_hdr = self.session.getRPMHeaders(rpm_id, headers=['SOURCERPM'])
             srpm_filename = rpm_hdr['SOURCERPM']
             if srpm_filename in srpm_build_paths:


### PR DESCRIPTION
For easier debugging log which RPM is being pocessed by plugin

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
