### PR TITLE
inject_parent_image should handle empty koji_parent_build

### DIFF
--- a/atomic_reactor/plugins/pre_inject_parent_image.py
+++ b/atomic_reactor/plugins/pre_inject_parent_image.py
@@ -61,7 +61,7 @@ class InjectParentImage(PreBuildPlugin):
         self.koji_session = get_koji_session(self.workflow, self.koji_fallback)
         try:
             self.koji_parent_build = int(koji_parent_build)
-        except ValueError:
+        except (ValueError, TypeError):
             self.koji_parent_build = koji_parent_build
 
         self._koji_parent_build_info = None


### PR DESCRIPTION
* CLOUDBLD-111

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
