### PR TITLE
download_remote_sources plugin should not run for empty remote_source…

### DIFF
--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -20,7 +20,7 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
     key = 'download_remote_source'
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow, remote_source_url,
+    def __init__(self, tasker, workflow, remote_source_url=None,
                  remote_source_build_args=None):
         """
         :param tasker: ContainerTasker instance
@@ -37,6 +37,10 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
         """
         Run the plugin.
         """
+        if not self.url:
+            self.log.info('No remote source url to download, skipping plugin')
+            return
+
         # Download the source code archive
         archive = download_url(self.url, self.workflow.source.workdir)
 


### PR DESCRIPTION
…_url

* OSBS-8478

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
