### PR TITLE
Handle deprecated signing intents

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -235,6 +235,13 @@
                           "items": {
                               "type": "string"
                           }
+                      },
+                      "deprecated_keys": {
+                          "description": "deprecated signing intent keys",
+                          "type": "array",
+                          "items": {
+                              "type": "string"
+                          }
                       }
                     },
                     "additionalProperties": false,

--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -108,7 +108,7 @@ class ODCSClient(object):
 
         return response.json()
 
-    def renew_compose(self, compose_id):
+    def renew_compose(self, compose_id, sigkeys=None):
         """Renew, or extend, existing compose
 
         If the compose has already been removed, ODCS creates a new compose.
@@ -116,11 +116,17 @@ class ODCSClient(object):
         cases, caller should assume the compose ID will change.
 
         :param compose_id: int, compose ID to renew
+        :param sigkeys: list, new signing intent keys to regenerate compose with
 
         :return: dict, status of compose being renewed.
         """
+        params = {}
+        if sigkeys is not None:
+            params['sigkeys'] = sigkeys
+
         logger.info("Renewing compose %d", compose_id)
-        response = self.session.patch('{}composes/{}'.format(self.url, compose_id))
+        response = self.session.patch('{}composes/{}'.format(self.url, compose_id),
+                                      params)
         response.raise_for_status()
         response_json = response.json()
         compose_id = response_json['id']

--- a/tests/utils/test_odcs.py
+++ b/tests/utils/test_odcs.py
@@ -194,6 +194,7 @@ def test_renew_compose(odcs_client):
                            callback=handle_composes_patch)
 
     odcs_client.renew_compose(COMPOSE_ID)
+    odcs_client.renew_compose(COMPOSE_ID, ['SIGKEY1', 'SIGKEY2'])
 
 
 def assert_request_token(request, session):


### PR DESCRIPTION
To handle deprecated signing intents, we add a new deprecated_keys to the odcs configmap option. This deprecated keys will be used to infer the name of a signing intent based on its former keys. Given we are able to obtain a signing intent name, we can proceed to request a compose to be renewed with (and only with) the current signing keys in that signing intent (without the deprecated keys).

For the signing intent substitution to be respected, ODCS to be deployed with https://pagure.io/odcs/pull-request/362. Builds will not fail and the sigkeys passed to ODCS will just be ignored otherwise.

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
