### PR TITLE
Create RegistryClient class

### DIFF
--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -397,7 +397,9 @@ class TestKojiParent(object):
             response = flexmock(content=json.dumps(manifest_list))
         else:
             response = {}
-        flexmock(atomic_reactor.util).should_receive('get_manifest').and_return((response, None))
+        (flexmock(atomic_reactor.util.RegistryClient)
+         .should_receive('get_manifest')
+         .and_return((response, None)))
 
         expected_result = {BASE_IMAGE_KOJI_BUILD: KOJI_BUILD,
                            PARENT_IMAGES_KOJI_BUILDS: {
@@ -632,7 +634,9 @@ class TestKojiParent(object):
             response = flexmock(content=json.dumps(manifest_list))
         else:
             response = {}
-        flexmock(atomic_reactor.util).should_receive('get_manifest').and_return((response, None))
+        (flexmock(atomic_reactor.util.RegistryClient)
+         .should_receive('get_manifest')
+         .and_return((response, None)))
 
         expected_result = {BASE_IMAGE_KOJI_BUILD: KOJI_BUILD,
                            PARENT_IMAGES_KOJI_BUILDS: {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1500,7 +1500,7 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
             elif version == 'v2_list':
                 return_list[version] = v2_list_response
 
-    (flexmock(atomic_reactor.util)
+    (flexmock(atomic_reactor.util.RegistryClient)
      .should_receive('get_all_manifests')
      .and_return(return_list)
      .once())
@@ -1512,7 +1512,7 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
 
     else:
         if found_versions and ('v2' in found_versions or 'v2_list' in found_versions):
-            (flexmock(atomic_reactor.util)
+            (flexmock(atomic_reactor.util.RegistryClient)
              .should_receive('get_config_and_id_from_registry')
              .and_return(inspect_data, config_digest)
              .once())


### PR DESCRIPTION
* CLOUDBLD-397

Depends on #1469 

The `create_from_config()` method of RegistrySession will eventually be used in `pin_operator_digest` to support other registries.

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
