### PR TITLE
add logging for yum repos and compose ids

### DIFF
--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -92,3 +92,5 @@ class InjectYumRepoPlugin(PreBuildPlugin):
         yum_repos = list(self.workflow.files)
         add_yum_repos_to_dockerfile(yum_repos, df, inherited_user,
                                     self.workflow.builder.base_from_scratch)
+        for repo in yum_repos:
+            self.log.info("injected yum repo: %s", repo)

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 from __future__ import unicode_literals, absolute_import
 
+from copy import deepcopy
 from datetime import datetime, timedelta
 import os
 import yaml
@@ -168,12 +169,20 @@ class ResolveComposesPlugin(PreBuildPlugin):
                            build_info['nvr'], build_info['id'])
 
         all_compose_ids = set(self.compose_ids)
+        original_compose_ids = deepcopy(all_compose_ids)
         all_compose_ids.update(parent_compose_ids)
         self.all_compose_ids = list(all_compose_ids)
+        for compose_id in all_compose_ids:
+            if compose_id not in original_compose_ids:
+                self.log.info('Inheriting compose id %s', compose_id)
 
         all_yum_repos = set(self.repourls)
+        original_yum_repos = deepcopy(all_yum_repos)
         all_yum_repos.update(parent_repourls)
         self.repourls = list(all_yum_repos)
+        for repo in all_yum_repos:
+            if repo not in original_yum_repos:
+                self.log.info('Inheriting yum repo %s', repo)
 
     def read_configs(self):
         self.odcs_config = get_config(self.workflow).get_odcs_config()
@@ -330,6 +339,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
 
         for arch, repofiles in repos_by_arch.items():
             override_build_kwarg(self.workflow, 'yum_repourls', repofiles, arch)
+
         # Only set the None override if there are no other repos
         if not repos_by_arch:
             override_build_kwarg(self.workflow, 'yum_repourls', noarch_repos, None)

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -299,7 +299,7 @@ class TestResolveComposes(object):
     ])
     def test_inherit_parents(self, workflow, reactor_config_map, parent_compose, parent_repourls,
                              repo_provided, inherit_parent, scratch, isolated, allow_inherit,
-                             compose_defined, ids):
+                             compose_defined, ids, caplog):
         arches = ['ppc64le', 'x86_64']
         if inherit_parent and compose_defined:
             repo_config = dedent("""\
@@ -447,11 +447,17 @@ class TestResolveComposes(object):
         else:
             assert set(nonearch_repourls) == set(expected_yum_repourls)
 
+        if allow_inherit and parent_compose:
+            for parent_id in parent_compose_ids:
+                assert 'Inheriting compose id {}'.format(parent_id) in caplog.text
+
         all_yum_repourls = []
         if repo_provided:
             all_yum_repourls = list(current_repourl)
         if allow_inherit and parent_repourls:
             all_yum_repourls.extend(parent_repo)
+            assert 'Inheriting yum repo http://example.com/parent.repo' in caplog.text
+
         assert set(workflow.all_yum_repourls) == set(all_yum_repourls)
 
     @pytest.mark.parametrize('arches', (

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -496,7 +496,7 @@ def test_multiple_repourls(tmpdir):
     ),
 ])
 def test_multistage_dockerfiles(name, inherited_user, dockerfile, expect_cleanup_lines,
-                                base_from_scratch, tmpdir):
+                                base_from_scratch, tmpdir, caplog):
     # expect repo ADD instructions where indicated in the content, and RUN rm at the end.
     # begin by splitting on "### ADD HERE" so we know where to expect changes.
     segments = re.split(r'^.*ADD HERE.*$\n?', dockerfile, flags=re.M)
@@ -527,6 +527,7 @@ def test_multistage_dockerfiles(name, inherited_user, dockerfile, expect_cleanup
     # the rest of the lines should be cleanup lines
     cleanup_lines = new_df[len(expected_lines):]
     assert remove_lines_match(cleanup_lines, expect_cleanup_lines, [repo_file])
+    assert "injected yum repo: /etc/yum.repos.d/myrepo.repo" in caplog.text
 
 
 def test_empty_dockerfile(tmpdir):


### PR DESCRIPTION
Fixes OSBS-8381

Add explicit logging of injected yum repos and inherited yum repos and compose ids.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
