### PR TITLE
Include content sets in the image only when compose with pulp_repos are

### DIFF
--- a/atomic_reactor/plugins/pre_add_content_sets.py
+++ b/atomic_reactor/plugins/pre_add_content_sets.py
@@ -55,7 +55,9 @@ class AddContentSetsPlugin(PreBuildPlugin):
         file_path = os.path.join(workdir, REPO_CONTENT_SETS_CONFIG)
         content_sets = {}
 
-        if os.path.exists(file_path):
+        config_data = self.workflow.source.config.compose or {}
+
+        if os.path.exists(file_path) and config_data.get('pulp_repos'):
             content_sets = read_yaml_from_file_path(file_path, 'schemas/content_sets.json') or {}
 
         output_json = {'content_sets': []}

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -17,6 +17,7 @@ from atomic_reactor.util import ImageName
 class StubConfig(object):
     image_build_method = None
     release_env_var = None
+    compose = None
 
 
 class StubSource(object):


### PR DESCRIPTION
in container.yaml

* CLOUDBLD-764

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
