### PR TITLE
Remove unused `_make_labels()` in orchestrate_build

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -522,23 +522,6 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
 
         return build_kwargs
 
-    def _make_labels(self):
-        labels = {}
-        koji_build_id = None
-        ids = {
-            build_info.build.get_koji_build_id()
-            for build_info in self.worker_builds
-            if build_info.build
-        }
-        self.log.debug('all koji-build-ids: %s', ids)
-        if ids:
-            koji_build_id = ids.pop()
-
-        if koji_build_id:
-            labels['koji-build-id'] = koji_build_id
-
-        return labels
-
     def get_fs_task_id(self):
         task_id = None
 
@@ -862,8 +845,6 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
             for build_info in self.worker_builds if build_info.build
         }}
 
-        labels = self._make_labels()
-
         fail_reasons = {
             build_info.platform: build_info.get_fail_reason()
             for build_info in self.worker_builds
@@ -877,6 +858,6 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
 
         if fail_reasons:
             return BuildResult(fail_reason=json.dumps(fail_reasons),
-                               annotations=annotations, labels=labels)
+                               annotations=annotations)
 
-        return BuildResult.make_remote_image_result(annotations, labels=labels)
+        return BuildResult.make_remote_image_result(annotations)

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -435,8 +435,6 @@ def test_orchestrate_build(tmpdir, caplog, config_kwargs,
         }
     })
 
-    assert (build_result.labels == {})
-
     build_info = get_worker_build_info(workflow, 'x86_64')
     assert build_info.osbs
 
@@ -478,9 +476,8 @@ def test_orchestrate_build_annotations_and_labels(tmpdir, metadata_fragment):
         }
         if metadata_fragment:
             annotations.update(md)
+        return make_build_response(build_name, 'Complete', annotations)
 
-        labels = {'koji-build-id': 'koji-build-id'}
-        return make_build_response(build_name, 'Complete', annotations, labels)
     (flexmock(OSBS)
         .should_receive('wait_for_build_to_finish')
         .replace_with(mock_wait_for_build_to_finish))
@@ -545,8 +542,6 @@ def test_orchestrate_build_annotations_and_labels(tmpdir, metadata_fragment):
         expected['worker-builds']['ppc64le'].update(md)
 
     assert (build_result.annotations == expected)
-
-    assert (build_result.labels == {'koji-build-id': 'koji-build-id'})
 
     build_info = get_worker_build_info(workflow, 'x86_64')
     assert build_info.osbs


### PR DESCRIPTION
`_make_labels()` collects the 'koji-build-id' labels
from the worker builds, but that label is never
set on worker builds, so the method **always**
returns an empty dict.

* CLOUDBLD-91

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
