### PR TITLE
Handle resolve_remote_source skips

### DIFF
--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -361,7 +361,7 @@ def get_image_output(workflow, image_id, arch):
 
 
 def get_source_tarball_output(workflow):
-    plugin_results = workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE, {})
+    plugin_results = workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE) or {}
     remote_source_path = plugin_results.get('remote_source_path')
     if not remote_source_path:
         return None
@@ -372,7 +372,7 @@ def get_source_tarball_output(workflow):
 
 
 def get_remote_source_json_output(workflow):
-    plugin_results = workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE, {})
+    plugin_results = workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE) or {}
     remote_source_json = plugin_results.get('remote_source_json')
     if not remote_source_json:
         return None

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -519,6 +519,8 @@ def mock_environment(tmpdir, session=None, name=None,
             'remote_source_json': {'stub': 'data'},
             'remote_source_path': source_path}
         workflow.prebuild_results[PLUGIN_RESOLVE_REMOTE_SOURCE] = remote_source_result
+    else:
+        workflow.prebuild_results[PLUGIN_RESOLVE_REMOTE_SOURCE] = None
 
     if push_operator_manifests_enabled:
         workflow.postbuild_results[PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY] = \


### PR DESCRIPTION
If resolve_remote_source does not run, returning None, the koji_util
functions relying on it should handle the None values.

* OSBS-8137

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
