### PR TITLE
Whitelist annotation must be set as string

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -180,7 +180,7 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         koji_config = get_koji(self.workflow, {})
         whitelist = koji_config.get('task_annotations_whitelist')
         if whitelist:
-            annotations['koji_task_annotations_whitelist'] = whitelist
+            annotations['koji_task_annotations_whitelist'] = json.dumps(whitelist)
 
     def _update_annotations(self, annotations, updates):
         if updates:

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -830,6 +830,8 @@ def test_set_koji_annotations_whitelist(tmpdir, koji_conf):
     if whitelist:
         assert 'koji_task_annotations_whitelist' in annotations
         assert all(entry in whitelist for entry in koji_conf['task_annotations_whitelist'])
+        assert all(entry in whitelist for entry in json.loads(
+            annotations['koji_task_annotations_whitelist']))
     else:
         assert 'koji_task_annotations_whitelist' not in annotations
 


### PR DESCRIPTION
The OpenShift build annotation must be set as a string and then
converted to a list, if needed.

* OSBS-8138

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
