### PR TITLE
flatpak_create_dockerfile: allow overriding base image

### DIFF
--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -104,7 +104,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
         # call parent constructor
         super(FlatpakCreateDockerfilePlugin, self).__init__(tasker, workflow)
 
-        self.base_image = get_flatpak_base_image(workflow, base_image)
+        self.default_base_image = get_flatpak_base_image(workflow, base_image)
 
     def _load_source(self):
         flatpak_yaml = self.workflow.source.config.flatpak
@@ -143,6 +143,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
 
         install_packages_str = ' '.join(builder.get_install_packages())
 
+        base_image = source.flatpak_yaml.get('base_image', self.default_base_image)
         name = source.flatpak_yaml.get('name', module_info.name)
         component = source.flatpak_yaml.get('component', module_info.name)
 
@@ -152,7 +153,7 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
                                                 component=component,
                                                 stream=module_info.stream.replace('-', '_'),
                                                 version=module_info.version,
-                                                base_image=self.base_image,
+                                                base_image=base_image,
                                                 modules=modules_str,
                                                 packages=install_packages_str,
                                                 rpm_qf_args=rpm_qf_args()))

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -35,6 +35,8 @@ The `flatpak` section of container.yaml contains extra information needed to cre
 
 **component**: (optional). `com.redhat.component` label in generated Dockerfile. Used to name the build when uploading to Koji. Defaults to the module name.
 
+**base_image**: (optional). image to use when creating filesystem; also will be recorded as the parent image of the output image. This overrides the `flatpak: base_image` setting in the reactor config.
+
 **branch**: (required) The branch of the application or runtime. In many cases, this will match the stream name of the module.
 
 **cleanup-commands**: (optional, runtime only). A shell script that is run after installing all packages.

--- a/tests/flatpak.py
+++ b/tests/flatpak.py
@@ -314,9 +314,9 @@ SDK_CONFIG = {
 
 def build_flatpak_test_configs(extensions=None):
     configs = {
-        'app': APP_CONFIG,
-        'runtime': RUNTIME_CONFIG,
-        'sdk': SDK_CONFIG,
+        'app': dict(APP_CONFIG),
+        'runtime': dict(RUNTIME_CONFIG),
+        'sdk': dict(SDK_CONFIG),
     }
 
     extensions = extensions or {}


### PR DESCRIPTION
The flatpak base_image ends up being used in two different ways:
 - To provide an environment to run dnf in to create the final filesystem
 - As the recorded parent image in openshift and koji

While the identity of the base image doesn't really matter at all for
the first usage, recording a parent that correctly matches a particular
branch of the distribution can help make things work correctly
automatic rebuilds, etc. For this reason, allow setting the base
image in container.yaml, instead of just in the global configuration.



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
