### PR TITLE
auth: Use retries when querying for token

### DIFF
--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -1,0 +1,60 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
+from atomic_reactor.constants import (HTTP_CLIENT_STATUS_RETRY,
+                                      HTTP_MAX_RETRIES,
+                                      HTTP_BACKOFF_FACTOR,
+                                      HTTP_REQUEST_TIMEOUT)
+
+
+class SessionWithTimeout(requests.Session):
+    """
+    requests Session with added timeout
+    """
+    def __init__(self, *args, **kwargs):
+        super(SessionWithTimeout, self).__init__(*args, **kwargs)
+
+    def request(self, *args, **kwargs):
+        kwargs.setdefault('timeout', HTTP_REQUEST_TIMEOUT)
+        return super(SessionWithTimeout, self).request(*args, **kwargs)
+
+
+# This is a hook to mock during tests to temporarily disable retries
+def _http_retries_disabled():
+    return False
+
+
+def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
+                                  times=HTTP_MAX_RETRIES, delay=HTTP_BACKOFF_FACTOR,
+                                  method_whitelist=None, raise_on_status=True):
+    if _http_retries_disabled():
+        times = 0
+
+    retry = Retry(
+        total=int(times),
+        backoff_factor=delay,
+        status_forcelist=client_statuses,
+        method_whitelist=method_whitelist
+    )
+
+    # raise_on_status was added later to Retry, adding compatibility to work
+    # with newer versions and ignoring this option with older ones
+    if hasattr(retry, 'raise_on_status'):
+        retry.raise_on_status = raise_on_status
+
+    session = SessionWithTimeout()
+    session.mount('http://', HTTPAdapter(max_retries=retry))
+    session.mount('https://', HTTPAdapter(max_retries=retry))
+
+    return session

--- a/tests/retry_mock.py
+++ b/tests/retry_mock.py
@@ -9,10 +9,10 @@ of the BSD license. See the LICENSE file for details.
 from __future__ import unicode_literals, absolute_import
 
 from flexmock import flexmock
-from atomic_reactor import util
+import atomic_reactor.utils.retries
 
 
 def mock_get_retry_session():
-    (flexmock(util)
+    (flexmock(atomic_reactor.utils.retries)
         .should_receive('_http_retries_disabled')
         .and_return(True))

--- a/tests/utils/test_retries.py
+++ b/tests/utils/test_retries.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import requests
+from urllib3 import Retry
+
+import pytest
+from flexmock import flexmock
+
+from atomic_reactor.constants import (HTTP_MAX_RETRIES,
+                                      HTTP_REQUEST_TIMEOUT)
+from atomic_reactor.utils.retries import SessionWithTimeout, get_retrying_requests_session
+
+
+@pytest.mark.parametrize('timeout', [None, 0, 10])
+def test_session_with_timeout(timeout):
+    """
+    Test that session sets default timeout if not specified
+    """
+    session = SessionWithTimeout()
+
+    test_url = 'http://test.net'
+
+    def mocked_request(method, url, **kwargs):
+        assert method == 'GET'
+        assert url == test_url
+        assert 'timeout' in kwargs
+        expected_timeout = timeout if timeout is not None else HTTP_REQUEST_TIMEOUT
+        assert kwargs['timeout'] == expected_timeout
+
+    (flexmock(requests.Session)
+     .should_receive('request')
+     .replace_with(mocked_request))
+
+    if timeout is not None:
+        session.get(test_url, timeout=timeout)
+    else:
+        session.get(test_url)
+
+
+@pytest.mark.parametrize('times', [None, 0, 5])
+def test_get_retrying_requests_session(times):
+    """
+    Test that retries are set properly for http(s):// adapters
+
+    Most arguments are simply passed to Retry.__init__, test only basic functionality
+    """
+    if times is not None:
+        session = get_retrying_requests_session(times=times)
+    else:
+        session = get_retrying_requests_session()
+
+    http = session.adapters['http://']
+    https = session.adapters['https://']
+
+    assert isinstance(http.max_retries, Retry)
+    assert isinstance(https.max_retries, Retry)
+
+    expected_total = times if times is not None else HTTP_MAX_RETRIES
+    assert http.max_retries.total == expected_total
+    assert https.max_retries.total == expected_total


### PR DESCRIPTION
* CLOUDBLD-1292

Move get_retrying_requests_session() out of util and into its own module
to avoid a cyclic import between auth and util.

Use a retrying session when querying for token in HTTPBearerAuth.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
