### PR TITLE
include task_id in email from sendmail plugin

### DIFF
--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -259,6 +259,7 @@ class SendMailPlugin(ExitPlugin):
             'Repositories: %(repositories)s',
             'Status: %(endstate)s',
             'Submitted by: %(user)s',
+            'Task id: %(task_id)s'
         ])
 
         # Failed autorebuilds include logs as attachments.
@@ -286,7 +287,8 @@ class SendMailPlugin(ExitPlugin):
             'image_name': image_name,
             'endstate': endstate,
             'user': '<autorebuild>' if rebuild else self.submitter,
-            'logs': url
+            'logs': url,
+            'task_id': self.koji_task_id
         }
 
         vcs = self.workflow.source.get_vcs_info()

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -537,17 +537,18 @@ class TestSendMailPlugin(object):
         common_body = [
             'Status: ' + status,
             'Submitted by: ',
+            'Task id: ' + str(MOCK_KOJI_TASK_ID),
             'Source url: ' + git_source_url,
             'Source ref: ' + git_source_ref,
         ]
         exp_body.extend(common_body)
 
         if autorebuild:
-            exp_body[-3] += '<autorebuild>'
+            exp_body[-4] += '<autorebuild>'
         elif koji_integration and to_koji_submitter:
-            exp_body[-3] += MOCK_KOJI_SUBMITTER_EMAIL
+            exp_body[-4] += MOCK_KOJI_SUBMITTER_EMAIL
         else:
-            exp_body[-3] += SendMailPlugin.DEFAULT_SUBMITTER
+            exp_body[-4] += SendMailPlugin.DEFAULT_SUBMITTER
 
         if log_url_cases[(koji_integration, autorebuild, success)]:
             if has_koji_logs:


### PR DESCRIPTION
* OSBS-8557

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
