### PR TITLE
Set proper image_id for flatpak builds

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ if [[ $OS == "fedora" ]]; then
   PIP="pip$PYTHON_VERSION"
   PKG="dnf"
   ENABLE_REPO="--enablerepo=updates-testing"
-  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree python$PYTHON_VERSION-libmodulemd glibc-langpack-en"
+  PKG_EXTRA="dnf-plugins-core desktop-file-utils flatpak ostree skopeo python$PYTHON_VERSION-libmodulemd glibc-langpack-en"
   BUILDDEP="dnf builddep"
   PYTHON="python$PYTHON_VERSION"
 else
@@ -41,7 +41,7 @@ else
   PIP="pip"
   PKG="yum"
   ENABLE_REPO=
-  PKG_EXTRA="yum-utils epel-release git-core desktop-file-utils flatpak ostree python2-libmodulemd2"
+  PKG_EXTRA="yum-utils epel-release git-core desktop-file-utils flatpak ostree skopeo python2-libmodulemd2"
   BUILDDEP="yum-builddep"
   PYTHON="python"
 fi


### PR DESCRIPTION
The builder image_id is used to set extra.docker.id in the koji archive
metadata. For regular builds, the image id is the built image config
digest. For flatpak builds, this is set as the image config id for the
file system built by the docker_api builder. This is not the final image
config digest since flatpak will build a new OCI image using the
aforementioned file system. This patch sets the image_id to the OCI
image config built by flatpak.

The actual image_id should not change in the case the image is converted
from OCI to docker upon a registry push (given the JSON file order is
kept). The OCI image config and docker image config specs are
compatible.

* OSBS-8780

Signed-off-by: Athos Ribeiro <athos@redhat.com>



Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
