### PR TITLE
resolve_composes: strip out profiles from modules

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta
 import os
 from collections import defaultdict
 
+from osbs.repo_utils import ModuleSpec
+
 from atomic_reactor.constants import (PLUGIN_KOJI_PARENT_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
                                       REPO_CONTENT_SETS_CONFIG, BASE_IMAGE_KOJI_BUILD)
 
@@ -485,9 +487,14 @@ class ComposeConfig(object):
         return request
 
     def render_modules_request(self):
+        # In the Flatpak case, the profile is used to determine which packages
+        # are installed into the Flatpak. But ODCS doesn't understand profiles,
+        # and they won't affect the compose in any case.
+        noprofile_modules = [ModuleSpec.from_str(m).to_str(include_profile=False)
+                             for m in self.modules]
         request = {
             'source_type': 'module',
-            'source': ' '.join(self.modules),
+            'source': ' '.join(noprofile_modules),
             'sigkeys': self.signing_intent['keys'],
         }
         if self.arches:

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -454,9 +454,9 @@ class TestResolveComposes(object):
         repo_config = dedent("""\
             compose:
                 modules:
-                - spam
-                - bacon
-                - eggs
+                - spam:stable
+                - bacon:stable
+                - eggs:stable/profile
             """)
         mock_repo_config(workflow._tmpdir, repo_config)
 
@@ -464,7 +464,7 @@ class TestResolveComposes(object):
             .should_receive('start_compose')
             .with_args(
                 source_type='module',
-                source='spam bacon eggs',
+                source='spam:stable bacon:stable eggs:stable',
                 sigkeys=['R123'],
                 arches=arches)
             .once()
@@ -480,9 +480,9 @@ class TestResolveComposes(object):
         repo_config = dedent("""\
             compose:
                 modules:
-                - spam
-                - bacon
-                - eggs
+                - spam:stable
+                - bacon:stable
+                - eggs:stable
                 modular_koji_tags:
                 - earliest
                 - latest
@@ -493,7 +493,7 @@ class TestResolveComposes(object):
             .should_receive('start_compose')
             .with_args(
                 source_type='module',
-                source='spam bacon eggs',
+                source='spam:stable bacon:stable eggs:stable',
                 sigkeys=['R123'],
                 arches=arches,
                 modular_koji_tags=['earliest', 'latest'])
@@ -513,9 +513,9 @@ class TestResolveComposes(object):
                 compose:
                     packages:
                     modules:
-                    - spam_modules
-                    - bacon_modules
-                    - eggs_modules
+                    - spam:stable
+                    - bacon:stable
+                    - eggs:stable
                 """)
         mock_repo_config(workflow._tmpdir, repo_config)
 
@@ -530,7 +530,7 @@ class TestResolveComposes(object):
         (flexmock(ODCSClient)
             .should_receive('start_compose')
             .with_args(source_type='module',
-                       source='spam_modules bacon_modules eggs_modules',
+                       source='spam:stable bacon:stable eggs:stable',
                        sigkeys=['R123'],
                        arches=['x86_64'])
             .and_return(ODCS_COMPOSE))


### PR DESCRIPTION
For Flatpaks, we want to allow specifying modules as name:stream/profile
to allow fine-tuning which packages from the module get installed into
the container - but when we switched Flatpaks to use resolve_composes
instead of having a separate plugin, the logic to strip out profiles
before triggering the build got lost.

Parsing the specs to remove the /profile causes us to reject a bare
'name' with a clear:

   atomic_reactor.plugin.PluginFailedException: plugin 'resolve_composes'
   raised an exception: ValueError: Module specification spam_modules should
   be in NAME:STREAM[:VERSION[:CONTEXT]][/PROFILE] format

exception - previously this would been passed to ODCS, which would fail
the compose. The tests are updated accordingly so all modules are in
name:stream format.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
