### PR TITLE
Source containers: update koji docs

### DIFF
--- a/docs/koji.md
+++ b/docs/koji.md
@@ -88,6 +88,17 @@ Data which is placed here includes:
 
 - `build.extra.typeinfo.operator-manifests.archive` (string): name of the archive containing operator manifest files
 
+# Type-specific source container build metadata
+
+The same note about `image` and `build.extra.typeinfo.image` from previous section applies here.
+
+Data which is placed here includes:
+
+- `build.extra.image.media_types`: the same as for image builds (see previous section)
+- `build.extra.image.sources_for_nvr` (str): koji N-V-R for the original image build
+- `build.extra.image.sources_signing_intent` (str): signing intent used to fetch source RPMs
+- `build.extra.submitter`: the same as for regular image builds (see previous section)
+
 # Type-specific buildroot metadata:
 
 In each buildroot, the extra.osbs key is used to define a map that contains these items:

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -12,6 +12,8 @@ The `koji_parent` pre-build plugin determines the expected NVR (Name-Version-Rel
 
 The `fetch_maven_artifacts` pre-build plugin will use configuration files to download external maven artifacts. One of these sources can be a Koji build.
 
+The `fetch_sources` pre-build plugins determines and pulls sources which should be added into source container image, based on provided koji build N-V-R/ID.
+
 The `inject_parent_image` pre-build plugin overwrites the parent image to be used based on a given Koji build.
 
 ## Exit plugins


### PR DESCRIPTION

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
