### PR TITLE
imagebuilder does not accept build args after dir/Dockerfile param

### DIFF
--- a/atomic_reactor/plugins/build_imagebuilder.py
+++ b/atomic_reactor/plugins/build_imagebuilder.py
@@ -45,14 +45,16 @@ class ImagebuilderPlugin(BuildStepPlugin):
 
         allow_repo_dir_in_dockerignore(builder.df_dir)
 
-        process_args = ['imagebuilder', '-t', image, builder.df_dir]
+        process_args = ['imagebuilder', '-t', image]
         for buildarg, buildargval in builder.buildargs.items():
-            process_args.append('-build-arg')
+            process_args.append('--build-arg')
             process_args.append('%s="%s"' % (buildarg, buildargval))
+        process_args.append(builder.df_dir)
 
         ib_process = subprocess.Popen(process_args, **kwargs)
 
         self.log.debug('imagebuilder build has begun; waiting for it to finish')
+        self.log.debug(process_args)
         output = []
         while True:
             poll = ib_process.poll()

--- a/tests/plugins/test_imagebuilder.py
+++ b/tests/plugins/test_imagebuilder.py
@@ -87,10 +87,11 @@ def test_popen_cmd(docker_tasker, workflow, image_id):
 
     real_popen = subprocess.Popen
 
-    process_args = ['imagebuilder', '-t', fake_builder.image.to_str(), fake_builder.df_dir]
+    process_args = ['imagebuilder', '-t', fake_builder.image.to_str()]
     for argname, argval in fake_builder.buildargs.items():
-        process_args.append('-build-arg')
+        process_args.append('--build-arg')
         process_args.append('%s="%s"' % (argname, argval))
+    process_args.append(fake_builder.df_dir)
 
     flexmock(subprocess, Popen=lambda *args, **kw: real_popen(['echo', '-n', str(args)], **kw))
     workflow.build_docker_image()


### PR DESCRIPTION
* OSBS-8514

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
