### PR TITLE
Allow blacklisting srpms from source container images

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -661,6 +661,13 @@
           "limit_media_types": {
             "description": "Do not report any media types other than these",
             "allOf": [{"$ref": "#/definitions/media_types"}]
+          },
+          "blacklist_srpms": {
+              "description": "Don't include specified srpms to source container image, specify SRPM name",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
* OSBS-8749

Signed-off-by: Robert Cerven <rcerven@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
