### PR TITLE
operator manifest: improve error message

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -15,7 +15,11 @@ from osbs.utils import Labels
 
 from atomic_reactor import util
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.constants import PLUGIN_PIN_OPERATOR_DIGESTS_KEY, INSPECT_CONFIG
+from atomic_reactor.constants import (
+    PLUGIN_PIN_OPERATOR_DIGESTS_KEY,
+    INSPECT_CONFIG,
+    REPO_CONTAINER_CONFIG,
+)
 from atomic_reactor.util import (has_operator_bundle_manifest,
                                  get_manifest_digests,
                                  read_yaml_from_url,
@@ -325,12 +329,14 @@ class PullspecReplacer(object):
         replacements = mapping.get(package)
 
         if replacements is None:
-            raise RuntimeError("Replacement not configured for package {} (from {})"
-                               .format(package, image))
+            raise RuntimeError("Replacement not configured for package {} (from {}). "
+                               "Please specify replacement in {}"
+                               .format(package, image, REPO_CONTAINER_CONFIG))
         elif len(replacements) > 1:
             options = ", ".join(replacements)
-            raise RuntimeError("Multiple replacements for package {} (from {}): {}"
-                               .format(package, image, options))
+            raise RuntimeError("Multiple replacements for package {} (from {}): {}. "
+                               "Please specify replacement in {}"
+                               .format(package, image, options, REPO_CONTAINER_CONFIG))
 
         self.log.debug("Replacement for package %s: %s", package, replacements[0])
         replacement = ImageName.parse(replacements[0])

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -676,19 +676,22 @@ class TestPullspecReplacer(object):
          {'a': {}},
          None,
          {PKG_LABEL: 'foo-package'},
-         'Replacement not configured for package foo-package (from a/x/foo:1)'),
+         'Replacement not configured for package foo-package (from a/x/foo:1). '
+         'Please specify replacement in container.yaml'),
         # replacements configured in user config, repo missing
         ('a/x/foo:1',
          None,
          {'a': {}},
          {PKG_LABEL: 'foo-package'},
-         'Replacement not configured for package foo-package (from a/x/foo:1)'),
+         'Replacement not configured for package foo-package (from a/x/foo:1). '
+         'Please specify replacement in container.yaml'),
         # multiple options for replacement in site config
         ('a/x/foo:1',
          {'a': {'foo-package': ['bar', 'baz']}},
          None,
          {PKG_LABEL: 'foo-package'},
-         'Multiple replacements for package foo-package (from a/x/foo:1): bar, baz'),
+         'Multiple replacements for package foo-package (from a/x/foo:1): bar, baz. '
+         'Please specify replacement in container.yaml'),
         # user tried to override with an invalid replacement
         ('a/x/foo:1',
          {'a': {'foo-package': ['bar', 'baz']}},


### PR DESCRIPTION
Inform users that they have to update container.yaml config.

Signed-off-by: Martin Bašti <mbasti@redhat.com>



Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
