### PR TITLE
add signing intent to koji build metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -405,6 +405,7 @@ class KojiImportPlugin(ExitPlugin):
         else:
             source_result = self.workflow.prebuild_results[PLUGIN_FETCH_SOURCES_KEY]
             extra['image']['sources_for_nvr'] = source_result['sources_for_nvr']
+            extra['image']['sources_signing_intent'] = source_result['signing_intent']
 
         koji_task_id = metadata.get('labels', {}).get('koji-task-id')
         if koji_task_id is not None:

--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -78,6 +78,7 @@ class FetchSourcesPlugin(PreBuildPlugin):
                 'sources_for_koji_build_id': self.koji_build_id,
                 'sources_for_nvr': self.koji_build_nvr,
                 'image_sources_dir': sources_dir,
+                'signing_intent': self.signing_intent,
         }
 
     def download_sources(self, urls, insecure=False):

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -228,7 +228,8 @@ class TestFetchSources(object):
     def test_koji_signing_intent(self, requests_mock, docker_tasker, koji_session, tmpdir,
                                  signing_intent, caplog):
         """Make sure fetch_sources plugin prefers the koji image build signing intent"""
-        extra_image = {'odcs': {'signing_intent': 'unsigned'}}
+        image_signing_intent = 'unsigned'
+        extra_image = {'odcs': {'signing_intent': image_signing_intent}}
 
         koji_build = deepcopy(KOJI_BUILD)
         koji_build['extra'].update({'image': extra_image})
@@ -249,6 +250,7 @@ class TestFetchSources(object):
             assert msg not in caplog.text
         if signing_intent in ['one, multiple']:
             assert get_srpm_url('usedKey') not in caplog.text
+        assert result[constants.PLUGIN_FETCH_SOURCES_KEY]['signing_intent'] == image_signing_intent
 
     def test_no_build_info(self, requests_mock, docker_tasker, koji_session, tmpdir):
         mock_koji_manifest_download(requests_mock)

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -61,6 +61,7 @@ LogEntry = namedtuple('LogEntry', ['platform', 'line'])
 NAMESPACE = 'mynamespace'
 BUILD_ID = 'build-1'
 SOURCES_FOR_KOJI_NVR = 'component-release-version'
+SOURCES_SIGNING_INTENT = 'some_intent'
 
 PUSH_OPERATOR_MANIFESTS_RESULTS = {
     "endpoint": 'registry.url/endpoint',
@@ -366,7 +367,8 @@ def mock_environment(tmpdir, session=None, name=None,
                                             image_id="id1234",
                                             annotations=annotations)
     workflow.prebuild_plugins_conf = {}
-    workflow.prebuild_results[PLUGIN_FETCH_SOURCES_KEY] = {'sources_for_nvr': SOURCES_FOR_KOJI_NVR}
+    workflow.prebuild_results[PLUGIN_FETCH_SOURCES_KEY] = {'sources_for_nvr': SOURCES_FOR_KOJI_NVR,
+                                                           'signing_intent': SOURCES_SIGNING_INTENT}
     workflow.prebuild_results[CheckAndSetRebuildPlugin.key] = is_rebuild
     workflow.postbuild_results[PostBuildRPMqaPlugin.key] = [
         "name1;1.0;1;x86_64;0;2000;" + FAKE_SIGMD5.decode() + ";23000;"
@@ -2258,6 +2260,7 @@ class TestKojiImport(object):
         assert isinstance(image, dict)
 
         assert image['sources_for_nvr'] == SOURCES_FOR_KOJI_NVR
+        assert image['sources_signing_intent'] == SOURCES_SIGNING_INTENT
 
         if expected_media_types:
             media_types = image['media_types']


### PR DESCRIPTION
* OSBS-8365

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
