### PR TITLE
ODCS timeout is configurable in reactor config

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -104,7 +104,10 @@ def get_odcs_session(workflow):
     config = get_odcs(workflow)
     from atomic_reactor.utils.odcs import ODCSClient
 
-    client_kwargs = {'insecure': config.get('insecure', False)}
+    client_kwargs = {
+        'insecure': config.get('insecure', False),
+        'timeout': config.get('timeout', None),
+    }
 
     openidc_dir = config['auth'].get('openidc_dir')
     if openidc_dir:

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -251,6 +251,10 @@
             "default_signing_intent": {
                 "description": "Default signing intent",
                 "type": "string"
+            },
+            "timeout": {
+                "description": "How long in seconds to wait for requested compose to complete. Defaults to 3600",
+                "type": "integer"
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1190,6 +1190,7 @@ class TestReactorConfigPlugin(object):
               - name: release
                 keys: [R123]
               default_signing_intent: default
+              timeout: 3600
         """, False),
 
         ("""\
@@ -1270,7 +1271,10 @@ class TestReactorConfigPlugin(object):
             return
         config_json = read_yaml(config, 'schemas/config.json')
 
-        auth_info = {'insecure': config_json['odcs'].get('insecure', False)}
+        auth_info = {
+            'insecure': config_json['odcs'].get('insecure', False),
+            'timeout': config_json['odcs'].get('timeout', None),
+        }
         if 'openidc_dir' in config_json['odcs']['auth']:
             config_json['odcs']['auth']['openidc_dir'] = str(tmpdir)
             filename = str(tmpdir.join('token'))

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -798,26 +798,26 @@ class TestResolveComposes(object):
                                   reactor_config_map=reactor_config_map)
 
     @pytest.mark.parametrize(('plugin_args', 'expected_kwargs'), (
-        ({
-            'odcs_insecure': True,
-        }, {'insecure': True}),
-
-        ({
-            'odcs_insecure': False,
-        }, {'insecure': False}),
-
-        ({
-            'odcs_openidc_secret_path': True,
-        }, {'token': 'the-token', 'insecure': False}),
-
-        ({
-            'odcs_ssl_secret_path': True,
-        }, {'cert': '<tbd-cert-path>', 'insecure': False}),
-
-        ({
-            'odcs_ssl_secret_path': 'non-existent-path',
-        }, {'insecure': False}),
-
+        (
+            {'odcs_insecure': True},
+            {'insecure': True, 'timeout': None}
+        ),
+        (
+            {'odcs_insecure': False},
+            {'insecure': False, 'timeout': None}
+        ),
+        (
+            {'odcs_openidc_secret_path': True},
+            {'token': 'the-token', 'insecure': False, 'timeout': None}
+        ),
+        (
+            {'odcs_ssl_secret_path': True},
+            {'cert': '<tbd-cert-path>', 'insecure': False, 'timeout': None}
+        ),
+        (
+            {'odcs_ssl_secret_path': 'non-existent-path'},
+            {'insecure': False, 'timeout': None}
+        ),
     ))
     def test_odcs_session_creation(self, tmpdir, workflow, reactor_config_map,
                                    plugin_args, expected_kwargs):


### PR DESCRIPTION
* CLOUDBLD-69

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
