### PR TITLE
Fix container build dir for remote source archive

### DIFF
--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -47,10 +47,13 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
         # Download the source code archive
         archive = download_url(self.url, self.workflow.source.workdir)
 
-        # Unpack the source code archive into a dedicated dir in workdir
-        dest_dir = os.path.join(self.workflow.source.workdir, self.REMOTE_SOURCE)
+        # Unpack the source code archive into a dedicated dir in container build workdir
+        dest_dir = os.path.join(self.workflow.builder.df_dir, self.REMOTE_SOURCE)
         if not os.path.exists(dest_dir):
             os.makedirs(dest_dir)
+        else:
+            raise RuntimeError('Conflicting path {} already exists in the dist-git repository'
+                               .format(self.REMOTE_SOURCE))
 
         with tarfile.open(archive) as tf:
             tf.extractall(dest_dir)


### PR DESCRIPTION
The remote source archive must be extracted in a directory visible for
the container engine to copy from into the container during build time.
The path should also consider
https://github.com/openshift/imagebuilder/issues/139

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
