### PR TITLE
Add Koji support for remote sources

### DIFF
--- a/atomic_reactor/cachito_util.py
+++ b/atomic_reactor/cachito_util.py
@@ -14,6 +14,7 @@ import logging
 import requests
 import time
 
+from atomic_reactor.constants import REMOTE_SOURCES_FILENAME
 from atomic_reactor.download import download_url
 from atomic_reactor.util import get_retrying_requests_session
 
@@ -133,7 +134,7 @@ class CachitoAPI(object):
                 else:
                     time.sleep(burst_retry)
 
-    def download_sources(self, request, dest_dir='.', dest_filename='remote-sources.tar.gz'):
+    def download_sources(self, request, dest_dir='.', dest_filename=REMOTE_SOURCES_FILENAME):
         """Download the sources from a Cachito request
 
         :param request: int or dict, either the Cachito request ID or a dict with 'id' key

--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -163,6 +163,10 @@ OPERATOR_MANIFESTS_ARCHIVE = 'operator_manifests.zip'
 
 KOJI_BTYPE_IMAGE = 'image'
 KOJI_BTYPE_OPERATOR_MANIFESTS = 'operator-manifests'
+KOJI_BTYPE_CONTAINER_FIRST = 'remote-sources'
 
 # Path to where the remote source bundle is copied to during the build process
 REMOTE_SOURCE_DIR = '/remote-source'
+
+# Name of downloaded remote sources tarball
+REMOTE_SOURCES_FILENAME = 'remote-sources.tar.gz'


### PR DESCRIPTION
* Use new remote-sources koji btype
* Upload remote sources artifacts (tarball and json) as new btype
* Update build extra.image.remote_source_url metadata

* Relates to Cachito integration
* OSBS-8137

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
