### PR TITLE
Validate build_env configuration in schema

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -706,6 +706,25 @@
         },
         "required": ["allowed_registries"],
         "additionalProperties": false
+    },
+    "build_env_vars": {
+      "description": "Variables to propagate to build environment",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of environment variable",
+            "type": "string"
+          },
+          "value": {
+            "description": "Value of environment variable",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["name", "value"]
+      }
     }
   },
   "definitions": {

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1713,6 +1713,40 @@ class TestReactorConfigPlugin(object):
         plugin.run()
         assert plugin.workflow.user_params == USER_PARAMS
 
+    @pytest.mark.parametrize('config, valid', [
+        ("""\
+          version: 1
+          build_env_vars: []
+        """, True),
+        ("""\
+          version: 1
+          build_env_vars:
+          - name: HTTP_PROXY
+            value: example.proxy.net
+          - name: NO_PROXY
+            value: localhost
+        """, True),
+        ("""\
+          version: 1
+          build_env_vars:
+          - name: FOO
+            value: 1
+        """, False),  # values must be strings
+        ("""\
+          version: 1
+          build_env_vars:
+          - name: FOO
+        """, False),  # values must be defined
+    ])
+    def test_validate_build_env_vars(self, config, valid):
+        # Only test schema validation, atomic-reactor has no additional support
+        # for build_env_vars (osbs-client does, however)
+        if valid:
+            read_yaml(config, 'schemas/config.json')
+        else:
+            with pytest.raises(OsbsValidationException):
+                read_yaml(config, 'schemas/config.json')
+
 
 def test_ensure_odcsconfig_does_not_modify_original_signing_intents():
     signing_intents = [{'name': 'release', 'keys': ['R123', 'R234']}]


### PR DESCRIPTION
* CLOUDBLD-1228

build_env is a list of environment variables to be propagated to build
environment (osbs-client does this, atomic-reactor only validates schema)

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
