### PR TITLE
Option to allow OSBS autorebuilds to ignore isolated parent builds

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -419,6 +419,7 @@ class DockerBuildWorkflow(object):
         self.reserved_build_id = None
         self.reserved_token = None
         self.triggered_after_koji_task = None
+        self.cancel_isolated_autorebuild = False
         self.koji_source_nvr = {}
         self.koji_source_source_url = None
         self.koji_source_manifest = None

--- a/atomic_reactor/plugins/pre_koji_delegate.py
+++ b/atomic_reactor/plugins/pre_koji_delegate.py
@@ -123,6 +123,12 @@ class KojiDelegatePlugin(PreBuildPlugin):
 
         self.osbs = get_openshift_session(self.workflow, NO_FALLBACK)
 
+        # will be set by koji_parent
+        if self.workflow.cancel_isolated_autorebuild:
+            self.log.info("ignoring isolated build for autorebuild, the build will be cancelled")
+            self.cancel_build()
+            raise BuildCanceledException("Build was canceled")
+
         self.delegate_task()
 
         # we will remove all exit plugins, as we don't want any of them running,
@@ -132,5 +138,5 @@ class KojiDelegatePlugin(PreBuildPlugin):
         # without canceling build build would end up as failed build, and we don't want
         # to have this build as failed but cancelled so it doesn't inerfere with real failed builds
         self.cancel_build()
-        self.log.info('Build was delegated, will cancel itself')
+        self.log.info('Build was delegated, the build will be cancelled')
         raise BuildCanceledException("Build was canceled")

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -55,6 +55,7 @@ class StubInsideBuilder(object):
     def __init__(self):
         self.base_image = None
         self.parent_images = {}
+        self.parent_images_digests = {}
         self.df_path = None
         self.df_dir = None
         self.git_dockerfile_path = None
@@ -68,6 +69,7 @@ class StubInsideBuilder(object):
         self.tasker = None
         self.original_df = None
         self.buildargs = {}
+        self.custom_base_image = False
 
         self._inspection_data = None
         self._parent_inspection_data = {}


### PR DESCRIPTION
* CLOUDBLD-926

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
