### PR TITLE
 operator manifests: Read mapping files from URLs 

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -229,13 +229,13 @@ class PullspecReplacer(object):
             for registry in site_config.get("registry_post_replace", [])
         }
 
-        self.package_mapping_files = {
-            mapping["registry"]: mapping["package_mappings_file"]
+        self.package_mapping_urls = {
+            mapping["registry"]: mapping["package_mappings_url"]
             for mapping in site_config.get("repo_replacements", [])
         }
-        # Mapping of [file path => package mapping]
+        # Mapping of [url => package mapping]
         # Loaded when needed, see _get_site_mapping
-        self.file_package_mappings = {}
+        self.url_package_mappings = {}
 
         self.user_package_mappings = {
             mapping["registry"]: mapping["package_mappings"]
@@ -315,16 +315,16 @@ class PullspecReplacer(object):
         Get the package mapping file for the given registry. If said file has
         not yet been read, read it and save mapping for later. Return mapping.
         """
-        mapping_file = self.package_mapping_files.get(registry)
+        mapping_url = self.package_mapping_urls.get(registry)
 
-        if mapping_file is None:
+        if mapping_url is None:
             return None
-        elif mapping_file in self.file_package_mappings:
-            return self.file_package_mappings[mapping_file]
+        elif mapping_url in self.url_package_mappings:
+            return self.url_package_mappings[mapping_url]
 
-        self.log.debug("Downloading mapping file for %s from %s", registry, mapping_file)
-        mapping = read_yaml_from_url(mapping_file, "schemas/package_mapping.json")
-        self.file_package_mappings[mapping_file] = mapping
+        self.log.debug("Downloading mapping file for %s from %s", registry, mapping_url)
+        mapping = read_yaml_from_url(mapping_url, "schemas/package_mapping.json")
+        self.url_package_mappings[mapping_url] = mapping
         return mapping
 
     def _get_component_name(self, image):

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -18,7 +18,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import PLUGIN_PIN_OPERATOR_DIGESTS_KEY, INSPECT_CONFIG
 from atomic_reactor.util import (has_operator_bundle_manifest,
                                  get_manifest_digests,
-                                 read_yaml_from_file_path,
+                                 read_yaml_from_url,
                                  ImageName)
 from atomic_reactor.plugins.pre_reactor_config import get_operator_manifests
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
@@ -322,7 +322,8 @@ class PullspecReplacer(object):
         elif mapping_file in self.file_package_mappings:
             return self.file_package_mappings[mapping_file]
 
-        mapping = read_yaml_from_file_path(mapping_file, "schemas/package_mapping.json")
+        self.log.debug("Downloading mapping file for %s from %s", registry, mapping_file)
+        mapping = read_yaml_from_url(mapping_file, "schemas/package_mapping.json")
         self.file_package_mappings[mapping_file] = mapping
         return mapping
 

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -694,12 +694,13 @@
                 "registry": {
                   "type": "string"
                 },
-                "package_mappings_file": {
-                  "description": "Path to file containing repo replacement mappings",
-                  "type": "string"
+                "package_mappings_url": {
+                  "description": "URL of file containing repo replacement mappings",
+                  "type": "string",
+                  "pattern": "^http(s?)://.*$"
                 }
               },
-              "required": ["registry", "package_mappings_file"],
+              "required": ["registry", "package_mappings_url"],
               "additionalProperties": false
             }
           },

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -197,7 +197,7 @@ def get_site_config(allowed_registries=None, registry_post_replace=None, repo_re
             {'old': old, 'new': new} for old, new in registry_post_replace.items()
         ],
         'repo_replacements': [
-            {'registry': registry, 'package_mappings_file': path}
+            {'registry': registry, 'package_mappings_url': path}
             for registry, path in repo_replacements.items()
         ]
     }

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1476,7 +1476,7 @@ class TestReactorConfigPlugin(object):
                 - bar
               repo_replacements:
                 - registry: foo
-                  package_mappings_file: mapping.yaml
+                  package_mappings_url: https://somewhere.net/mapping.yaml
               registry_post_replace:
                 - old: foo
                   new: bar
@@ -1520,14 +1520,22 @@ class TestReactorConfigPlugin(object):
               allowed_registries: null
               repo_replacements:
                 - registry: foo
-        """, False),  # missing package mappings file
+        """, False),  # missing package mappings url
         ("""\
           version: 1
           operator_manifests:
               allowed_registries: null
               repo_replacements:
-                - package_mappings_file: mapping.yaml
+                - package_mappings_url: https://somewhere.net/mapping.yaml
         """, False),  # missing registry
+        ("""\
+          version: 1
+          operator_manifests:
+              allowed_registries: null,
+              repo_replacements:
+                - registry: foo
+                  package_mappings_url: mapping.yaml
+        """, False),  # package mappings url is not a url
     ])
     def test_get_operator_manifests(self, config, valid):
         _, workflow = self.prepare()


### PR DESCRIPTION
* OSBS-8639

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
