### PR TITLE
Allow specifying additional labels for Flatpaks in container.yaml

### DIFF
--- a/atomic_reactor/plugins/pre_add_flatpak_labels.py
+++ b/atomic_reactor/plugins/pre_add_flatpak_labels.py
@@ -1,0 +1,55 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+
+
+Pre build plugin which adds additional labels to the Dockerfile automatically
+created for a flatpak, based on the flatpak: labels key in container.yaml.
+"""
+
+from __future__ import unicode_literals, absolute_import
+
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.util import df_parser, label_to_string
+
+
+class AddFlatpakLabelsPlugin(PreBuildPlugin):
+    key = "add_flatpak_labels"
+    is_allowed_to_fail = False
+
+    def __init__(self, tasker, workflow):
+        """
+        constructor
+
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        """
+        # call parent constructor
+        super(AddFlatpakLabelsPlugin, self).__init__(tasker, workflow)
+
+    def run(self):
+        """
+        run the plugin
+        """
+        flatpak_yaml = self.workflow.source.config.flatpak
+        if flatpak_yaml is None:
+            return
+        labels = flatpak_yaml.get('labels')
+        if not labels:
+            return
+
+        dockerfile = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
+        lines = dockerfile.lines
+
+        # Sort to get repeatable results with Python2
+        formatted_labels = []
+        for k in sorted(labels):
+            formatted_labels.append(label_to_string(k, labels[k]))
+
+        # put labels at the end of dockerfile (since they change metadata and do not interact
+        # with FS, this should cause no harm)
+        lines.append('\nLABEL ' + " ".join(formatted_labels) + '\n')
+        dockerfile.lines = lines

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1327,6 +1327,30 @@ class LabelFormatter(string.Formatter):
         return (self.get_value(field_name, args, kwargs), field_name)
 
 
+# Make sure to escape '\' and '"' characters.
+try:
+    # py3
+    _label_env_trans = str.maketrans({'\\': '\\\\',
+                                      '"': '\\"'})
+except AttributeError:
+    # py2
+    _label_env_trans = None
+
+
+def _label_escape(s):
+    if _label_env_trans:
+        return s.translate(_label_env_trans)
+    return s.replace('\\', '\\\\').replace('"', '\\"')
+
+
+def label_to_string(key, value):
+    """Return a string "<key>"="<value>" with proper escaping to appear in
+    a label statement. Multiple values results can be combined and used as
+    LABEL "key"="value" "key2"="value2"
+    """
+    return '"%s"="%s"' % (_label_escape(key), _label_escape(value))
+
+
 class SessionWithTimeout(requests.Session):
     """
     requests Session with added timeout

--- a/docs/flatpak.md
+++ b/docs/flatpak.md
@@ -43,6 +43,8 @@ The `flatpak` section of container.yaml contains extra information needed to cre
 
 **command**: (optional, application only). The name of the executable to run to start the application. If not specified, defaults to the first executable found in /usr/bin.
 
+**labels**: (optional). A map defining additional labels to be added to the resulting image.
+
 **tags**: (optional, application only). Tags to add to the Flatpak metadata for searching.
 
 **finish-args**: (optional, application only). Arguments to `flatpak build-finish`. (see the flatpak-build-finish man page.) This is a string split on whitespace with shell style quoting.
@@ -74,6 +76,8 @@ flatpak:
     id: org.gnome.eog
     branch: stable
     command: eog
+    labels:
+        maintainer: susan@example.com
     tags: ["Viewer"]
     finish-args: >
         --filesystem=host

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -46,6 +46,7 @@ from atomic_reactor.util import (ImageName, wait_for_command,
                                  get_build_json, is_scratch_build, is_isolated_build, df_parser,
                                  base_image_is_custom,
                                  are_plugins_in_order, LabelFormatter,
+                                 label_to_string,
                                  guess_manifest_media_type,
                                  get_manifest_media_type,
                                  get_manifest_media_version,
@@ -1041,6 +1042,16 @@ def test_label_formatter(labels, test_string, expected):
     else:
         with pytest.raises(KeyError):
             LabelFormatter().vformat(test_string, [], labels)
+
+
+@pytest.mark.parametrize(('key', 'value', 'expected'), [
+    ('a', 'b', '"a"="b"'),
+    ('a"', 'b"', '"a\\""="b\\""'),
+    ('a""', 'b""', '"a\\"\\""="b\\"\\""'),
+    ('a\\', 'b\\', '"a\\\\"="b\\\\"'),
+])
+def test_label_to_string(key, value, expected):
+    assert expected == label_to_string(key, value)
 
 
 @pytest.mark.parametrize(('tag_conf', 'tag_annotation', 'expected_primary',


### PR DESCRIPTION
If a user wants to add an additional labels on the resulting Flatpak image, like a `maintainer` label, then they need a way to do it without modifying the Dockerfile (since the Dockerfile for Flaptaks is autogenerated). 

This PR adds a new plugin `add_flatpak_labels` that reads the `labels` key from the `flatpak` section of `container.yaml` and adds a LABEL line to the resulting Dockerfile with the given labels.

Some relevant code from `add_labels_in_df` is moved into a utility function.

Corresponding patches to osbs-client and osbs-docs will be needed.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
