### PR TITLE
Fix: don't run dockerfile checks for Flatpak

### DIFF
--- a/atomic_reactor/plugins/pre_check_user_settings.py
+++ b/atomic_reactor/plugins/pre_check_user_settings.py
@@ -30,8 +30,24 @@ class CheckUserSettingsPlugin(PreBuildPlugin):
     key = PLUGIN_CHECK_USER_SETTINGS
     is_allowed_to_fail = False
 
+    def __init__(self, tasker, workflow, flatpak=False):
+        """
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param flatpak: bool, if build is for flatpak
+        """
+        super(CheckUserSettingsPlugin, self).__init__(tasker, workflow)
+
+        self.flatpak = flatpak
+
     def dockerfile_checks(self):
         """Checks for Dockerfile"""
+        if self.flatpak:
+            self.log.info(
+                "Skipping Dockerfile checks because this is flatpak build "
+                "without user Dockerfile")
+            return
+
         self.appregistry_bundle_label_mutually_exclusive()
 
     def appregistry_bundle_label_mutually_exclusive(self):


### PR DESCRIPTION
Flatpak builds have no user Dockerfiles specified

* OSBS-8634

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
