### PR TITLE
Bump check for build existence to higher scope...

### DIFF
--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -246,8 +246,8 @@ def get_koji_module_build(session, module_spec):
                     else:
                         build = b
 
-        if build is None:
-            raise RuntimeError("No build found for {}".format(module_spec.to_str()))
+    if build is None:
+        raise RuntimeError("No build found for {}".format(module_spec.to_str()))
 
     archives = session.listArchives(buildID=build['build_id'])
     # The RPM list for the 'modulemd.txt' archive has all the RPMs, recent

--- a/tests/utils/test_koji.py
+++ b/tests/utils/test_koji.py
@@ -314,6 +314,23 @@ class TestGetKojiModuleBuild(object):
 
         get_koji_module_build(session, spec)
 
+    # CLOUDBLD-876
+    def test_with_context_without_build(self):
+        module = 'eog:my-stream:20180821163756:775baa8e'
+        module_koji_nvr = 'eog-my_stream-20180821163756.775baa8e'
+        koji_return = None
+
+        spec = ModuleSpec.from_str(module)
+        session = flexmock()
+        (session
+            .should_receive('getBuild')
+            .with_args(module_koji_nvr)
+            .and_return(koji_return))
+
+        with pytest.raises(Exception) as e:
+            get_koji_module_build(session, spec)
+        assert 'No build found' in str(e.value)
+
     @pytest.mark.parametrize(('koji_return', 'should_raise'), [
         ([{
             'build_id': 1138198,


### PR DESCRIPTION
...to catch missing flatpak modules.

Using the same dist-git from the original bug report, log now looks like

```text
"2020-04-30 19:01:24,478 platform:- - atomic_reactor.plugin - ERROR - plugin 'flatpak_update_dockerfile' raised an exception: RuntimeError: No build found for python27:2.7:8030020200422185346:851f4228"
```

* CLOUDBLD-876

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
