### PR TITLE
Fix source container image docker-archive metadata

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -13,7 +13,7 @@ import tempfile
 
 from atomic_reactor.build import BuildResult
 from atomic_reactor.constants import (PLUGIN_SOURCE_CONTAINER_KEY, EXPORTED_SQUASHED_IMAGE_NAME,
-                                      IMAGE_TYPE_OCI_TAR, PLUGIN_FETCH_SOURCES_KEY)
+                                      IMAGE_TYPE_DOCKER_ARCHIVE, PLUGIN_FETCH_SOURCES_KEY)
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.util import get_exported_image_metadata
 
@@ -41,7 +41,7 @@ class SourceContainerPlugin(BuildStepPlugin):
             self.log.error("failed to save docker-archive :\n%s", e.output)
             raise
 
-        img_metadata = get_exported_image_metadata(output_path, IMAGE_TYPE_OCI_TAR)
+        img_metadata = get_exported_image_metadata(output_path, IMAGE_TYPE_DOCKER_ARCHIVE)
         self.workflow.exported_image_sequence.append(img_metadata)
 
     def run(self):


### PR DESCRIPTION
* https://github.com/containerbuildsystem/atomic-reactor/pull/1344
* OSBS-8464

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
