### PR TITLE
operators: Special handling for relatedImages

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -158,6 +158,18 @@ class OperatorCSV(object):
         with open(self.path, "w") as f:
             yaml.dump(self.data, f)
 
+    def has_related_images(self):
+        """
+        Check if OperatorCSV has a non-empty relatedImages section.
+        """
+        return bool(self._related_image_pullspecs())
+
+    def has_related_image_envs(self):
+        """
+        Check if OperatorCSV has any RELATED_IMAGE_* env vars.
+        """
+        return bool(self._related_image_env_pullspecs())
+
     def get_pullspecs(self):
         """
         Find pullspecs in predefined locations.

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -336,14 +336,14 @@ class TestOperatorCSV(object):
         assert pullspecs == self._original_pullspecs
 
         expected_logs = [
-            "original.yaml - Found pullspec for related image foo: {foo}",
-            "original.yaml - Found pullspec for related image bar: {bar}",
-            "original.yaml - Found pullspec in RELATED_IMAGE_EGGS var: {eggs}",
-            "original.yaml - Found pullspec in RELATED_IMAGE_P2 var: {p2}",
+            "original.yaml - Found pullspec for relatedImage foo: {foo}",
+            "original.yaml - Found pullspec for relatedImage bar: {bar}",
+            "original.yaml - Found pullspec for RELATED_IMAGE_EGGS var: {eggs}",
+            "original.yaml - Found pullspec for RELATED_IMAGE_P2 var: {p2}",
             "original.yaml - Found pullspec for container spam: {spam}",
             "original.yaml - Found pullspec for container ham: {ham}",
             "original.yaml - Found pullspec for container jam: {jam}",
-            "original.yaml - Found pullspec in annotations: {baz}",
+            "original.yaml - Found pullspec for containerImage annotation: {baz}",
             "original.yaml - Found pullspec for initContainer p1: {p1}",
         ]
         for log in expected_logs:
@@ -355,14 +355,14 @@ class TestOperatorCSV(object):
         assert csv.data == REPLACED.data
 
         expected_logs = [
-            "{file} - Replaced pullspec for related image foo: {foo} -> {foo.replace}",
-            "{file} - Replaced pullspec for related image bar: {bar} -> {bar.replace}",
-            "{file} - Replaced pullspec in RELATED_IMAGE_EGGS var: {eggs} -> {eggs.replace}",
-            "{file} - Replaced pullspec in RELATED_IMAGE_P2 var: {p2} -> {p2.replace}",
+            "{file} - Replaced pullspec for relatedImage foo: {foo} -> {foo.replace}",
+            "{file} - Replaced pullspec for relatedImage bar: {bar} -> {bar.replace}",
+            "{file} - Replaced pullspec for RELATED_IMAGE_EGGS var: {eggs} -> {eggs.replace}",
+            "{file} - Replaced pullspec for RELATED_IMAGE_P2 var: {p2} -> {p2.replace}",
             "{file} - Replaced pullspec for container spam: {spam} -> {spam.replace}",
             "{file} - Replaced pullspec for container ham: {ham} -> {ham.replace}",
             "{file} - Replaced pullspec for container jam: {jam} -> {jam.replace}",
-            "{file} - Replaced pullspec in annotations: {baz} -> {baz.replace}",
+            "{file} - Replaced pullspec for containerImage annotation: {baz} -> {baz.replace}",
             "{file} - Replaced pullspec for initContainer p1: {p1} -> {p1.replace}",
         ]
         for log in expected_logs:


### PR DESCRIPTION
* CLOUDBLD-493

Add `set_related_images()` method to OperatorCSV, refactor code to use the same underlying mechanism for other methods.

Call this method in `pin_operator_digest` after pinning pullspecs.

Add `has_related_image[_env]s` methods to OperatorCSV, use them to exclude CSVs that already have a relatedImages section from pinning etc.

Maintainers will complete the following section:
- [x] Commit messages are descriptive enough
- [x] "Signed-off-by:" line is present in each commit
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request includes link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
