### PR TITLE
Add detail to CachitoAPIUnsuccessfulRequest...

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -129,9 +129,12 @@ class CachitoAPI(object):
                    Request %s is in "%s" state: %s
                    Details: %s
                    """), request_id, state, state_reason, json.dumps(response_json, indent=4))
-                raise CachitoAPIUnsuccessfulRequest(
-                   'Request {} is in "{}" state: {}'.format(request_id, state, state_reason))
-
+                raise CachitoAPIUnsuccessfulRequest(dedent('''\
+                    Cachito request is in "{}" state, reason: {}
+                    Request {} ({}) tried to get repo '{}' at reference '{}'.
+                    '''.format(state, state_reason, request_id, url,
+                               response_json['repo'], response_json['ref']))
+                )
             if state == 'complete':
                 logger.debug(dedent("""\
                     Request %s is complete


### PR DESCRIPTION
...exception message text
- Add unit test
- Fix up existing CachitoAPIUnsuccessfulRequest unit test

* CLOUDBLD-987

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
