### PR TITLE
Allow passing empty containers in Cachito params

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -80,7 +80,7 @@ class CachitoAPI(object):
             'dependency_replacements': dependency_replacements,
         }
         # Remove None values
-        payload = {k: v for k, v in payload.items() if v}
+        payload = {k: v for k, v in payload.items() if v is not None}
 
         url = '{}/api/v1/requests'.format(self.api_url)
         logger.debug('Making request %s with payload:\n%s', url, json.dumps(payload, indent=4))

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -35,6 +35,8 @@ CACHITO_REQUEST_REPO = 'https://github.com/release-engineering/retrodep.git'
     {},
     {'flags': ['spam', 'bacon']},
     {'pkg_managers': ['gomod']},
+    {'pkg_managers': []},
+    {'pkg_managers': None},
     {'user': 'ham'},
     {'dependency_replacements': [{
         'name': 'eample.com/repo/project',
@@ -51,8 +53,12 @@ def test_request_sources(additional_params, caplog):
 
         assert body_json['repo'] == CACHITO_REQUEST_REPO
         assert body_json['ref'] == CACHITO_REQUEST_REF
+
         for key, value in additional_params.items():
-            assert body_json[key] == value
+            if value is not None:
+                assert body_json[key] == value
+            else:
+                assert key not in body_json
 
         return (201, {}, json.dumps(response_data))
 


### PR DESCRIPTION
Cachito handles empty lists passed to pkg_managers in a special manner.
We want to lose aotmic-reactor restrictions when passing parameters to
cachito, since an empty array may have a different meaning from a null
value.

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
