### PR TITLE
Add missing whitespace to error message

### DIFF
--- a/atomic_reactor/plugins/pre_check_user_settings.py
+++ b/atomic_reactor/plugins/pre_check_user_settings.py
@@ -56,7 +56,7 @@ class CheckUserSettingsPlugin(PreBuildPlugin):
         are mutually exclusive. Fail when both are specified.
         """
         msg = (
-            "only one of labels com.redhat.com.delivery.appregistry"
+            "only one of labels com.redhat.com.delivery.appregistry "
             "and com.redhat.delivery.operator.bundle is allowed"
         )
         self.log.debug("Running check: %s", msg)


### PR DESCRIPTION
* OSBS-8634

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
