### PR TITLE
Operator manifests: Compute manifest list digests

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -319,8 +319,8 @@ class PullspecReplacer(object):
             return image
         self.log.debug("Querying %s for manifest list digest", image.registry)
         registry_client = self._get_registry_client(image.registry)
-        digests = registry_client.get_manifest_digests(image, versions=("v2_list",))
-        return self._replace(image, tag=digests["v2_list"])
+        digest = registry_client.get_manifest_list_digest(image)
+        return self._replace(image, tag=digest)
 
     def replace_registry(self, image):
         """

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -829,6 +829,18 @@ class RegistryClient(object):
         response, _ = self.get_manifest(image, version)
         return response
 
+    def get_manifest_list_digest(self, image):
+        """Return manifest list digest for image
+
+        :param image:
+        :return:
+        """
+        response = self.get_manifest_list(image)
+        if response is None:
+            raise RuntimeError('Unable to fetch v2.manifest_list for {}'.format(image.to_str()))
+        digest_dict = get_checksums(io.BytesIO(response.content), ['sha256'])
+        return 'sha256:{}'.format(digest_dict['sha256sum'])
+
     def get_all_manifests(self, image, versions=('v1', 'v2', 'v2_list')):
         """Return manifest digests for image.
 


### PR DESCRIPTION
Some registries doesn't provide information about manifest list digest
in `Docker-Content-Digest` header, thus we cannot rely on that attribute
and we have to compute digest.

* CLOUDBLD-1260

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
