### PR TITLE
fail source build if no srpms found already in fetch_sources

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -73,6 +73,12 @@ class FetchSourcesPlugin(PreBuildPlugin):
         koji_config = get_koji(self.workflow, {})
         insecure = koji_config.get('insecure_download', False)
         urls = self.get_srpm_urls(signing_intent['keys'], insecure=insecure)
+
+        if not urls:
+            msg = "No srpms found for source container, would produce empty source container image"
+            self.log.error(msg)
+            raise RuntimeError(msg)
+
         sources_dir = self.download_sources(urls, insecure=insecure)
         return {
                 'sources_for_koji_build_id': self.koji_build_id,

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -401,3 +401,18 @@ class TestFetchSources(object):
             assert 'RPM comes from an external repo' in str(exc_info.value)
         else:
             assert 'Missing SOURCERPM header' in str(exc_info.value)
+
+    def test_no_srpms(self, docker_tasker, koji_session, tmpdir):
+        (flexmock(koji_session)
+            .should_receive('listArchives')
+            .and_return([{'id': 1}]))
+        (flexmock(koji_session)
+            .should_receive('listRPMs')
+            .with_args(imageID=1)
+            .and_return([]))
+
+        runner = mock_env(tmpdir, docker_tasker, koji_build_nvr='foobar-1-1')
+        with pytest.raises(PluginFailedException) as exc_info:
+            runner.run()
+
+        assert 'No srpms found for source container' in str(exc_info.value)


### PR DESCRIPTION
* OSBS-8372

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
