### PR TITLE
Use koji support for retries

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -145,6 +145,9 @@ GIT_BACKOFF_FACTOR = 5
 KOJI_RESERVE_MAX_RETRIES = 20
 # wait for 2sec (usual time of bump_release with reserve)
 KOJI_RESERVE_RETRY_DELAY = 2
+KOJI_MAX_RETRIES = 120
+KOJI_RETRY_INTERVAL = 60
+KOJI_OFFLINE_RETRY_INTERVAL = 120
 
 # Media types
 MEDIA_TYPE_DOCKER_V2_SCHEMA1 = "application/vnd.docker.distribution.manifest.v1+json"


### PR DESCRIPTION
* OSBS-7758

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
