### PR TITLE
Fix setting default CachitoAPI timeout to None

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -146,7 +146,7 @@ def get_cachito_session(workflow):
 
     api_kwargs = {
         'insecure': config.get('insecure', False),
-        'timeout': config.get('timeout', False),
+        'timeout': config.get('timeout'),
     }
 
     ssl_certs_dir = config['auth'].get('ssl_certs_dir')

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -363,8 +363,9 @@
                 "additionalProperties": false
             },
             "timeout": {
-                "description": "How long in seconds to wait for a Cachito request completes. Defaults to 3600",
-                "type": "integer"
+                "description": "How long in seconds to wait for a Cachito request completes",
+                "type": "integer",
+                "default": 3600
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -1426,7 +1426,7 @@ class TestReactorConfigPlugin(object):
 
         auth_info = {
             'insecure': config_json['cachito'].get('insecure', False),
-            'timeout': config_json['cachito'].get('timeout', False),
+            'timeout': config_json['cachito'].get('timeout'),
         }
 
         ssl_dir_raise = False


### PR DESCRIPTION
The CachitoAPI class expects either an integer or None. Setting it to
False makes it forward an invalid value to the API.

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
