### PR TITLE
clean exit plugins, if autorebuild will be canceled for isolated parent

### DIFF
--- a/atomic_reactor/plugins/pre_koji_delegate.py
+++ b/atomic_reactor/plugins/pre_koji_delegate.py
@@ -121,6 +121,9 @@ class KojiDelegatePlugin(PreBuildPlugin):
 
         self.osbs = get_openshift_session(self.workflow, NO_FALLBACK)
 
+        # Do not run exit plugins. Especially sendmail
+        self.workflow.exit_plugins_conf = []
+
         if self.workflow.cancel_isolated_autorebuild:  # this is set by the koji_parent plugin
             self.log.info("ignoring isolated build for autorebuild, the build will be cancelled")
             self.cancel_build()
@@ -128,8 +131,6 @@ class KojiDelegatePlugin(PreBuildPlugin):
 
         self.delegate_task()
 
-        # Do not run exit plugins. Especially sendmail
-        self.workflow.exit_plugins_conf = []
         # We cancel the build so it does not inerfere with real failed builds
         self.cancel_build()
         self.log.info('Build was delegated, the build will be cancelled')


### PR DESCRIPTION
* CLOUDBLD-926

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
