### PR TITLE
operator manifests: Add OCP 4.4 workaround

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -119,7 +119,9 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
 
         for operator_csv in operator_manifest.files:
             self.log.info("Replacing pullspecs in %s", operator_csv.path)
-            operator_csv.replace_pullspecs(replacement_pullspecs)
+            # Replace pullspecs everywhere, not just in locations in which they
+            # are expected to be found - OCP 4.4 workaround
+            operator_csv.replace_pullspecs_everywhere(replacement_pullspecs)
             operator_csv.dump()
 
     def _get_operator_manifest(self):


### PR DESCRIPTION
* OSBS-8640

Replace pullspecs everywhere, not just in locations in which they are
expected to be found.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
