### PR TITLE
new koji build metadata osbs_build providing information about build

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -173,3 +173,9 @@ REMOTE_SOURCE_DIR = '/remote-source'
 
 # Name of downloaded remote sources tarball
 REMOTE_SOURCES_FILENAME = 'remote-source.tar.gz'
+
+# koji osbs_build metadata
+KOJI_KIND_IMAGE_BUILD = 'container_build'
+KOJI_KIND_IMAGE_SOURCE_BUILD = 'source_container_build'
+KOJI_SUBTYPE_OP_APPREGISTRY = 'operator_appregistry'
+KOJI_SOURCE_ENGINE = 'bsi'

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -88,9 +88,16 @@ Data which is placed here includes:
 
 - `build.extra.typeinfo.operator-manifests.archive` (string): name of the archive containing operator manifest files
 
+General build info metadata is placed in `build.extra.osbs_build`.
+
+Data which is placed here includes:
+- `build.extra.osbs_build.kind` (string): build kind, either container_build or source_container_build
+- `build.extra.osbs_build.subtypes`(str list): build subtypes: flatpak, operator_appregistry and others might be added in future
+- `build.extra.osbs_build.engine` (string): build engine to build image, bsi (for source containers), docker_api, imagebuilder, buildah_bud
+
 # Type-specific source container build metadata
 
-The same note about `image` and `build.extra.typeinfo.image` from previous section applies here.
+The same note about `image`, `build.extra.typeinfo.image` and `build.extra.osbs_build` from previous section applies here.
 
 Data which is placed here includes:
 


### PR DESCRIPTION
kind, subtypes and engine

* OSBS-8618

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
