### PR TITLE
Make timeout=0 work again for odcs and cachito

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -45,7 +45,7 @@ class CachitoAPI(object):
     def __init__(self, api_url, insecure=False, cert=None, timeout=None):
         self.api_url = api_url
         self.session = self._make_session(insecure=insecure, cert=cert)
-        self.timeout = timeout or 3600
+        self.timeout = 3600 if timeout is None else timeout
 
     def _make_session(self, insecure, cert):
         # method_whitelist=False allows retrying non-idempotent methods like POST

--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -30,7 +30,7 @@ class ODCSClient(object):
             self.url = url
         else:
             self.url = url + '/'
-        self.timeout = timeout or 3600
+        self.timeout = 3600 if timeout is None else timeout
         self._setup_session(insecure=insecure, token=token, cert=cert)
 
     def _setup_session(self, insecure, token, cert):

--- a/tests/utils/test_odcs.py
+++ b/tests/utils/test_odcs.py
@@ -205,7 +205,8 @@ def assert_request_token(request, session):
 
 
 @responses.activate
-def test_wait_for_compose_timeout():
+@pytest.mark.parametrize('timeout', (0, 20))
+def test_wait_for_compose_timeout(timeout):
     compose_url = '{}composes/{}'.format(ODCS_URL, COMPOSE_ID)
 
     responses.add(responses.GET, compose_url, body=compose_json(0, 'generating'))
@@ -214,7 +215,7 @@ def test_wait_for_compose_timeout():
         .and_return(2000, 1000)  # end time, start time
         .one_by_one())
 
-    odcs_client = ODCSClient(ODCS_URL, timeout=20)
-    expected_error = 'Retrieving {} timed out after {} seconds'.format(compose_url, 20)
+    odcs_client = ODCSClient(ODCS_URL, timeout=timeout)
+    expected_error = 'Retrieving {} timed out after {} seconds'.format(compose_url, timeout)
     with pytest.raises(RuntimeError, match=expected_error):
         odcs_client.wait_for_compose(COMPOSE_ID)


### PR DESCRIPTION
* CLOUDBLD-1311

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
