### PR TITLE
Use NVR as a suffix for the remote source archive

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -169,4 +169,4 @@ KOJI_BTYPE_CONTAINER_FIRST = 'remote-sources'
 REMOTE_SOURCE_DIR = '/remote-source'
 
 # Name of downloaded remote sources tarball
-REMOTE_SOURCES_FILENAME = 'remote-sources.tar.gz'
+REMOTE_SOURCES_FILENAME = 'remote-source.tar.gz'

--- a/atomic_reactor/koji_util.py
+++ b/atomic_reactor/koji_util.py
@@ -360,13 +360,14 @@ def get_image_output(workflow, image_id, arch):
     return metadata, output
 
 
-def get_source_tarball_output(workflow):
+def get_source_tarball_output(workflow, nvr):
     plugin_results = workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE) or {}
     remote_source_path = plugin_results.get('remote_source_path')
     if not remote_source_path:
         return None
 
-    metadata = get_output_metadata(remote_source_path, REMOTE_SOURCES_FILENAME)
+    koji_archive_filename = '{}-{}'.format(nvr, REMOTE_SOURCES_FILENAME)
+    metadata = get_output_metadata(remote_source_path, koji_archive_filename)
     output = Output(file=open(remote_source_path), metadata=metadata)
     return output
 

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -501,8 +501,9 @@ class KojiImportPlugin(ExitPlugin):
             output_files.append(output_file)
 
         # add remote source tarball and remote-source.json files to output
+        nvr = '{}-{}-{}'.format(build['name'], build['version'], build['release'])
         for remote_source_output in [
-            get_source_tarball_output(self.workflow),
+            get_source_tarball_output(self.workflow, nvr),
             get_remote_source_json_output(self.workflow)
         ]:
             if remote_source_output:

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -2149,12 +2149,14 @@ class TestKojiImport(object):
 
     @pytest.mark.parametrize('has_remote_source', [True, False])
     def test_remote_sources(self, tmpdir, os_env, has_remote_source, reactor_config_map):
+        component, version, release = ('ns-name-container', '1.0', '1')
         session = MockedClientSession('')
         tasker, workflow = mock_environment(
             tmpdir,
             name='ns/name',
-            version='1.0',
-            release='1',
+            component=component,
+            version=version,
+            release=release,
             session=session,
             has_remote_source=has_remote_source)
 
@@ -2168,6 +2170,13 @@ class TestKojiImport(object):
         assert 'extra' in build
         extra = build['extra']
         assert isinstance(extra, dict)
+
+        uploaded_sources_name = '{}-{}-{}-{}'.format(
+            component,
+            version,
+            release,
+            REMOTE_SOURCES_FILENAME
+        )
         # https://github.com/PyCQA/pylint/issues/2186
         # pylint: disable=W1655
         if has_remote_source:
@@ -2177,12 +2186,12 @@ class TestKojiImport(object):
             assert 'remote-sources' in extra['typeinfo']
             assert 'remote_source_url' in extra['typeinfo']['remote-sources']
             assert extra['typeinfo']['remote-sources']['remote_source_url'] == 'example.com'
-            assert REMOTE_SOURCES_FILENAME in session.uploaded_files.keys()
+            assert uploaded_sources_name in session.uploaded_files.keys()
             assert 'remote-source.json' in session.uploaded_files.keys()
         else:
             assert 'remote_source_url' not in extra['image']
             assert 'typeinfo' not in extra
-            assert REMOTE_SOURCES_FILENAME not in session.uploaded_files.keys()
+            assert uploaded_sources_name not in session.uploaded_files.keys()
             assert 'remote-source.json' not in session.uploaded_files.keys()
 
     @pytest.mark.parametrize('blocksize', (None, 1048576))

--- a/tests/test_cachito_util.py
+++ b/tests/test_cachito_util.py
@@ -155,7 +155,7 @@ def test_wait_for_request_bad_request_type():
 ))
 def test_download_sources(tmpdir, cachito_request):
     blob = 'glop-glop-I\'m-a-blob'
-    expected_dest_path = os.path.join(str(tmpdir), 'remote-sources.tar.gz')
+    expected_dest_path = os.path.join(str(tmpdir), 'remote-source.tar.gz')
 
     responses.add(
         responses.GET,


### PR DESCRIPTION
* Relates to OSBS-8137
* Relates to FACTORY-5450

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
