### PR TITLE
Add support for cachito dependency replacements

### DIFF
--- a/atomic_reactor/cachito_util.py
+++ b/atomic_reactor/cachito_util.py
@@ -52,14 +52,18 @@ class CachitoAPI(object):
             session.cert = cert
         return session
 
-    def request_sources(self, repo, ref, flags=None, pkg_managers=None, user=None):
+    def request_sources(self, repo, ref, flags=None, pkg_managers=None, user=None,
+                        dependency_replacements=None):
         """Start a new Cachito request
 
         :param repo: str, the URL to the SCM repository
         :param ref: str, the SCM reference to fetch
+        :param flags: list<str>, list of flag names
         :param pkg_managers: list<str>, list of package managers to be used for resolving
                              dependencies
-        :param flags: list<str>, list of flag names
+        :param user: str, user the request is created on behalf of. This is reserved for privileged
+                     users that can act as cachito representatives
+        :param dependency_replacements: list<dict>, dependencies to be replaced by cachito
 
         :return: dict, representation of the created Cachito request
         :raise CachitoAPIInvalidRequest: if Cachito determines the request is invalid
@@ -70,6 +74,7 @@ class CachitoAPI(object):
             'flags': flags,
             'pkg_managers': pkg_managers,
             'user': user,
+            'dependency_replacements': dependency_replacements,
         }
         # Remove None values
         payload = {k: v for k, v in payload.items() if v}

--- a/tests/test_cachito_util.py
+++ b/tests/test_cachito_util.py
@@ -33,6 +33,12 @@ CACHITO_REQUEST_REPO = 'https://github.com/release-engineering/retrodep.git'
     {'flags': ['spam', 'bacon']},
     {'pkg_managers': ['gomod']},
     {'user': 'ham'},
+    {'dependency_replacements': [{
+        'name': 'eample.com/repo/project',
+        'type': 'gomod',
+        'version': '1.1.1',
+        }]
+     },
 ))
 def test_request_sources(additional_params, caplog):
     response_data = {'id': CACHITO_REQUEST_ID}


### PR DESCRIPTION
* OSBS-8139

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
