### PR TITLE
Make Cachito timeout configurable in reactor config

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -141,7 +141,10 @@ def get_cachito(workflow):
 def get_cachito_session(workflow):
     config = get_cachito(workflow)
 
-    api_kwargs = {'insecure': config.get('insecure', False)}
+    api_kwargs = {
+        'insecure': config.get('insecure', False),
+        'timeout': config.get('timeout', False),
+    }
 
     ssl_certs_dir = config['auth'].get('ssl_certs_dir')
     if ssl_certs_dir:

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -357,6 +357,10 @@
                     }
                 },
                 "additionalProperties": false
+            },
+            "timeout": {
+                "description": "How long in seconds to wait for a Cachito request completes. Defaults to 3600",
+                "type": "integer"
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1362,6 +1362,7 @@ class TestReactorConfigPlugin(object):
               api_url: https://cachito.example.com
               auth:
                   ssl_certs_dir: /var/run/secrets/atomic-reactor/cachitosecret
+              timeout: 1000
         """, False),
 
         ("""\
@@ -1420,7 +1421,10 @@ class TestReactorConfigPlugin(object):
             return
         config_json = read_yaml(config, 'schemas/config.json')
 
-        auth_info = {'insecure': config_json['cachito'].get('insecure', False)}
+        auth_info = {
+            'insecure': config_json['cachito'].get('insecure', False),
+            'timeout': config_json['cachito'].get('timeout', False),
+        }
 
         ssl_dir_raise = False
         if 'ssl_certs_dir' in config_json['cachito']['auth']:


### PR DESCRIPTION
* CLOUDBLD-69

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
