### PR TITLE
util: Fix read_yaml_from_url

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1278,8 +1278,8 @@ def read_yaml_from_url(url, schema, package='atomic_reactor'):
     resp.raise_for_status()
 
     f = io.StringIO()
-    for chunk in resp.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE, decode_unicode=True):
-        f.write(chunk)
+    for chunk in resp.iter_content(chunk_size=DEFAULT_DOWNLOAD_BLOCK_SIZE):
+        f.write(chunk.decode('utf-8'))
 
     f.seek(0)
     return osbs_read_yaml(f.read(), schema, package)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1166,6 +1166,16 @@ def test_read_yaml(tmpdir, source, config):
     assert output == expected
 
 
+@pytest.mark.parametrize('content_type', ['application/octet-stream', 'text/plain'])
+@responses.activate
+def test_read_yaml_from_url_different_content_types(content_type):
+    url = 'https://somewhere.net/config.yaml'
+    responses.add(responses.GET, url, body=REACTOR_CONFIG_MAP, content_type=content_type)
+    output = read_yaml_from_url(url, 'schemas/config.json')
+    expected = yaml.safe_load(REACTOR_CONFIG_MAP)
+    assert output == expected
+
+
 LogEntry = namedtuple('LogEntry', ['platform', 'line'])
 
 


### PR DESCRIPTION
* CLOUDBLD-1063

The method incorrectly assumed that passing `decode_unicode=True` to the
`iter_content()` method of a response would always produce unicode
chunks. That it not the case when the Content-Type of the response is
not appropriate. Instead, make sure chunks are always bytes and decode
them explicitly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
