### PR TITLE
operator manifests: Sanitize manifests_dir input

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -126,9 +126,14 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
         if self.user_config is None:
             raise RuntimeError("operator_manifests configuration missing in container.yaml")
 
-        manifests_dir = os.path.join(self.workflow.source.path, self.user_config["manifests_dir"])
-        self.log.info("Looking for operator CSV files in %s", manifests_dir)
+        repo_dir = os.path.realpath(self.workflow.source.path)
+        manifests_rel_path = self.user_config["manifests_dir"]
 
+        manifests_dir = os.path.realpath(os.path.join(repo_dir, manifests_rel_path))
+        if not manifests_dir.startswith(repo_dir):
+            raise RuntimeError("manifests_dir points outside of cloned repository")
+
+        self.log.info("Looking for operator CSV files in %s", manifests_dir)
         operator_manifest = OperatorManifest.from_directory(manifests_dir)
 
         if operator_manifest.files:


### PR DESCRIPTION
* OSBS-8785

Make sure that path configured by user does not point outside of cloned
git repo.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
