### PR TITLE
operator manifests: Fix digest replacement

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -216,7 +216,7 @@ class PullspecReplacer(object):
         if image.tag.startswith("sha256:"):
             return image
         digests = get_manifest_digests(image, image.registry, versions=("v2_list",))
-        return self._replace(image, tag="sha256:{}".format(digests["v2_list"]))
+        return self._replace(image, tag=digests["v2_list"])
 
     def replace_registry(self, image):
         """

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -258,8 +258,8 @@ class TestPinOperatorDigest(object):
             'replace-registry': 'new-registry'
         }
 
-        mock_digest_query('keep-registry/ns/foo:latest', 'abcdef')
-        mock_digest_query('replace-registry/ns/bar:1', 'fedcba')
+        mock_digest_query('keep-registry/ns/foo:latest', 'sha256:abcdef')
+        mock_digest_query('replace-registry/ns/bar:1', 'sha256:fedcba')
         # there should be no queries for the pullspecs which already contain a digest
 
         f = mock_operator_csv(tmpdir, 'csv.yaml', pullspecs)
@@ -361,8 +361,8 @@ class TestPullspecReplacer(object):
         assert replacer.registry_is_allowed(image) == allowed
 
     @pytest.mark.parametrize('image, should_query, digest', [
-        ('registry/ns/foo', True, '123456'),
-        ('registry/ns/bar@sha256:654321', False, '654321'),
+        ('registry/ns/foo', True, 'sha256:123456'),
+        ('registry/ns/bar@sha256:654321', False, 'sha256:654321'),
     ])
     @responses.activate
     def test_pin_digest(self, image, should_query, digest):
@@ -377,7 +377,7 @@ class TestPullspecReplacer(object):
         assert replaced.registry == image.registry
         assert replaced.namespace == image.namespace
         assert replaced.repo == image.repo
-        assert replaced.tag == 'sha256:{}'.format(digest)
+        assert replaced.tag == digest
 
     @pytest.mark.parametrize('image, replacement_registries, replaced', [
         ('old-registry/ns/foo', {'old-registry': 'new-registry'}, 'new-registry/ns/foo'),


### PR DESCRIPTION
* OSBS-8637

The Docker-Content-Digest header returned when querying a registry
already contains the 'sha256:' prefix. Fix code and unit test mock.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
