### PR TITLE
Deflate operator manifest zip file

### DIFF
--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -125,7 +125,7 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
                 for f in files:
                     filedir = os.path.relpath(root, manifests_path)
                     filepath = os.path.join(filedir, f)
-                    archive.write(os.path.join(root, f), filepath)
+                    archive.write(os.path.join(root, f), filepath, zipfile.ZIP_DEFLATED)
             manifest_files = archive.namelist()
             if not manifest_files:
                 self.log.error('Empty operator manifests directory')


### PR DESCRIPTION
Currently zip file is not deflated. Deflate it to reduce size for
archiving and uploading.

* CLOUDBLD-1374

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
