### PR TITLE
Rename constant for remote-sources Koji BTtype

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -166,7 +166,7 @@ OPERATOR_MANIFESTS_ARCHIVE = 'operator_manifests.zip'
 
 KOJI_BTYPE_IMAGE = 'image'
 KOJI_BTYPE_OPERATOR_MANIFESTS = 'operator-manifests'
-KOJI_BTYPE_CONTAINER_FIRST = 'remote-sources'
+KOJI_BTYPE_REMOTE_SOURCES = 'remote-sources'
 
 # Path to where the remote source bundle is copied to during the build process
 REMOTE_SOURCE_DIR = '/remote-source'

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -48,7 +48,7 @@ from atomic_reactor.constants import (
     PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
     PLUGIN_RESOLVE_REMOTE_SOURCE,
     METADATA_TAG, OPERATOR_MANIFESTS_ARCHIVE,
-    KOJI_BTYPE_CONTAINER_FIRST,
+    KOJI_BTYPE_REMOTE_SOURCES,
     KOJI_BTYPE_OPERATOR_MANIFESTS,
 )
 from atomic_reactor.util import (Output, get_build_json,
@@ -271,7 +271,7 @@ class KojiImportPlugin(ExitPlugin):
         if remote_source_result:
             url = remote_source_result['annotations']['remote_source_url']
             remote_source_typeinfo = {
-                KOJI_BTYPE_CONTAINER_FIRST: {
+                KOJI_BTYPE_REMOTE_SOURCES: {
                     'remote_source_url': url,
                 },
             }
@@ -506,7 +506,7 @@ class KojiImportPlugin(ExitPlugin):
             get_remote_source_json_output(self.workflow)
         ]:
             if remote_source_output:
-                add_custom_type(remote_source_output, KOJI_BTYPE_CONTAINER_FIRST)
+                add_custom_type(remote_source_output, KOJI_BTYPE_REMOTE_SOURCES)
                 remote_source = add_buildroot_id(remote_source_output, buildroot_id)
                 output_files.append(remote_source)
                 output.append(remote_source.metadata)


### PR DESCRIPTION
This reflects reality better. It was probably just forgotten with old
name

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
