### PR TITLE
log dockerfile only if builder isn't None

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -619,7 +619,8 @@ def build_inside(input_method, input_args=None, substitutions=None):
     try:
         build_result = dbw.build_docker_image()
     except Exception as e:
-        logger.info("Dockerfile used for build:\n%s", dbw.builder.original_df)
+        if dbw.builder:
+            logger.info("Dockerfile used for build:\n%s", dbw.builder.original_df)
         logger.error('image build failed: %s', e)
         raise
     else:


### PR DESCRIPTION
* OSBS-8397

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
