### PR TITLE
Use urllib3 directly instead of via requests.packages

### DIFF
--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -46,10 +46,10 @@ from atomic_reactor.source import get_source_instance_for
 from atomic_reactor.util import ImageName, figure_out_build_file, Dockercfg
 from osbs.utils import clone_git_repo
 
-from requests.packages.urllib3.exceptions import (InsecureRequestWarning, ProtocolError,
-                                                  ReadTimeoutError)
-
-requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+from urllib3.exceptions import (InsecureRequestWarning, ProtocolError,
+                                ReadTimeoutError)
+from urllib3 import disable_warnings
+disable_warnings(InsecureRequestWarning)
 
 logger = logging.getLogger(__name__)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -19,7 +19,7 @@ import sys
 import requests
 from requests.exceptions import SSLError, HTTPError, RetryError
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util import Retry
+from urllib3.util import Retry
 import shutil
 import tempfile
 import logging

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015-2019 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -12,7 +12,7 @@ from __future__ import print_function, unicode_literals, absolute_import
 from atomic_reactor.core import DockerTasker, retry, RetryGeneratorException, ContainerTasker
 from atomic_reactor.util import ImageName, clone_git_repo, CommandResult
 from tests.constants import LOCALHOST_REGISTRY, INPUT_IMAGE, DOCKERFILE_GIT, MOCK, COMMAND
-from requests.packages.urllib3.exceptions import ProtocolError, ReadTimeoutError
+from urllib3.exceptions import ProtocolError, ReadTimeoutError
 from tests.util import requires_internet
 
 from base64 import b64encode


### PR DESCRIPTION
Relates to OSBS-8409

Signed-off-by: Tim Waugh <twaugh@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
