### PR TITLE
Fetch Image Content Manifest from Cachito...

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -94,7 +94,9 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
         remote_source_json = self.source_request_to_json(source_request)
         remote_source_url = self.cachito_session.assemble_download_url(source_request)
         remote_source_conf_url = remote_source_json.get('configuration_files')
-        self.set_worker_params(source_request, remote_source_url, remote_source_conf_url)
+        remote_source_icm_url = remote_source_json.get('content_manifest')
+        self.set_worker_params(source_request, remote_source_url, remote_source_conf_url,
+                               remote_source_icm_url)
 
         dest_dir = self.workflow.source.workdir
         dest_path = self.cachito_session.download_sources(source_request, dest_dir=dest_dir)
@@ -108,7 +110,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
             'remote_source_path': dest_path,
         }
 
-    def set_worker_params(self, source_request, remote_source_url, remote_source_conf_url):
+    def set_worker_params(self, source_request, remote_source_url, remote_source_conf_url,
+                          remote_source_icm_url):
         build_args = {}
         # This matches values such as 'deps/gomod' but not 'true'
         rel_path_regex = re.compile(r'^[^/]+/[^/]+(?:/[^/]+)*$')
@@ -129,6 +132,7 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
         override_build_kwarg(self.workflow, 'remote_source_url', remote_source_url)
         override_build_kwarg(self.workflow, 'remote_source_build_args', build_args)
         override_build_kwarg(self.workflow, 'remote_source_configs', remote_source_conf_url)
+        override_build_kwarg(self.workflow, 'remote_source_icm_url', remote_source_icm_url)
 
     def source_request_to_json(self, source_request):
         """Create a relevant representation of the source request"""

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -42,7 +42,11 @@ CACHITO_REQUEST_DOWNLOAD_URL = '{}/api/v1/{}/download'.format(CACHITO_URL, CACHI
 CACHITO_REQUEST_CONFIG_URL = '{}/api/v1/requests/{}/configuration-files'.format(
     CACHITO_URL,
     CACHITO_REQUEST_ID
-    )
+)
+CACHITO_ICM_URL = '{}/api/v1/requests/{}/content-manifest'.format(
+    CACHITO_URL,
+    CACHITO_REQUEST_ID
+)
 
 REMOTE_SOURCE_REPO = 'https://git.example.com/team/repo.git'
 REMOTE_SOURCE_REF = 'b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a'
@@ -163,13 +167,14 @@ def mock_cachito_api(workflow, user=KOJI_TASK_OWNER, source_request=None,
             ref=REMOTE_SOURCE_REF,
             user=user,
             dependency_replacements=dependency_replacements,
-        )
+         )
         .and_return({'id': CACHITO_REQUEST_ID}))
 
     (flexmock(CachitoAPI)
         .should_receive('wait_for_request')
         .with_args({'id': CACHITO_REQUEST_ID})
         .and_return(source_request))
+
     (flexmock(CachitoAPI)
         .should_receive('download_sources')
         .with_args(source_request, dest_dir=str(workflow._tmpdir))
@@ -384,5 +389,6 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
             'GOPATH': '/remote-source/deps/gomod',
             'GOCACHE': '/remote-source/deps/gomod',
         }
+        assert worker_params['remote_source_icm_url'] == CACHITO_ICM_URL
 
     return results


### PR DESCRIPTION
...and forward to a new pre-build plugin: `add_image_content_manifest`

- 'pre_resolve_remote_source.py' adds the ICM URL as a param for
  `set_worker_params()`

* CLOUDBLD-1132

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
