### PR TITLE
Limit maximum image size for regular images before pushing to registry

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -439,6 +439,13 @@ def get_operator_manifests(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'operator_manifests', fallback)
 
 
+def get_image_size_limit(workflow):
+    config = get_value(workflow, 'image_size_limit', {})
+    return {
+        'binary_image': config.get('binary_image', 0),
+    }
+
+
 class ClusterConfig(object):
     """
     Configuration relating to a particular cluster

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -734,6 +734,18 @@
         "additionalProperties": false,
         "required": ["name", "value"]
       }
+    },
+    "image_size_limit": {
+      "description": "Define maximum uncompressed image size in bytes for binary image checked before push",
+      "type": "object",
+      "properties": {
+        "binary_image": {
+          "description": "Maximum size of binary images. Set to 0 or omit to skip the check",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
     }
   },
   "definitions": {


### PR DESCRIPTION
* CLOUDBLD-1095

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
