### PR TITLE
Allow composes with deprecated signing intents

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -17,6 +17,7 @@ from atomic_reactor.util import (read_yaml, read_yaml_from_file_path,
                                  get_build_json, DefaultKeyDict)
 from osbs.utils import RegistryURI
 
+import logging
 import os
 import six
 
@@ -494,6 +495,8 @@ class ODCSConfig(object):
     """
 
     def __init__(self, signing_intents, default_signing_intent):
+        self.log = logging.getLogger(self.__class__.__name__)
+
         self.default_signing_intent = default_signing_intent
 
         self.signing_intents = []
@@ -521,12 +524,25 @@ class ODCSConfig(object):
         if isinstance(keys, six.text_type):
             keys = keys.split()
         keys = set(keys)
+        deprecated_intent_matches = []
         for entry in reversed(self.signing_intents):
             keys_set = set(entry['keys'])
             if (keys and keys_set >= keys) or keys == keys_set:
                 return entry
 
-        raise ValueError('unknown signing intent keys "{}"'.format(keys))
+            permissive_keys_set = set(entry['keys'] + entry.get('deprecated_keys', []))
+            if keys and permissive_keys_set >= keys:
+                deprecated_intent_matches.append(entry)
+
+        if not deprecated_intent_matches:
+            raise ValueError('unknown signing intent keys "{}"'.format(keys))
+
+        self.log.warning(
+            'signing intent keys "%s" contain deprecated entries in the "%s" signing intent',
+            keys,
+            deprecated_intent_matches[0]['name']
+         )
+        return deprecated_intent_matches[0]
 
 
 class ReactorConfigPlugin(PreBuildPlugin):

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -235,6 +235,13 @@
                           "items": {
                               "type": "string"
                           }
+                      },
+                      "deprecated_keys": {
+                          "description": "deprecated signing intent keys",
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
                       }
                     },
                     "additionalProperties": false,


### PR DESCRIPTION
* OSBS-8822

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
