### PR TITLE
Re-enable tito in atomic-reactor

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -20,8 +20,6 @@
 %global owner containerbuildsystem
 %global project atomic-reactor
 
-%global commit 82cd704b9faf4f4c20d0d278218ada2baf590b4b
-%global shortcommit %(c=%{commit}; echo ${c:0:7})
 
 %global dock_obsolete_vr 1.3.7-2
 
@@ -33,7 +31,7 @@ Summary:        Improved builder for Docker images
 Group:          Development/Tools
 License:        BSD
 URL:            https://github.com/%{owner}/%{project}
-Source0:        https://github.com/%{owner}/%{project}/archive/%{commit}/%{project}-%{commit}.tar.gz
+Source0:        https://github.com/containerbuildsystem/%{name}/archive/%{version}.tar.gz
 
 BuildArch:      noarch
 
@@ -202,7 +200,7 @@ Plugins for automated rebuilds
 
 
 %prep
-%setup -qn %{name}-%{commit}
+%setup -q
 
 
 %build

--- a/rel-eng/lib/builder.py
+++ b/rel-eng/lib/builder.py
@@ -1,0 +1,12 @@
+from tito.builder import Builder
+
+
+class AtomicReactorBuilder(Builder):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # tarball has to represent Source0
+        # but internal structure should remain same
+        # i.e. {name}-{version} otherwise %setup -q
+        # will fail
+        self.tgz_filename = self.display_version + ".tar.gz"

--- a/rel-eng/tito.props
+++ b/rel-eng/tito.props
@@ -1,9 +1,10 @@
 [buildconfig]
-builder = tito.builder.Builder
+builder = builder.AtomicReactorBuilder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
 tag_format = {version}
+lib_dir = rel-eng/lib
 
 [version_template]
 destination_file = ./atomic_reactor/version.py


### PR DESCRIPTION
This should effectively make tito usable again.
Changes are not sufficient in https://github.com/containerbuildsystem/atomic-reactor/commit/4761f957c8a46f7322b6fe3b9fd44b3cc2c4e1c3.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
