### PR TITLE
Add extra build metadata reflecting fetched artifacts

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -42,6 +42,7 @@ except ImportError:
 from atomic_reactor.constants import (
     PROG,
     PLUGIN_KOJI_IMPORT_PLUGIN_KEY,
+    PLUGIN_FETCH_MAVEN_KEY,
     PLUGIN_FETCH_WORKER_METADATA_KEY, PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
     PLUGIN_VERIFY_MEDIA_KEY,
     PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY,
@@ -406,6 +407,13 @@ class KojiImportPlugin(ExitPlugin):
                         self.log.error("invalid task ID %r", fs_task_id, exc_info=1)
                     else:
                         extra['filesystem_koji_task_id'] = task_id
+
+            fetch_result = self.workflow.prebuild_results.get(PLUGIN_FETCH_MAVEN_KEY)
+            if fetch_result:
+                for key in ('koji_artifacts', 'url_artifacts'):
+                    fetched = fetch_result.get(key)
+                    if fetched:
+                        extra["image"][key] = fetched
 
             extra['image'].update(get_parent_image_koji_data(self.workflow))
 


### PR DESCRIPTION
Augments the pre_fetch_maven_artifacts plugin to produce more detailed results, which are then used by the exit_koji_import plugin to add extra build data declaring what artifacts were pulled in by `fetch_artifacts_koji.yaml` and `fetch_artifacts_url.yaml`

Adds keys two new keys -- "koji_artifacts" and "url_artifacts" to build["extra"]["image"], named obviously after the two files that specify the relevant artifacts to fetch.

I'd like feedback if there should be more or less information recorded to extra, or if the keys I came up with are silly and you'd prefer something else.

I tested this via test.sh, under OS=fedora OS_VERSION=29 PYTHON_VERSION=3
I encountered some issues with pip not being functional using the default configuration in test.sh, it seems that there's some odd conflicts in that centos image that result in pip.main not existing.

Fixes #1435 

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
