### PR TITLE
Make Internet connection check a little faster

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -34,7 +34,7 @@ def is_string_type(obj):
 
 def has_connection():
     try:
-        requests.get("https://github.com/")
+        requests.head("http://github.com/")
         return True
     except requests.ConnectionError:
         return False


### PR DESCRIPTION
Testing whether Internet connect is available only cares about if the
remote server is able to response something, but not the concrete
content returned. So, when remote server responses 301, it's enough, no
need to wait for a 200 response with the real content from redirected
URL.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
