### PR TITLE
Fix built Flatpak OCI workflow

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -182,3 +182,6 @@ KOJI_KIND_IMAGE_SOURCE_BUILD = 'source_container_build'
 KOJI_SUBTYPE_OP_APPREGISTRY = 'operator_appregistry'
 KOJI_SUBTYPE_OP_BUNDLE = 'operator_bundle'
 KOJI_SOURCE_ENGINE = 'bsi'
+
+# Storage names as defined in skopeo
+DOCKER_STORAGE_TRANSPORT_NAME = 'docker-daemon'

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -32,9 +32,11 @@ from atomic_reactor.plugin import (
     PrePublishPluginsRunner,
 )
 from atomic_reactor.source import get_source_instance_for, DummySource
-from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
 from atomic_reactor.constants import (
     CONTAINER_DEFAULT_BUILD_METHOD,
+    DOCKER_STORAGE_TRANSPORT_NAME,
+    INSPECT_ROOTFS,
+    INSPECT_ROOTFS_LAYERS,
     PLUGIN_BUILD_ORCHESTRATE_KEY
 )
 from atomic_reactor.util import ImageName, exception_message
@@ -383,6 +385,7 @@ class DockerBuildWorkflow(object):
         self.built_image_inspect = None
         self.layer_sizes = []
         self.default_image_build_method = CONTAINER_DEFAULT_BUILD_METHOD
+        self.storage_transport = DOCKER_STORAGE_TRANSPORT_NAME
 
         # list of images pulled during the build, to be deleted after the build
         self.pulled_base_images = set()

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -475,7 +475,6 @@ def write_docker_file(config, tmpdir):
     ('app', 'both', None),
     ('runtime', 'annotations', None),
     ('sdk', 'annotations', None),
-    ('sdk', 'annotations', None),
 ])
 def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, flatpak_metadata, breakage):
     # Check that we actually have flatpak available


### PR DESCRIPTION
After a flatpak OCI is built, it should be pushed into the internal container storage for further analysis (built images are inspected for metadata). This fixes an issue introduced in 917335d, where atomic-reactor would try to inspect the image and fail since the image would not be available.
    
Since the filesystem image used to build the OCI is not being tracked anymore, this image would never get removed in the end of the build process. Therefore, we align the image for removal and proper clean up.

Maintainers will complete the following section:
- [ ] Commit messages are descriptive enough
- [ ] "Signed-off-by:" line is present in each commit
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request includes link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
