### PR TITLE
Defer Cachito configurations download to workers

### DIFF
--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -17,6 +17,7 @@ import tarfile
 from atomic_reactor.constants import REMOTE_SOURCE_DIR
 from atomic_reactor.download import download_url
 from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import get_cachito
 from atomic_reactor.utils.cachito import CFG_TYPE_B64
 
 
@@ -51,7 +52,9 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
             return
 
         # Download the source code archive
-        archive = download_url(self.url, self.workflow.source.workdir)
+        cachito_config = get_cachito(self.workflow)
+        verify_cert = cachito_config.get('insecure', False)
+        archive = download_url(self.url, self.workflow.source.workdir, insecure=verify_cert)
 
         # Unpack the source code archive into a dedicated dir in container build workdir
         dest_dir = os.path.join(self.workflow.builder.df_dir, self.REMOTE_SOURCE)

--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -92,8 +92,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
 
         remote_source_json = self.source_request_to_json(source_request)
         remote_source_url = self.cachito_session.assemble_download_url(source_request)
-        remote_source_configs = self.cachito_session.get_request_config(source_request)
-        self.set_worker_params(source_request, remote_source_url, remote_source_configs)
+        remote_source_conf_url = self.cachito_session.assemble_request_config_url(source_request)
+        self.set_worker_params(source_request, remote_source_url, remote_source_conf_url)
 
         dest_dir = self.workflow.source.workdir
         dest_path = self.cachito_session.download_sources(source_request, dest_dir=dest_dir)
@@ -107,7 +107,7 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
             'remote_source_path': dest_path,
         }
 
-    def set_worker_params(self, source_request, remote_source_url, remote_source_configs):
+    def set_worker_params(self, source_request, remote_source_url, remote_source_conf_url):
         build_args = {
             # Turn the environment variables into absolute paths that
             # represent where the remote sources are copied to during
@@ -117,7 +117,7 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
         }
         override_build_kwarg(self.workflow, 'remote_source_url', remote_source_url)
         override_build_kwarg(self.workflow, 'remote_source_build_args', build_args)
-        override_build_kwarg(self.workflow, 'remote_source_configs', remote_source_configs)
+        override_build_kwarg(self.workflow, 'remote_source_configs', remote_source_conf_url)
 
     def source_request_to_json(self, source_request):
         """Create a relevant representation of the source request"""

--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -92,7 +92,7 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
 
         remote_source_json = self.source_request_to_json(source_request)
         remote_source_url = self.cachito_session.assemble_download_url(source_request)
-        remote_source_conf_url = self.cachito_session.assemble_request_config_url(source_request)
+        remote_source_conf_url = remote_source_json.get('configuration_files')
         self.set_worker_params(source_request, remote_source_url, remote_source_conf_url)
 
         dest_dir = self.workflow.source.workdir
@@ -122,7 +122,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
     def source_request_to_json(self, source_request):
         """Create a relevant representation of the source request"""
         required = ('ref', 'repo')
-        optional = ('dependencies', 'flags', 'packages', 'pkg_managers', 'environment_variables')
+        optional = ('dependencies', 'flags', 'packages', 'pkg_managers', 'environment_variables',
+                    'configuration_files')
 
         data = {}
         try:

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -184,21 +184,17 @@ class CachitoAPI(object):
         request_id = self._get_request_id(request)
         return '{}/api/v1/requests/{}/download'.format(self.api_url, request_id)
 
-    def get_request_config(self, request):
-        """Get the configuration files associated with a request
+    def assemble_request_config_url(self, request):
+        """Return the URL to download the configuration files associated with a request
 
         :param request: int or dict, either the Cachito request ID or a dict with 'id' key
 
-        :return: list<dict>, configuration data for the given request.
-                 entries include path, type, and content
+        :return: str, the URL to download the configuration files
         """
         request_id = self._get_request_id(request)
         logger.debug('Retrieving configuration files for request %ds', request_id)
         url = '{}/api/v1/requests/{}/configuration-files'.format(self.api_url, request_id)
-        response = self.session.get(url)
-        response_json = response.json()
-        response.raise_for_status()
-        return response_json
+        return url
 
     def _get_request_id(self, request):
         if isinstance(request, int):

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -184,18 +184,6 @@ class CachitoAPI(object):
         request_id = self._get_request_id(request)
         return '{}/api/v1/requests/{}/download'.format(self.api_url, request_id)
 
-    def assemble_request_config_url(self, request):
-        """Return the URL to download the configuration files associated with a request
-
-        :param request: int or dict, either the Cachito request ID or a dict with 'id' key
-
-        :return: str, the URL to download the configuration files
-        """
-        request_id = self._get_request_id(request)
-        logger.debug('Retrieving configuration files for request %ds', request_id)
-        url = '{}/api/v1/requests/{}/configuration-files'.format(self.api_url, request_id)
-        return url
-
     def _get_request_id(self, request):
         if isinstance(request, int):
             return request

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -39,7 +39,10 @@ KOJI_TASK_OWNER = 'spam'
 CACHITO_URL = 'https://cachito.example.com'
 CACHITO_REQUEST_ID = 98765
 CACHITO_REQUEST_DOWNLOAD_URL = '{}/api/v1/{}/download'.format(CACHITO_URL, CACHITO_REQUEST_ID)
-CACHITO_REQUEST_CONFIGS = [{'eggs': 'bacon'}, {'bread': 'jam'}]
+CACHITO_REQUEST_CONFIG_URL = '{}/api/v1/requests/{}/configuration-files'.format(
+    CACHITO_URL,
+    CACHITO_REQUEST_ID
+    )
 
 REMOTE_SOURCE_REPO = 'https://git.example.com/team/repo.git'
 REMOTE_SOURCE_REF = 'b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a'
@@ -172,9 +175,9 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
         .and_return(CACHITO_REQUEST_DOWNLOAD_URL))
 
     (flexmock(CachitoAPI)
-        .should_receive('get_request_config')
+        .should_receive('assemble_request_config_url')
         .with_args(source_request)
-        .and_return(CACHITO_REQUEST_CONFIGS))
+        .and_return(CACHITO_REQUEST_CONFIG_URL))
 
 
 def mock_koji(user=KOJI_TASK_OWNER):
@@ -360,7 +363,7 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
         orchestrator_build_workspace = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         worker_params = orchestrator_build_workspace[WORKSPACE_KEY_OVERRIDE_KWARGS][None]
         assert worker_params['remote_source_url'] == CACHITO_REQUEST_DOWNLOAD_URL
-        assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIGS
+        assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIG_URL
         assert worker_params['remote_source_build_args'] == {
             'GOPATH': '/remote-source/deps/gomod',
             'GOCACHE': '/remote-source/deps/gomod',

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -147,6 +147,7 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
                     'version': 'v2.0.3'
                 }
             ],
+            'configuration_files': CACHITO_REQUEST_CONFIG_URL,
             'extra_cruft': 'ignored',
         }
 
@@ -173,11 +174,6 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
         .should_receive('assemble_download_url')
         .with_args(source_request)
         .and_return(CACHITO_REQUEST_DOWNLOAD_URL))
-
-    (flexmock(CachitoAPI)
-        .should_receive('assemble_request_config_url')
-        .with_args(source_request)
-        .and_return(CACHITO_REQUEST_CONFIG_URL))
 
 
 def mock_koji(user=KOJI_TASK_OWNER):
@@ -355,6 +351,7 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
                     'version': 'v2.0.3'
                 }
             ],
+            'configuration_files': CACHITO_REQUEST_CONFIG_URL
         }
         assert results['remote_source_path'] == expected_dowload_path(workflow)
 

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -298,41 +298,11 @@ def test_assemble_download_url(tmpdir, cachito_request):
     assert url == CACHITO_REQUEST_DOWNLOAD_URL
 
 
-@responses.activate
 @pytest.mark.parametrize('cachito_request', (
     CACHITO_REQUEST_ID,
     {'id': CACHITO_REQUEST_ID},
 ))
-@pytest.mark.parametrize('response_data', (
-    [],
-    [
-        {
-            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
-            "path": "app/.npmrc",
-            "type": "base64",
-        }
-    ],
-    [
-        {
-            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
-            "path": "app/.npmrc",
-            "type": "base64",
-        },
-        {
-            "content": "cmVnaXN0cnk9aHR0cDovL2RvbWFpbi5sb2NhbC9yZXBvLwo=",
-            "path": "app/.npmrc2",
-            "type": "base64",
-        }
-    ],
-))
-def test_get_request_config(tmpdir, cachito_request, response_data):
-    responses.add(
-        responses.GET,
-        '{}/api/v1/requests/{}/configuration-files'.format(CACHITO_URL, CACHITO_REQUEST_ID),
-        content_type='application/json',
-        status=200,
-        body=json.dumps(response_data))
-
-    response_json = CachitoAPI(CACHITO_URL).get_request_config(cachito_request)
-
-    assert response_json == response_data
+def test_assemble_request_config_url(tmpdir, cachito_request):
+    expected = '{}/api/v1/requests/{}/configuration-files'.format(CACHITO_URL, CACHITO_REQUEST_ID)
+    url = CachitoAPI(CACHITO_URL).assemble_request_config_url(cachito_request)
+    assert url == expected

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -296,13 +296,3 @@ def test_download_sources_bad_request_type(tmpdir):
 def test_assemble_download_url(tmpdir, cachito_request):
     url = CachitoAPI(CACHITO_URL).assemble_download_url(cachito_request)
     assert url == CACHITO_REQUEST_DOWNLOAD_URL
-
-
-@pytest.mark.parametrize('cachito_request', (
-    CACHITO_REQUEST_ID,
-    {'id': CACHITO_REQUEST_ID},
-))
-def test_assemble_request_config_url(tmpdir, cachito_request):
-    expected = '{}/api/v1/requests/{}/configuration-files'.format(CACHITO_URL, CACHITO_REQUEST_ID)
-    url = CachitoAPI(CACHITO_URL).assemble_request_config_url(cachito_request)
-    assert url == expected


### PR DESCRIPTION
Cachito provided additional remote source configurations may contain large files. Forwarding them as user params from the orchestrator to the workers may result in large chunks of data being passed in the parameters and being appended to the build logs. This may lead to build failures.

Instead, we defer querying the Cachito configurations endpoint to the    worker builds.

* CLOUDBLD-427

This PR also proposes using cachito configurations to downoad the sources in the download remote sources plugin:

If Cachito configuration is set to insecure, i.e., to not verify SSL certificates, that configuration should also be propagated to the download_remote_sources plugin when fetching the source bundles from Cachito.

* CLOUDBLD-203
* CLOUDBLD-427

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
