### PR TITLE
don't fail remove_metadata if fragment annotation doesn't exist

### DIFF
--- a/atomic_reactor/plugins/exit_remove_worker_metadata.py
+++ b/atomic_reactor/plugins/exit_remove_worker_metadata.py
@@ -31,6 +31,10 @@ class RemoveWorkerMetadataPlugin(ExitPlugin):
 
         for platform, build_annotations in worker_builds.items():
             try:
+                if ('metadata_fragment' not in build_annotations or
+                        'metadata_fragment_key' not in build_annotations):
+                    continue
+
                 cm_key, _ = get_platform_config(platform, build_annotations)
             except BadConfigMapError:
                 continue


### PR DESCRIPTION
* OSBS-7246

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
