### PR TITLE
Use docker-archive for source container images

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -31,14 +31,14 @@ class SourceContainerPlugin(BuildStepPlugin):
 
         cmd = ['skopeo', 'copy']
         source_img = 'oci:{}'.format(image_output_dir)
-        dest_img = 'oci-archive:{}'.format(output_path)
+        dest_img = 'docker-archive:{}'.format(output_path)
         cmd += [source_img, dest_img]
 
         self.log.info("Calling: %s", ' '.join(cmd))
         try:
             subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
-            self.log.error("failed to save oci-archive :\n%s", e.output)
+            self.log.error("failed to save docker-archive :\n%s", e.output)
             raise
 
         img_metadata = get_exported_image_metadata(output_path, IMAGE_TYPE_OCI_TAR)

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -114,8 +114,8 @@ def test_running_build(tmpdir, caplog, sources_dir, sources_dir_exists, sources_
             assert args[0] == 'skopeo'
             assert args[1] == 'copy'
             assert args[2] == 'oci:%s' % temp_image_output_dir
-            assert args[3] == 'oci-archive:%s' % os.path.join(temp_image_export_dir,
-                                                              EXPORTED_SQUASHED_IMAGE_NAME)
+            assert args[3] == 'docker-archive:%s' % os.path.join(temp_image_export_dir,
+                                                                 EXPORTED_SQUASHED_IMAGE_NAME)
 
             if export_failed:
                 raise subprocess.CalledProcessError(returncode=1, cmd=args, output="Failed")


### PR DESCRIPTION
The oci-archive is currently not supported by pub.

* OSBS-8464

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
