### PR TITLE
Ensure ODCSConfig does not change original signing_intents

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -506,7 +506,10 @@ class ODCSConfig(object):
 
         self.signing_intents = []
         # Signing intents are listed in reverse restrictive order in configuration.
-        for restrictiveness, intent in enumerate(reversed(signing_intents)):
+        # Since the input signing_intents will be modified by inserting a new
+        # key restrictiveness, this deepcopy ensures the original
+        # signing_intent dict objects are not modified accidentally.
+        for restrictiveness, intent in enumerate(reversed(deepcopy(signing_intents))):
             intent['restrictiveness'] = restrictiveness
             self.signing_intents.append(intent)
 

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -31,7 +31,8 @@ import osbs.conf
 import osbs.api
 from osbs.utils import RegistryURI
 from osbs.exceptions import OsbsValidationException
-from atomic_reactor.plugins.pre_reactor_config import (ReactorConfig,
+from atomic_reactor.plugins.pre_reactor_config import (ODCSConfig,
+                                                       ReactorConfig,
                                                        ReactorConfigPlugin,
                                                        get_config, WORKSPACE_CONF_KEY,
                                                        get_koji_session,
@@ -1601,3 +1602,15 @@ class TestReactorConfigPlugin(object):
                                      basename=filename)
         plugin.run()
         assert plugin.workflow.user_params == USER_PARAMS
+
+
+def test_ensure_odcsconfig_does_not_modify_original_signing_intents():
+    signing_intents = [{'name': 'release', 'keys': ['R123', 'R234']}]
+    odcs_config = ODCSConfig(signing_intents, 'release')
+    assert [{
+        'name': 'release',
+        'keys': ['R123', 'R234'],
+        'restrictiveness': 0
+    }] == odcs_config.signing_intents
+    # Verify original intent is not modified.
+    assert 'restrictiveness' not in signing_intents[0]


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
