### PR TITLE
Support Cachito environment variables that are not paths

### DIFF
--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -128,6 +128,7 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
             'repo': REMOTE_SOURCE_REPO,
             'ref': REMOTE_SOURCE_REF,
             'environment_variables': {
+                'GO111MODULE': 'on',
                 'GOPATH': 'deps/gomod',
                 'GOCACHE': 'deps/gomod',
             },
@@ -332,6 +333,7 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
             'repo': REMOTE_SOURCE_REPO,
             'ref': REMOTE_SOURCE_REF,
             'environment_variables': {
+                'GO111MODULE': 'on',
                 'GOPATH': 'deps/gomod',
                 'GOCACHE': 'deps/gomod',
             },
@@ -362,6 +364,7 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
         assert worker_params['remote_source_url'] == CACHITO_REQUEST_DOWNLOAD_URL
         assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIG_URL
         assert worker_params['remote_source_build_args'] == {
+            'GO111MODULE': 'on',
             'GOPATH': '/remote-source/deps/gomod',
             'GOCACHE': '/remote-source/deps/gomod',
         }


### PR DESCRIPTION
Cachito provides environment variable values that are relative paths or literal values that OSBS sets as build arguments in the user's Dockerfile. For the gomod package manager, all the environment variables were relative paths and OSBS converted them to absolute paths in the container. Cachito recently added support for the npm package manager, which specifies environment variables that are literal values and not relative paths. OSBS needs to detect these values and not convert them to absolute paths.

Eventually, Cachito will add the concept of environment variable types, which will allow OSBS to stop making educated guesses on which values are paths.

Resolves CLOUDBLD-1483

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file