### PR TITLE
Add additional remote sources build args

### DIFF
--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -10,8 +10,10 @@ Downloads and unpacks the source code archive from Cachito and sets appropriate 
 
 from __future__ import absolute_import
 
+import os
 import tarfile
 
+from atomic_reactor.constants import REMOTE_SOURCE_DIR
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.download import download_url
 
@@ -19,6 +21,7 @@ from atomic_reactor.download import download_url
 class DownloadRemoteSourcePlugin(PreBuildPlugin):
     key = 'download_remote_source'
     is_allowed_to_fail = False
+    REMOTE_SOURCE = 'unpacked_remote_sources'
 
     def __init__(self, tasker, workflow, remote_source_url,
                  remote_source_build_args=None):
@@ -40,11 +43,23 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
         # Download the source code archive
         archive = download_url(self.url, self.workflow.source.workdir)
 
-        # Unpack the source code archive into the workdir
+        # Unpack the source code archive into a dedicated dir in workdir
+        dest_dir = os.path.join(self.workflow.source.workdir, self.REMOTE_SOURCE)
+        if not os.path.exists(dest_dir):
+            os.makedirs(dest_dir)
+
         with tarfile.open(archive) as tf:
-            tf.extractall(self.workflow.source.workdir)
+            tf.extractall(dest_dir)
 
         # Set build args
         self.workflow.builder.buildargs.update(self.buildargs)
+
+        # To copy the sources into the build image, Dockerfile should contain
+        # COPY $REMOTE_SOURCE $REMOTE_SOURCE_DIR
+        args_for_dockerfile_to_add = {
+            'REMOTE_SOURCE': self.REMOTE_SOURCE,
+            'REMOTE_SOURCE_DIR': REMOTE_SOURCE_DIR,
+            }
+        self.workflow.builder.buildargs.update(args_for_dockerfile_to_add)
 
         return archive

--- a/tests/plugins/test_download_remote_source.py
+++ b/tests/plugins/test_download_remote_source.py
@@ -13,6 +13,7 @@ import os
 import responses
 import tarfile
 
+from atomic_reactor.constants import REMOTE_SOURCE_DIR
 from atomic_reactor.inner import DockerBuildWorkflow
 from tests.constants import TEST_IMAGE
 from tests.stubs import StubInsideBuilder
@@ -57,7 +58,7 @@ class TestDownloadRemoteSource(object):
         assert filecontent == content.getvalue()
 
         # Expect a file 'abc' in the workdir
-        with open(os.path.join(workflow.source.workdir, member), 'rb') as f:
+        with open(os.path.join(workflow.source.workdir, plugin.REMOTE_SOURCE, member), 'rb') as f:
             filecontent = f.read()
 
         assert filecontent == abc_content
@@ -65,3 +66,8 @@ class TestDownloadRemoteSource(object):
         # Expect buildargs to have been set
         for arg, value in buildargs.items():
             assert workflow.builder.buildargs[arg] == value
+        # along with the args needed to add the sources in the Dockerfile
+        assert workflow.builder.buildargs['REMOTE_SOURCE'] == plugin.REMOTE_SOURCE
+        assert workflow.builder.buildargs['REMOTE_SOURCE_DIR'] == REMOTE_SOURCE_DIR
+        # https://github.com/openshift/imagebuilder/issues/139
+        assert not workflow.builder.buildargs['REMOTE_SOURCE'].startswith('/')


### PR DESCRIPTION
We add build arguments to allow remote sources to be copied into the
build image. Since the ADD command can extract tar archives directly,
there is no more need to extract the sources in the workdir.

To accomplish this, a Dockerfile must contain the following
instructions:

```
RUN mkdir $REMOTE_SOURCE_DIR
ADD $REMOTE_SOURCE $REMOTE_SOURCE_DIR
```

* OSBS-8473
* OSBS-8135

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
