### PR TITLE
pre_resolve_compose: remove PDC support

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_module_compose.py
+++ b/atomic_reactor/plugins/pre_resolve_module_compose.py
@@ -97,8 +97,7 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
                  compose_ids=tuple(),
                  odcs_url=None, odcs_insecure=False,
                  odcs_openidc_secret_path=None,
-                 signing_intent=None,
-                 pdc_url=None, pdc_insecure=False):
+                 signing_intent=None):
         """
         constructor
 
@@ -109,8 +108,6 @@ class ResolveModuleComposePlugin(PreBuildPlugin):
         :param odcs_insecure: If True, don't check SSL certificates for `odcs_url`
         :param odcs_openidc_secret_path: directory to look in for a `token` file (optional)
         :param signing_intent: override the signing intent from git repo configuration
-        :param pdc_url: unused
-        :param pdc_insecure: unused
         :
         """
         # call parent constructor


### PR DESCRIPTION
Fixes OSBS-7605

pdc support was deprecated in September 2018, so remove the last remnants
of it from the code.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>

doc change at https://github.com/containerbuildsystem/osbs-docs/pull/121

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
