### PR TITLE
Use koji NVR for content manifest file name

### DIFF
--- a/atomic_reactor/plugins/pre_add_content_sets.py
+++ b/atomic_reactor/plugins/pre_add_content_sets.py
@@ -107,7 +107,7 @@ class AddContentSetsPlugin(PreBuildPlugin):
         """
         dfp = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
         labels = Labels(dfp.labels)
-        _, image_name = labels.get_name_and_value(Labels.LABEL_TYPE_NAME)
+        _, image_name = labels.get_name_and_value(Labels.LABEL_TYPE_COMPONENT)
         _, image_version = labels.get_name_and_value(Labels.LABEL_TYPE_VERSION)
         _, image_release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
 

--- a/tests/plugins/test_add_content_sets.py
+++ b/tests/plugins/test_add_content_sets.py
@@ -69,13 +69,13 @@ def mock_content_sets_config(tmpdir, empty=False):
         dedent("""\
             FROM base_image
             CMD build /spam/eggs
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         dedent("""\
             FROM base_image
             CMD build /spam/eggs
             ADD content_manifest.eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         2,
         'content_manifest.eggs-1.0-42.json',
@@ -84,13 +84,13 @@ def mock_content_sets_config(tmpdir, empty=False):
         dedent("""\
             FROM base_image
             CMD build /spam/eggs
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         dedent("""\
             FROM base_image
             CMD build /spam/eggs
             ADD content_manifest.eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         3,
         'content_manifest.eggs-1.0-42.json',
@@ -99,13 +99,13 @@ def mock_content_sets_config(tmpdir, empty=False):
         dedent("""\
             FROM scratch
             CMD build /spam/eggs
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         dedent("""\
             FROM scratch
             CMD build /spam/eggs
             ADD content_manifest.eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
-            LABEL name=eggs version=1.0 release=42
+            LABEL com.redhat.component=eggs version=1.0 release=42
         """),
         0,
         'content_manifest.eggs-1.0-42.json',


### PR DESCRIPTION
The name label may contain namespaces.

* CLOUDBLD-1003

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
