### PR TITLE
Allow cachito integration without koji

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -335,6 +335,11 @@
                 "description": "Don't check SSL certificate for api_url",
                 "type": "boolean"
             },
+            "unknown_user": {
+                "description": "User to set in cachito request user param in case koji user is not found",
+                "type": "string",
+                "default": "unknown_user"
+            },
             "auth": {
                 "description": "Authentication information",
                 "type": "object",


### PR DESCRIPTION
When using osbs-client directly, there will be no koji user to forward
to cachito. We allow the build to proceed by setting the cachito request
user param as 'unknown_user', which can be configured through the
reactor configmap.

* OSBS-8503
* OSBS-8375

Signed-off-by: Athos Ribeiro <athos@redhat.com>


Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
