### PR TITLE
operator util: Handle initContainer pullspecs

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -124,7 +124,7 @@ class OperatorCSV(object):
         return chain_get(self.data, annotations_path, default={})
 
     def _get_related_image_envs(self):
-        containers = self._get_containers()
+        containers = self._get_containers() + self._get_init_containers()
         envs = [
             e for c in containers
             for e in c.get("env", []) if e["name"].startswith("RELATED_IMAGE_")


### PR DESCRIPTION
* CLOUDBLD-438

New source of pullspecs:
`{...}.deployments[].spec.template.spec.initContainers[].image`

Also change docstrings of `{get,replace}_pullspecs()` methods, because
the list of known pullspec sources is already outdated and is not
unlikely to become outdated again in the future.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
