### PR TITLE
build_orchestrate_build: adjust for the removal of build_image

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -447,7 +447,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
                                                               self.osbs_client_config_fallback)
 
         if platform in self.build_image_digests:
-            kwargs['build_image'] = self.build_image_digests[platform]
+            kwargs['build_from'] = 'image:' + self.build_image_digests[platform]
         else:
             raise RuntimeError("build_image for platform '%s' not available" % platform)
 

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -409,7 +409,7 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
     # always has precedence over worker_build_image param.
     if config_kwargs is not None:
         expected_kwargs.update(config_kwargs)
-    expected_kwargs['build_image'] = 'registry/some_image@sha256:123456'
+    expected_kwargs['build_from'] = 'image:registry/some_image@sha256:123456'
 
     (flexmock(atomic_reactor.plugins.pre_reactor_config)
      .should_receive('get_openshift_session')
@@ -1639,10 +1639,10 @@ def test_set_build_image_with_override(tmpdir, platforms, override):
     runner.run()
 
     for plat in platforms:
-        used_build_image = get_worker_build_info(workflow, plat).osbs.build_conf.get_build_image()
-        expected_build_image = reactor_config['build_image_override'].get(plat,
-                                                                          default_build_image)
-        assert used_build_image == expected_build_image
+        used_image = get_worker_build_info(workflow, plat).osbs.build_conf.get_build_from()
+        expected_image = 'image:' + reactor_config['build_image_override'].get(plat,
+                                                                               default_build_image)
+        assert used_image == expected_image
 
 
 def test_no_platforms(tmpdir):


### PR DESCRIPTION
build_image is no longer valid in osbs-client, so use a properly
formatted build_from line instead.

part of [osbs-933](https://github.com/containerbuildsystem/osbs-client/pull/933)

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
