### PR TITLE
Improve logs for SRPM URL checks

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -196,11 +196,12 @@ class FetchSourcesPlugin(PreBuildPlugin):
                 request = req_session.head(url_candidate, verify=not insecure)
                 if request.ok:
                     srpm_urls.append(url_candidate)
+                    self.log.debug('%s is available for signing key "%s"', srpm_filename, sigkey)
                     break
-                self.log.debug('%s not found for signing key "%s" at %s (returned %s)',
-                               srpm_filename, sigkey, url_candidate, request.status_code)
 
             else:
+                self.log.error('%s not found for the given signing intent: %s"', srpm_filename,
+                               self.signing_intent)
                 missing_srpms.append(srpm_filename)
 
         if missing_srpms:


### PR DESCRIPTION
Logging 404 errors for header checks on possible signing intent related
URLs may be misleading unless followed by a success check or a build
failure. Instead, we log successful requests. If not SRPM is found for a
given package in the signing intent, we then log an error before
raising.

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
