### PR TITLE
Add pull_registries option to reactor config map

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -513,18 +513,7 @@
                     "description": "Don't check SSL certificate for url",
                     "type": "boolean"
                 },
-                "auth": {
-                    "description": "Authentication information",
-                    "type": "object",
-                    "properties": {
-                        "cfg_path": {
-                            "description": "Path to directory  containing .dockercfg for registry auth",
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": ["cfg_path"]
-                },
+                "auth": {"$ref": "#/definitions/registry_auth"},
                 "expected_media_types": {"$ref": "#/definitions/media_types"}
             },
             "additionalProperties": false,
@@ -573,32 +562,16 @@
         "required": ["tmpdir", "files"]
     },
     "source_registry": {
-        "description": "Container registry to pull parent images",
-        "type": "object",
-        "properties": {
-            "url": {
-                "description": "Registry url",
-                "type": "string"
-            },
-            "insecure": {
-                "description": "Don't check SSL certificate for url",
-                "type": "boolean"
-            },
-            "auth": {
-                "description": "Authentication information",
-                "type": "object",
-                   "properties": {
-                    "cfg_path": {
-                        "description": "Path to directory  containing .dockercfg for registry auth",
-                        "type": "string"
-                    }
-                },
-                "additionalProperties": false,
-                "required": ["cfg_path"]
-            }
-        },
-        "additionalProperties": false,
-        "required": ["url"]
+        "description": "Default container registry to use for pulling images",
+        "$ref": "#/definitions/source_registry"
+    },
+    "pull_registries": {
+        "description": "Other container registries that may be used for pulling images",
+        "type": "array",
+        "items": {
+            "description": "Any container registry other than the default one",
+            "$ref": "#/definitions/source_registry"
+        }
     },
     "sources_command": {
         "description": "Command to retrieve artifacts in lookaside cache",
@@ -760,6 +733,34 @@
                    "application/vnd.oci.image.manifest.v1+json",
                    "application/vnd.oci.image.index.v1+json"]
         }
+    },
+    "registry_auth": {
+        "description": "Registry authentication information",
+        "type": "object",
+        "properties": {
+            "cfg_path": {
+                "description": "Path to directory containing .dockercfg for registry auth",
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["cfg_path"]
+    },
+    "source_registry": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "description": "Registry url",
+                "type": "string"
+            },
+            "insecure": {
+                "description": "Don't check SSL certificate for url",
+                "type": "boolean"
+            },
+            "auth": {"$ref": "#/definitions/registry_auth"}
+        },
+        "additionalProperties": false,
+        "required": ["url"]
     }
   },
   "required": ["version"]

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -41,6 +41,7 @@ from atomic_reactor.plugins.pre_reactor_config import (ReactorConfig,
                                                        get_openshift_session,
                                                        get_clusters_client_config_path,
                                                        get_docker_registry,
+                                                       get_pull_registries,
                                                        get_platform_to_goarch_mapping,
                                                        get_goarch_to_platform_mapping,
                                                        get_default_image_build_method,
@@ -147,6 +148,115 @@ class TestReactorConfigPlugin(object):
             else:
                 with pytest.raises(OsbsValidationException):
                     get_docker_registry(workflow, docker_fallback)
+
+    @pytest.mark.parametrize(('config', 'expected'), [
+        ("""\
+            version: 1
+            pull_registries: []
+         """,
+         []),
+        ("""\
+            version: 1
+            pull_registries:
+            - url: registry.io
+         """,
+         [
+             {"uri": RegistryURI("registry.io"),
+              "insecure": False,
+              "dockercfg_path": None},
+         ]),
+        ("""\
+            version: 1
+            pull_registries:
+            - url: https://registry.io
+         """,
+         [
+             {"uri": RegistryURI("https://registry.io"),
+              "insecure": False,
+              "dockercfg_path": None},
+         ]),
+        ("""\
+            version: 1
+            pull_registries:
+            - url: registry.io
+              auth:
+                  cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
+         """,
+         [
+             {"uri": RegistryURI("registry.io"),
+              "insecure": False,
+              "dockercfg_path": "/var/run/secrets/atomic-reactor/v2-registry-dockercfg"},
+         ]),
+        ("""\
+            version: 1
+            pull_registries:
+            - url: registry.io
+              insecure: true
+              auth:
+                  cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
+         """,
+         [
+             {"uri": RegistryURI("registry.io"),
+              "insecure": True,
+              "dockercfg_path": "/var/run/secrets/atomic-reactor/v2-registry-dockercfg"},
+         ]),
+        ("""\
+            version: 1
+            pull_registries:
+            - url: registry.io
+              insecure: true
+              auth:
+                  cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
+            - url: registry.org
+         """,
+         [
+             {"uri": RegistryURI("registry.io"),
+              "insecure": True,
+              "dockercfg_path": "/var/run/secrets/atomic-reactor/v2-registry-dockercfg"},
+             {"uri": RegistryURI("registry.org"),
+              "insecure": False,
+              "dockercfg_path": None},
+         ]),
+    ])
+    def test_get_pull_registries(self, config, expected):
+        _, workflow = self.prepare()
+        reactor_conf = workflow.plugin_workspace.setdefault(ReactorConfigPlugin.key, {})
+
+        config_json = read_yaml(config, 'schemas/config.json')
+        reactor_conf[WORKSPACE_CONF_KEY] = ReactorConfig(config_json)
+
+        pull_registries = get_pull_registries(workflow)
+
+        # RegistryURI does not implement equality, check URI as string
+        for reg in pull_registries + expected:
+            reg['uri'] = reg['uri'].uri
+
+        assert pull_registries == expected
+
+    @pytest.mark.parametrize('config, error', [
+        ("""\
+             version: 1
+             pull_registries: {}
+         """,
+         "is not of type {!r}".format("array")),
+        ("""\
+             version: 1
+             pull_registries:
+             - insecure: false
+         """,
+         "{!r} is a required property".format("url")),
+        ("""\
+             version: 1
+             pull_registries:
+             - url: registry.io
+               auth: {}
+         """,
+         "{!r} is a required property".format("cfg_path")),
+    ])
+    def test_get_pull_registries_schema_validation(self, config, error):
+        with pytest.raises(OsbsValidationException) as exc_info:
+            read_yaml(config, 'schemas/config.json')
+        assert error in str(exc_info.value)
 
     def test_no_config(self):
         _, workflow = self.prepare()


### PR DESCRIPTION
* CLOUDBLD-397

pull_registries is a list of additional registries that may be used for
pulling container images (source_registry is the default one)

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
