### PR TITLE
Implement pin_operator_digest

### DIFF
--- a/atomic_reactor/operator_util.py
+++ b/atomic_reactor/operator_util.py
@@ -217,6 +217,8 @@ class OperatorManifest(object):
         :param path: Path to directory
         :return: OperatorManifest
         """
+        if not os.path.isdir(path):
+            raise RuntimeError("Path does not exist or is not a directory: {}".format(path))
         yaml_files = cls._get_yaml_files(path)
         operator_csvs = list(cls._get_csvs(yaml_files))
         return cls(operator_csvs)

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -8,11 +8,14 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import absolute_import, print_function
 
+import os.path
+
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import PLUGIN_PIN_OPERATOR_DIGESTS_KEY
-from atomic_reactor.util import has_operator_bundle_manifest
+from atomic_reactor.util import has_operator_bundle_manifest, get_manifest_digests, ImageName
 from atomic_reactor.plugins.pre_reactor_config import get_operator_manifests
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
+from atomic_reactor.operator_util import OperatorManifest
 
 
 class PinOperatorDigestsPlugin(PreBuildPlugin):
@@ -50,6 +53,9 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
         self.replacement_pullspecs = replacement_pullspecs
 
     def run(self):
+        """
+        Run pin_operator_digest plugin
+        """
         if self.should_run():
             if self.is_in_orchestrator():
                 return self.run_in_orchestrator()
@@ -57,6 +63,11 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
                 return self.run_in_worker()
 
     def should_run(self):
+        """
+        Determine if this is an operator manifest bundle build
+
+        :return: bool, should plugin run?
+        """
         if has_operator_bundle_manifest(self.workflow):
             return True
         else:
@@ -64,11 +75,164 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
             return False
 
     def run_in_orchestrator(self):
+        """
+        Run plugin in orchestrator. Find all image pullspecs,
+        compute their replacements and set build arg for worker
+        """
         try:
             self.site_config = get_operator_manifests(self.workflow)
         except KeyError:
-            raise RuntimeError("operator_manifests configuration missing in reactor config map")
-        override_build_kwarg(self.workflow, "operator_bundle_replacement_pullspecs", {})
+            msg = "operator_manifests configuration missing in reactor config map, aborting"
+            self.log.warning(msg)
+            return
+
+        operator_manifest = self._get_operator_manifest()
+        pullspecs = self._get_pullspecs(operator_manifest)
+
+        if pullspecs:
+            replacement_pullspecs = self._get_replacement_pullspecs(pullspecs)
+            self._set_worker_arg(replacement_pullspecs)
 
     def run_in_worker(self):
-        pass
+        """
+        Run plugin in worker. Replace image pullspecs
+        based on replacements computed in orchestrator.
+        """
+        if not self.replacement_pullspecs:
+            self.log.info("No pullspecs need to be replaced")
+            return
+
+        operator_manifest = self._get_operator_manifest()
+        replacement_pullspecs = {
+            ImageName.parse(old): ImageName.parse(new)
+            for old, new in self.replacement_pullspecs.items()
+        }
+
+        for operator_csv in operator_manifest.files:
+            self.log.info("Replacing pullspecs in %s", operator_csv.path)
+            operator_csv.replace_pullspecs(replacement_pullspecs)
+            operator_csv.dump()
+
+    def _get_operator_manifest(self):
+        if self.user_config is None:
+            raise RuntimeError("operator_manifest configuration missing in container.yaml")
+
+        manifests_dir = os.path.join(self.workflow.source.path, self.user_config["manifests_dir"])
+        self.log.info("Looking for operator CSV files in %s", manifests_dir)
+
+        operator_manifest = OperatorManifest.from_directory(manifests_dir)
+
+        if operator_manifest.files:
+            path_lines = "\n".join(f.path for f in operator_manifest.files)
+            self.log.info("Found operator CSV files:\n%s", path_lines)
+        else:
+            self.log.info("No operator CSV files found")
+
+        return operator_manifest
+
+    def _get_pullspecs(self, operator_manifest):
+        pullspecs = set()
+        for operator_csv in operator_manifest.files:
+            pullspecs.update(operator_csv.get_pullspecs())
+
+        if pullspecs:
+            pullspec_lines = "\n".join(sorted(map(str, pullspecs)))
+            self.log.info("Found pullspecs:\n%s", pullspec_lines)
+        else:
+            self.log.info("No pullspecs found")
+
+        return pullspecs
+
+    def _get_replacement_pullspecs(self, pullspecs):
+        self.log.info("Computing replacement pullspecs")
+        replacer = PullspecReplacer(user_config=self.user_config, site_config=self.site_config)
+
+        for p in pullspecs:
+            if not replacer.registry_is_allowed(p):
+                raise RuntimeError("Registry not allowed: {} (in {})".format(p.registry, p))
+
+        replacements = {}
+
+        for original in pullspecs:
+            pinned = replacer.pin_digest(original)
+            replaced = replacer.replace_registry(pinned)
+            if replaced != original:
+                replacements[original] = replaced
+
+        replacement_lines = "\n".join(
+            "{} -> {}".format(p, replacements[p]) if p in replacements
+            else "{} - no change".format(p)
+            for p in sorted(pullspecs, key=str)  # ImageName does not implement ordering
+        )
+        self.log.info("To be replaced:\n%s", replacement_lines)
+
+        return replacements
+
+    def _set_worker_arg(self, replacement_pullspecs):
+        arg = {str(old): str(new) for old, new in replacement_pullspecs.items()}
+        override_build_kwarg(self.workflow, "operator_bundle_replacement_pullspecs", arg)
+
+
+_KEEP = object()
+
+
+class PullspecReplacer(object):
+    """
+    Helper that takes care of replacing parts of image pullspecs
+    """
+
+    def __init__(self, user_config, site_config):
+        """
+        Initialize a PullspecReplacer
+
+        :param user_config: container.yaml operator_manifest configuration
+        :param site_config: reactor-config-map operator_manifests configuration
+        """
+        self.allowed_registries = site_config["allowed_registries"]
+        if self.allowed_registries is not None:
+            self.allowed_registries = set(self.allowed_registries)
+
+        self.registry_replace = {
+            registry["old"]: registry["new"]
+            for registry in site_config.get("registry_post_replace", [])
+        }
+
+    def registry_is_allowed(self, image):
+        """
+        Is image registry allowed in OSBS config?
+
+        :param image: ImageName
+        :return: bool
+        """
+        return self.allowed_registries is None or image.registry in self.allowed_registries
+
+    def pin_digest(self, image):
+        """
+        Replace image tag with manifest list digest
+
+        :param image: ImageName
+        :return: ImageName
+        """
+        if image.tag.startswith("sha256:"):
+            return image
+        digests = get_manifest_digests(image, image.registry, versions=("v2_list",))
+        return self._replace(image, tag="sha256:{}".format(digests["v2_list"]))
+
+    def replace_registry(self, image):
+        """
+        Replace image registry based on OSBS config
+
+        :param image: ImageName
+        :return: ImageName
+        """
+        if image.registry not in self.registry_replace:
+            return image
+        return self._replace(image, registry=self.registry_replace[image.registry])
+
+    def _replace(self, image, registry=_KEEP, namespace=_KEEP, repo=_KEEP, tag=_KEEP):
+        return ImageName(
+            registry=image.registry if registry is _KEEP else registry,
+            namespace=image.namespace if namespace is _KEEP else namespace,
+            repo=image.repo if repo is _KEEP else repo,
+            tag=image.tag if tag is _KEEP else tag,
+        )

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -145,7 +145,7 @@ These are run after 'git clone' is used to fetch the git repository content cont
    * Status: enabled
    * Overwrite parent image image reference.
  * **pin_operator_digest**
-   * Status: not yet enabled (implementation in progress)
+   * Status: enabled
    * Replace image pullspecs in operator manifest files (tag => digest, other replacements based on OSBS configuration)
 
 ### Buildstep plugins

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -6,20 +6,31 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
+
+from ruamel.yaml import YAML
 
 import pytest
+import responses
 
-from atomic_reactor.constants import PLUGIN_BUILD_ORCHESTRATE_KEY
+from atomic_reactor.constants import (PLUGIN_BUILD_ORCHESTRATE_KEY,
+                                      MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST)
+from atomic_reactor.util import ImageName
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
                                                        ReactorConfig,
                                                        WORKSPACE_CONF_KEY)
-from atomic_reactor.plugins.pre_pin_operator_digest import PinOperatorDigestsPlugin
+from atomic_reactor.plugins.build_orchestrate_build import (OrchestrateBuildPlugin,
+                                                            WORKSPACE_KEY_OVERRIDE_KWARGS)
+from atomic_reactor.plugins.pre_pin_operator_digest import (PinOperatorDigestsPlugin,
+                                                            PullspecReplacer)
 
 from tests.constants import TEST_IMAGE
 from tests.stubs import StubInsideBuilder, StubSource, StubConfig
+
+
+yaml = YAML()
 
 
 def mock_dockerfile(tmpdir, base='scratch', operator_bundle_label=True):
@@ -33,7 +44,8 @@ def mock_dockerfile(tmpdir, base='scratch', operator_bundle_label=True):
 
 def make_reactor_config(operators_config):
     config = {'version': 1}
-    config.update(operators_config)
+    if operators_config:
+        config['operator_manifests'] = operators_config
     return ReactorConfig(config)
 
 
@@ -93,13 +105,64 @@ def mock_env(docker_tasker, tmpdir, orchestrator,
     return runner
 
 
-class TestPinOperatorDigest(object):
-    def _get_site_config(self, allowed_registries=None):
-        return {
-            'operator_manifests': {
-                'allowed_registries': allowed_registries
-            }
+def mock_operator_csv(tmpdir, filename, pullspecs):
+    path = tmpdir.join(filename)
+    data = {
+        'kind': 'ClusterServiceVersion',
+        'spec': {
+            # It does not really matter where in the CSV these pullspecs go
+            # as long as operator_util is known to work properly
+            'relatedImages': [
+                {'name': 'foo-{}'.format(i + 1), 'image': image}
+                for i, image in enumerate(pullspecs)
+            ]
         }
+    }
+    with open(str(path), 'w') as f:
+        yaml.dump(data, f)
+    return path
+
+
+def mock_digest_query(pullspec, digest):
+    i = ImageName.parse(pullspec)
+    url = 'https://{}/v2/{}/{}/manifests/{}'.format(i.registry, i.namespace, i.repo, i.tag)
+    headers = {
+        'Content-Type': MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
+        'Docker-Content-Digest': digest
+    }
+    responses.add(responses.GET, url, headers=headers)
+
+
+def get_build_kwarg(workflow, k, platform=None):
+    """
+    Get build-kwarg override
+    """
+    key = OrchestrateBuildPlugin.key
+
+    workspace = workflow.plugin_workspace.get(key, {})
+    override_kwargs = workspace.get(WORKSPACE_KEY_OVERRIDE_KWARGS, {})
+    return override_kwargs.get(platform, {}).get(k)
+
+
+def get_site_config(allowed_registries=None, registry_post_replace=None):
+    registry_post_replace = registry_post_replace or {}
+    return {
+        'allowed_registries': allowed_registries,
+        'registry_post_replace': [
+            {'old': old, 'new': new} for old, new in registry_post_replace.items()
+        ]
+    }
+
+
+def get_user_config(manifests_dir):
+    return {
+        'manifests_dir': manifests_dir
+    }
+
+
+class TestPinOperatorDigest(object):
+    def _get_worker_arg(self, workflow):
+        return get_build_kwarg(workflow, "operator_bundle_replacement_pullspecs")
 
     @pytest.mark.parametrize('orchestrator', [True, False])
     def test_run_only_for_operator_bundle_label(self, orchestrator,
@@ -109,9 +172,222 @@ class TestPinOperatorDigest(object):
         runner.run()
         assert "Not an operator manifest bundle build, skipping plugin" in caplog.text
 
-    def test_missing_orchestrator_config(self, docker_tasker, tmpdir):
+    def test_missing_orchestrator_config(self, docker_tasker, tmpdir, caplog):
         runner = mock_env(docker_tasker, tmpdir, orchestrator=True)
+        runner.run()
+
+        msg = "operator_manifests configuration missing in reactor config map, aborting"
+        assert msg in caplog.text
+        assert "Looking for operator CSV files" not in caplog.text
+
+    @pytest.mark.parametrize('orchestrator', [True, False])
+    def test_missing_user_config(self, orchestrator, docker_tasker, tmpdir):
+        # make sure operator run does not fail because of missing site config
+        site_config = get_site_config()
+        # make sure worker run is not skipped because of missing replacements
+        replacement_pullspecs = {'a': 'b'}
+
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=orchestrator,
+                          site_config=site_config, replacement_pullspecs=replacement_pullspecs)
+
         with pytest.raises(PluginFailedException) as exc_info:
             runner.run()
-        msg = "operator_manifests configuration missing in reactor config map"
+        msg = "operator_manifest configuration missing in container.yaml"
         assert msg in str(exc_info.value)
+
+    @pytest.mark.parametrize('replacements', [None, {}])
+    def test_skip_worker_with_empty_replacements(self, replacements,
+                                                 docker_tasker, tmpdir, caplog):
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=False,
+                          replacement_pullspecs=replacements)
+        runner.run()
+        assert "No pullspecs need to be replaced" in caplog.text
+        assert "Looking for operator CSV files" not in caplog.text
+
+    @pytest.mark.parametrize('filepaths', [
+        [],
+        ['csv1.yaml', 'csv2.yaml']
+    ])
+    def test_orchestrator_no_pullspecs(self, filepaths, docker_tasker, tmpdir, caplog):
+        files = [mock_operator_csv(tmpdir, path, []) for path in filepaths]
+
+        user_config = get_user_config(manifests_dir=str(tmpdir))
+        site_config = get_site_config()
+
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=True,
+                          user_config=user_config, site_config=site_config)
+        runner.run()
+
+        caplog_text = "\n".join(rec.message for rec in caplog.records)
+
+        assert "Looking for operator CSV files in {}".format(tmpdir) in caplog_text
+        if files:
+            assert "Found operator CSV files:" in caplog_text
+            for f in files:
+                assert str(f) in caplog_text
+        else:
+            assert "No operator CSV files found" in caplog_text
+        assert "No pullspecs found" in caplog_text
+        assert self._get_worker_arg(runner.workflow) is None
+
+    def test_orchestrator_disallowed_registry(self, docker_tasker, tmpdir):
+        # TODO: ImageName parses x/y as namespace/repo and not registry/repo - does it matter?
+        pullspecs = ['allowed-registry/ns/foo:1', 'disallowed-registry/ns/bar:2']
+        mock_operator_csv(tmpdir, 'csv.yaml', pullspecs)
+
+        user_config = get_user_config(manifests_dir=str(tmpdir))
+        site_config = get_site_config(allowed_registries=['allowed-registry'])
+
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=True,
+                          user_config=user_config, site_config=site_config)
+
+        with pytest.raises(PluginFailedException) as exc_info:
+            runner.run()
+        msg = "Registry not allowed: disallowed-registry (in disallowed-registry/ns/bar:2)"
+        assert msg in str(exc_info.value)
+
+    @responses.activate
+    def test_orchestrator(self, docker_tasker, tmpdir, caplog):
+        pullspecs = [
+            'keep-registry/ns/foo',
+            'replace-registry/ns/bar:1',
+            'keep-registry/ns/spam@sha256:123456',
+            'replace-registry/ns/eggs@sha256:654321',
+        ]
+        replacement_registries = {
+            'replace-registry': 'new-registry'
+        }
+
+        mock_digest_query('keep-registry/ns/foo:latest', 'abcdef')
+        mock_digest_query('replace-registry/ns/bar:1', 'fedcba')
+        # there should be no queries for the pullspecs which already contain a digest
+
+        f = mock_operator_csv(tmpdir, 'csv.yaml', pullspecs)
+        pre_content = f.read()
+
+        user_config = get_user_config(manifests_dir=str(tmpdir))
+        site_config = get_site_config(registry_post_replace=replacement_registries)
+
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=True,
+                          user_config=user_config, site_config=site_config)
+        runner.run()
+
+        post_content = f.read()
+        assert pre_content == post_content  # worker does the replacement, not orchestrator
+
+        caplog_text = "\n".join(rec.message for rec in caplog.records)
+
+        # pullspecs are logged in alphabetical order, if tag is missing, :latest is added
+        pullspecs_log = (
+            'Found pullspecs:\n'
+            'keep-registry/ns/foo:latest\n'
+            'keep-registry/ns/spam@sha256:123456\n'
+            'replace-registry/ns/bar:1\n'
+            'replace-registry/ns/eggs@sha256:654321'
+        )
+        assert pullspecs_log in caplog_text
+
+        assert "Computing replacement pullspecs" in caplog_text
+
+        # replacements are logged in alphabetical order (ordered by the original pullspec)
+        replacements_log = (
+            'To be replaced:\n'
+            'keep-registry/ns/foo:latest -> keep-registry/ns/foo@sha256:abcdef\n'
+            'keep-registry/ns/spam@sha256:123456 - no change\n'
+            'replace-registry/ns/bar:1 -> new-registry/ns/bar@sha256:fedcba\n'
+            'replace-registry/ns/eggs@sha256:654321 -> new-registry/ns/eggs@sha256:654321'
+        )
+        assert replacements_log in caplog_text
+
+        replacement_pullspecs = {
+            'keep-registry/ns/foo:latest': 'keep-registry/ns/foo@sha256:abcdef',
+            'replace-registry/ns/bar:1': 'new-registry/ns/bar@sha256:fedcba',
+            'replace-registry/ns/eggs@sha256:654321': 'new-registry/ns/eggs@sha256:654321',
+        }
+        assert self._get_worker_arg(runner.workflow) == replacement_pullspecs
+
+    def test_worker(self, docker_tasker, tmpdir, caplog):
+        pullspecs = [
+            'keep-registry/ns/foo',
+            'replace-registry/ns/bar:1',
+            'keep-registry/ns/spam@sha256:123456',
+            'replace-registry/ns/eggs@sha256:654321',
+        ]
+        replacement_pullspecs = {
+            'keep-registry/ns/foo:latest': 'keep-registry/ns/foo@sha256:abcdef',
+            'replace-registry/ns/bar:1': 'new-registry/ns/bar@sha256:fedcba',
+            'replace-registry/ns/eggs@sha256:654321': 'new-registry/ns/eggs@sha256:654321',
+        }
+        replaced_pullspecs = [
+            'keep-registry/ns/foo@sha256:abcdef',
+            'new-registry/ns/bar@sha256:fedcba',
+            'keep-registry/ns/spam@sha256:123456',
+            'new-registry/ns/eggs@sha256:654321',
+        ]
+
+        manifests_dir = tmpdir.mkdir('manifests')
+        gets_replaced = mock_operator_csv(manifests_dir, 'csv1.yaml', pullspecs)
+        # this a reference file, make sure it does not get touched by putting it in parent dir
+        reference = mock_operator_csv(tmpdir, 'csv2.yaml', replaced_pullspecs)
+
+        user_config = get_user_config(manifests_dir=str(manifests_dir))
+
+        runner = mock_env(docker_tasker, tmpdir, orchestrator=False,
+                          user_config=user_config, replacement_pullspecs=replacement_pullspecs)
+        runner.run()
+
+        assert gets_replaced.read() == reference.read()
+
+        caplog_text = "\n".join(rec.message for rec in caplog.records)
+
+        assert 'Found operator CSV files:\n{}'.format(gets_replaced) in caplog_text
+        assert str(reference) not in caplog_text
+
+        assert 'Replacing pullspecs in {}'.format(gets_replaced) in caplog_text
+        assert 'Replacing pullspecs in {}'.format(reference) not in caplog_text
+
+
+class TestPullspecReplacer(object):
+    @pytest.mark.parametrize('allowed_registries, image, allowed', [
+        (None, 'registry/ns/foo', True),
+        (['registry'], 'registry/ns/foo', True),
+        ([], 'registry/ns/foo', False),  # not actually allowed in schema, but sensible
+        (['other-registry'], 'registry/ns/foo', False),
+    ])
+    def test_registry_is_allowed(self, allowed_registries, image, allowed):
+        site_config = get_site_config(allowed_registries=allowed_registries)
+        replacer = PullspecReplacer(user_config={}, site_config=site_config)
+        image = ImageName.parse(image)
+        assert replacer.registry_is_allowed(image) == allowed
+
+    @pytest.mark.parametrize('image, should_query, digest', [
+        ('registry/ns/foo', True, '123456'),
+        ('registry/ns/bar@sha256:654321', False, '654321'),
+    ])
+    @responses.activate
+    def test_pin_digest(self, image, should_query, digest):
+        image = ImageName.parse(image)
+        if should_query:
+            mock_digest_query(image, digest)
+
+        site_config = get_site_config()
+        replacer = PullspecReplacer(user_config={}, site_config=site_config)
+        replaced = replacer.pin_digest(image)
+
+        assert replaced.registry == image.registry
+        assert replaced.namespace == image.namespace
+        assert replaced.repo == image.repo
+        assert replaced.tag == 'sha256:{}'.format(digest)
+
+    @pytest.mark.parametrize('image, replacement_registries, replaced', [
+        ('old-registry/ns/foo', {'old-registry': 'new-registry'}, 'new-registry/ns/foo'),
+        ('registry/ns/foo', {}, 'registry/ns/foo'),
+    ])
+    def test_replace_registry(self, image, replacement_registries, replaced):
+        image = ImageName.parse(image)
+        replaced = ImageName.parse(replaced)
+
+        site_config = get_site_config(registry_post_replace=replacement_registries)
+        replacer = PullspecReplacer(user_config={}, site_config=site_config)
+
+        assert replacer.replace_registry(image) == replaced

--- a/tests/test_operator_util.py
+++ b/tests/test_operator_util.py
@@ -425,3 +425,21 @@ class TestOperatorManifest(object):
 
         manifest = OperatorManifest.from_directory(str(tmpdir))
         assert manifest.files == []
+
+    def test_directory_does_not_exist(self, tmpdir):
+        nonexistent = tmpdir.join("nonexistent")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            OperatorManifest.from_directory(str(nonexistent))
+
+        msg = "Path does not exist or is not a directory: {}".format(nonexistent)
+        assert str(exc_info.value) == msg
+
+        regular_file = tmpdir.join("some_file")
+        regular_file.write("hello")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            OperatorManifest.from_directory(str(regular_file))
+
+        msg = "Path does not exist or is not a directory: {}".format(regular_file)
+        assert str(exc_info.value) == msg


### PR DESCRIPTION
* OSBS-8637

Add the code that does what pin_operator_digest claims to do

Also add a minor fix for OperatorManifest (fail if path is not a directory)

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
