### PR TITLE
flatpak_create_dockerfile: Improve method of disabling system repos

### DIFF
--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -33,7 +33,7 @@ def add_yum_repos_to_dockerfile(yumrepos, df, inherited_user, base_from_scratch)
 
     # Insert the ADD line at the beginning of each stage
     df.add_lines(
-        "ADD %s* '%s'" % (RELATIVE_REPOS_PATH, YUM_REPOS_DIR),
+        "ADD %s* %s" % (RELATIVE_REPOS_PATH, YUM_REPOS_DIR),
         all_stages=True, at_start=True, skip_scratch=True
     )
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -152,6 +152,8 @@ def test_flatpak_create_dockerfile(tmpdir, docker_tasker,
         assert "FROM " + expect_base_image in df
         assert 'name="{}"'.format(config['name']) in df
         assert 'com.redhat.component="{}"'.format(config['component']) in df
+        assert "RUN rm -f /etc/yum.repos.d/*" in df
+        assert "ADD atomic-reactor-repos/* /etc/yum.repos.d/" in df
 
         m = re.search(r'module enable\s*(.*?)\s*&&', df)
         assert m

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -85,7 +85,7 @@ CMD blabla"""
     assert InjectYumRepoPlugin.key is not None
 
     expected_output = r"""FROM fedora
-ADD atomic-reactor-repos/* '/etc/yum.repos.d/'
+ADD atomic-reactor-repos/* /etc/yum.repos.d/
 RUN yum install -y python-django
 CMD blabla
 RUN rm -f '/etc/yum.repos.d/atomic-reactor-injected.repo'
@@ -117,7 +117,7 @@ CMD blabla"""
     assert InjectYumRepoPlugin.key is not None
 
     expected_output = r"""FROM fedora
-ADD atomic-reactor-repos/* '/etc/yum.repos.d/'
+ADD atomic-reactor-repos/* /etc/yum.repos.d/
 RUN yum install -y httpd                    uwsgi
 CMD blabla
 RUN rm -f '/etc/yum.repos.d/atomic-reactor-injected.repo'
@@ -269,7 +269,7 @@ def test_single_repourl(tmpdir):
         # Should see a single add line.
         after_add = before_add + 1
         assert (newdf[before_add:after_add] ==
-                ["ADD %s* '/etc/yum.repos.d/'\n" % RELATIVE_REPOS_PATH])
+                ["ADD %s* /etc/yum.repos.d/\n" % RELATIVE_REPOS_PATH])
 
         # Lines from there up to the remove line should be unchanged.
         before_remove = after_add + len(df_content.lines_before_remove)
@@ -319,7 +319,7 @@ def test_multiple_repourls(tmpdir):
         # Should see a single add line.
         after_add = before_add + 1
         assert (newdf[before_add:after_add] ==
-                ["ADD %s* '/etc/yum.repos.d/'\n" % RELATIVE_REPOS_PATH])
+                ["ADD %s* /etc/yum.repos.d/\n" % RELATIVE_REPOS_PATH])
 
         # Lines from there up to the remove line should be unchanged.
         before_remove = after_add + len(df_content.lines_before_remove)
@@ -504,7 +504,7 @@ def test_multistage_dockerfiles(name, inherited_user, dockerfile, expect_cleanup
 
     # build expected contents by manually inserting expected ADD lines between the segments
     for lines in segment_lines[:-1]:
-        lines.append("ADD %s* '/etc/yum.repos.d/'\n" % RELATIVE_REPOS_PATH)
+        lines.append("ADD %s* /etc/yum.repos.d/\n" % RELATIVE_REPOS_PATH)
     expected_lines = list(itertools.chain.from_iterable(segment_lines))  # flatten lines
 
     # now run the plugin to transform the given dockerfile


### PR DESCRIPTION
The previous way we disabled repositories from the base image required
knowing a set of patterns for repository names injected by atomic-reactor;
but when repositories are added with the yum_repourls option, this isn't
possible - the repository names come from the source repository files.

So, instead remove all repositories from the system, and then re-add the
repositories injected by atomic-reactor via pre_inject_yum_repo.



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
