### PR TITLE
Implement repo name replacements

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, unicode_literals
 
 import os.path
 

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -678,6 +678,24 @@
             "minItems": 1,
             "examples": [null, ["registry.fedoraproject.org", "quay.io"]]
           },
+          "repo_replacements": {
+            "description": "Replacements for repos found in pullspecs, configured per registry",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "registry": {
+                  "type": "string"
+                },
+                "package_mappings_file": {
+                  "description": "Path to file containing repo replacement mappings",
+                  "type": "string"
+                }
+              },
+              "required": ["registry", "package_mappings_file"],
+              "additionalProperties": false
+            }
+          },
           "registry_post_replace": {
             "description": "After looking up image digest, replace original registries",
             "type": "array",

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -254,6 +254,31 @@
           "description": "Relative path to directory containing operator manifests",
           "type": "string",
           "pattern": "^[^/].*$"
+        },
+        "repo_replacements": {
+          "description": "Additional replacements for repos not available in OSBS site config",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "registry": {
+                "description": "Configure replacements for this registry",
+                "type": "string"
+              },
+              "package_mappings": {
+                "description": "Repo replacement mappings",
+                "type": "object",
+                "patternProperties": {
+                  ".*": {"type": "string"}
+                },
+                "examples": [
+                  {"foo-bar": "foo/bar", "spam-eggs": "spam/eggs"}
+                ]
+              }
+            },
+            "required": ["registry", "package_mappings"],
+            "additionalProperties": false
+          }
         }
       },
       "required": ["manifests_dir"],

--- a/atomic_reactor/schemas/package_mapping.json
+++ b/atomic_reactor/schemas/package_mapping.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Schema for [package => repos] mapping files used in operator bundle builds",
+
+  "type": "object",
+  "patternProperties": {
+    ".*": {
+      "type": "array",
+      "description": "List of possible repos that package can be mapped to",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    }
+  }
+}

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1474,6 +1474,9 @@ class TestReactorConfigPlugin(object):
               allowed_registries:
                 - foo
                 - bar
+              repo_replacements:
+                - registry: foo
+                  package_mappings_file: mapping.yaml
               registry_post_replace:
                 - old: foo
                   new: bar
@@ -1511,6 +1514,20 @@ class TestReactorConfigPlugin(object):
               registry_post_replace:
                 - new: foo
         """, False),  # missing original registry
+        ("""\
+          version: 1
+          operator_manifests:
+              allowed_registries: null
+              repo_replacements:
+                - registry: foo
+        """, False),  # missing package mappings file
+        ("""\
+          version: 1
+          operator_manifests:
+              allowed_registries: null
+              repo_replacements:
+                - package_mappings_file: mapping.yaml
+        """, False),  # missing registry
     ])
     def test_get_operator_manifests(self, config, valid):
         _, workflow = self.prepare()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -278,6 +278,23 @@ class TestSourceConfigSchemaValidation(object):
           {'operator_manifests': {
               'manifests_dir': 'path/to/manifests'
           }}
+        ), (
+          """\
+          operator_manifests:
+            manifests_dir: path/to/manifests
+            repo_replacements:
+              - registry: foo
+                package_mappings:
+                  bar: baz
+                  spam: eggs
+          """,
+          {'operator_manifests': {
+              'manifests_dir': 'path/to/manifests',
+              'repo_replacements': [
+                  {'registry': 'foo',
+                   'package_mappings': {'bar': 'baz', 'spam': 'eggs'}}
+              ]
+          }}
         ),
     ])
     def test_valid_source_config(self, tmpdir, yml_config, attrs_updated):
@@ -400,6 +417,15 @@ class TestSourceConfigSchemaValidation(object):
         """\
         operator_manifests:
           manifests_dir: /absolute/path
+        """,
+
+        """\
+        operator_manifests:
+          manifests_dir: some/path
+          repo_replacements:
+            - registry: foo
+              package_mappings:
+                bar: 1  # not a string
         """,
     ])
     def test_invalid_source_config_validation_error(self, tmpdir, yml_config):


### PR DESCRIPTION
* OSBS-8637

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
