### PR TITLE
get_manifest should handle when response is None

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -929,6 +929,8 @@ def get_manifest(image, registry_session, version):
     try:
         response = query_registry(registry_session, image, digest=None, version=version)
     except (HTTPError, RetryError) as ex:
+        if ex.response is None:
+            raise
         if ex.response.status_code == requests.codes.not_found:
             saved_not_found = ex
         # If the registry has a v2 manifest that can't be converted into a v1


### PR DESCRIPTION
* OSBS-8600

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
