### PR TITLE
Fetch cachito request configuration files

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -21,6 +21,8 @@ from atomic_reactor.util import get_retrying_requests_session
 
 logger = logging.getLogger(__name__)
 
+CFG_TYPE_B64 = 'base64'
+
 
 class CachitoAPIError(Exception):
     """Top level exception for errors in interacting with Cachito's API"""

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -179,6 +179,22 @@ class CachitoAPI(object):
         request_id = self._get_request_id(request)
         return '{}/api/v1/requests/{}/download'.format(self.api_url, request_id)
 
+    def get_request_config(self, request):
+        """Get the configuration files associated with a request
+
+        :param request: int or dict, either the Cachito request ID or a dict with 'id' key
+
+        :return: list<dict>, configuration data for the given request.
+                 entries include path, type, and content
+        """
+        request_id = self._get_request_id(request)
+        logger.debug('Retrieving configuration files for request %ds', request_id)
+        url = '{}/api/v1/requests/{}/configuration-files'.format(self.api_url, request_id)
+        response = self.session.get(url)
+        response_json = response.json()
+        response.raise_for_status()
+        return response_json
+
     def _get_request_id(self, request):
         if isinstance(request, int):
             return request

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -39,6 +39,7 @@ KOJI_TASK_OWNER = 'spam'
 CACHITO_URL = 'https://cachito.example.com'
 CACHITO_REQUEST_ID = 98765
 CACHITO_REQUEST_DOWNLOAD_URL = '{}/api/v1/{}/download'.format(CACHITO_URL, CACHITO_REQUEST_ID)
+CACHITO_REQUEST_CONFIGS = [{'eggs': 'bacon'}, {'bread': 'jam'}]
 
 REMOTE_SOURCE_REPO = 'https://git.example.com/team/repo.git'
 REMOTE_SOURCE_REF = 'b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a'
@@ -169,6 +170,11 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
         .should_receive('assemble_download_url')
         .with_args(source_request)
         .and_return(CACHITO_REQUEST_DOWNLOAD_URL))
+
+    (flexmock(CachitoAPI)
+        .should_receive('get_request_config')
+        .with_args(source_request)
+        .and_return(CACHITO_REQUEST_CONFIGS))
 
 
 def mock_koji(user=KOJI_TASK_OWNER):
@@ -353,6 +359,7 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
         orchestrator_build_workspace = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         worker_params = orchestrator_build_workspace[WORKSPACE_KEY_OVERRIDE_KWARGS][None]
         assert worker_params['remote_source_url'] == CACHITO_REQUEST_DOWNLOAD_URL
+        assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIGS
         assert worker_params['remote_source_build_args'] == {
             'GOPATH': '/remote-source/deps/gomod',
             'GOCACHE': '/remote-source/deps/gomod',

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -242,3 +242,43 @@ def test_download_sources_bad_request_type(tmpdir):
 def test_assemble_download_url(tmpdir, cachito_request):
     url = CachitoAPI(CACHITO_URL).assemble_download_url(cachito_request)
     assert url == CACHITO_REQUEST_DOWNLOAD_URL
+
+
+@responses.activate
+@pytest.mark.parametrize('cachito_request', (
+    CACHITO_REQUEST_ID,
+    {'id': CACHITO_REQUEST_ID},
+))
+@pytest.mark.parametrize('response_data', (
+    [],
+    [
+        {
+            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
+            "path": "app/.npmrc",
+            "type": "base64",
+        }
+    ],
+    [
+        {
+            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
+            "path": "app/.npmrc",
+            "type": "base64",
+        },
+        {
+            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
+            "path": "app/.npmrc2",
+            "type": "base64",
+        }
+    ],
+))
+def test_get_request_config(tmpdir, cachito_request, response_data):
+    responses.add(
+        responses.GET,
+        '{}/api/v1/requests/{}/configuration-files'.format(CACHITO_URL, CACHITO_REQUEST_ID),
+        content_type='application/json',
+        status=200,
+        body=json.dumps(response_data))
+
+    response_json = CachitoAPI(CACHITO_URL).get_request_config(cachito_request)
+
+    assert response_json == response_data


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
