### PR TITLE
operator manifests: Unify configuration naming

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -48,7 +48,7 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
                                       provided to workers by osbs-client
         """
         super(PinOperatorDigestsPlugin, self).__init__(tasker, workflow)
-        self.user_config = workflow.source.config.operator_manifest
+        self.user_config = workflow.source.config.operator_manifests
         self.site_config = None  # Only relevant (and available) in orchestrator
         self.replacement_pullspecs = replacement_pullspecs
 
@@ -115,7 +115,7 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
 
     def _get_operator_manifest(self):
         if self.user_config is None:
-            raise RuntimeError("operator_manifest configuration missing in container.yaml")
+            raise RuntimeError("operator_manifests configuration missing in container.yaml")
 
         manifests_dir = os.path.join(self.workflow.source.path, self.user_config["manifests_dir"])
         self.log.info("Looking for operator CSV files in %s", manifests_dir)

--- a/atomic_reactor/schemas/container.json
+++ b/atomic_reactor/schemas/container.json
@@ -49,7 +49,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
-            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
+            "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "tags": {"$ref": "#/definitions/tags"},
             "set_release_env": {"$ref": "#/definitions/set_release_env"},
@@ -64,7 +64,7 @@
             "autorebuild": {"$ref": "#/definitions/autorebuild"},
             "compose": {"$ref": "#/definitions/compose"},
             "flatpak": {"$ref": "#/definitions/flatpak"},
-            "operator_manifest": {"$ref": "#/definitions/operator_manifest"},
+            "operator_manifests": {"$ref": "#/definitions/operator_manifests"},
             "image_build_method": {"$ref": "#/definitions/image_build_method"},
             "remote_source": {
               "type": ["object", "null"],
@@ -246,7 +246,7 @@
       },
       "additionalProperties": false
     },
-    "operator_manifest": {
+    "operator_manifests": {
       "description": "Configuration for operator manifest bundle builds",
       "type": "object",
       "properties": {

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -70,7 +70,7 @@ class SourceConfig(object):
                .format(meth, REPO_CONTAINER_CONFIG)
         )
         self.remote_source = self.data.get('remote_source')
-        self.operator_manifest = self.data.get('operator_manifest')
+        self.operator_manifests = self.data.get('operator_manifests')
 
 
 class Source(object):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -51,7 +51,7 @@ def make_reactor_config(operators_config):
 
 def make_user_config(operator_config):
     config = StubConfig()
-    setattr(config, 'operator_manifest', operator_config)
+    setattr(config, 'operator_manifests', operator_config)
     return config
 
 
@@ -192,7 +192,7 @@ class TestPinOperatorDigest(object):
 
         with pytest.raises(PluginFailedException) as exc_info:
             runner.run()
-        msg = "operator_manifest configuration missing in container.yaml"
+        msg = "operator_manifests configuration missing in container.yaml"
         assert msg in str(exc_info.value)
 
     @pytest.mark.parametrize('replacements', [None, {}])

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -272,10 +272,10 @@ class TestSourceConfigSchemaValidation(object):
             }}
         ), (
           """\
-          operator_manifest:
+          operator_manifests:
             manifests_dir: path/to/manifests
           """,
-          {'operator_manifest': {
+          {'operator_manifests': {
               'manifests_dir': 'path/to/manifests'
           }}
         ),
@@ -394,11 +394,11 @@ class TestSourceConfigSchemaValidation(object):
         """,
 
         """\
-        operator_manifest: {}
+        operator_manifests: {}
         """,
 
         """\
-        operator_manifest:
+        operator_manifests:
           manifests_dir: /absolute/path
         """,
     ])


### PR DESCRIPTION
Change operator_manifest in container.yaml to operator_manifestS to
unify it with the reactor-config-map option.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
