### PR TITLE
operator manifests: Allow pinning opt-out

### DIFF
--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -287,13 +287,19 @@ class TestSourceConfigSchemaValidation(object):
                 package_mappings:
                   bar: baz
                   spam: eggs
+            enable_digest_pinning: true
+            enable_repo_replacements: false
+            enable_registry_replacements: true
           """,
           {'operator_manifests': {
               'manifests_dir': 'path/to/manifests',
               'repo_replacements': [
                   {'registry': 'foo',
                    'package_mappings': {'bar': 'baz', 'spam': 'eggs'}}
-              ]
+              ],
+              "enable_digest_pinning": True,
+              "enable_repo_replacements": False,
+              "enable_registry_replacements": True,
           }}
         ),
     ])
@@ -426,6 +432,24 @@ class TestSourceConfigSchemaValidation(object):
             - registry: foo
               package_mappings:
                 bar: 1  # not a string
+        """,
+
+        """
+        operator_manifests:
+          manifests_dir: some/path
+          enable_digest_pinning: null  # not a boolean
+        """,
+
+        """
+        operator_manifests:
+          manifests_dir: some/path
+          enable_repo_replacements: 1  # not a boolean
+        """,
+
+        """
+        operator_manifests:
+          manifests_dir: some/path
+          enable_registry_replacements: "true"  # not a boolean
         """,
     ])
     def test_invalid_source_config_validation_error(self, tmpdir, yml_config):


### PR DESCRIPTION
* OSBS-8789

Users can configure whether to enable digest pinning and/or repo
replacement during operator manifest bundle builds in container.yaml.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
