### PR TITLE
Whitelist koji annotations from reactor_config_map

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -123,6 +123,13 @@
             "delegated_task_priority": {
                 "description": "When delegate_build is enabled, delegated task will use this koji task priority, if not set it will use default koji priority",
                 "type": "integer"
+            },
+            "task_annotations_whitelist": {
+                "description": "Annotations to be included in the build_annotations.json task output file. If empty or not described, the file will not be generated",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
             }
         },
         "additionalProperties": false,


### PR DESCRIPTION
Allow annotations whose names are listed in task_annotations_whitelist
koji's configuration in the configmap to be included in a new
koji_task_annotations_whitelist annotation. This may be used with koji
integration to whitelist annotations to be processed in a koji task.

* OSBS-8138

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
