### PR TITLE
 Implement new 'add_image_content_manifest' pre-build plugin

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -111,6 +111,7 @@ PLUGIN_FETCH_SOURCES_KEY = 'fetch_sources'
 PLUGIN_KOJI_DELEGATE_KEY = 'koji_delegate'
 PLUGIN_PUSH_FLOATING_TAGS_KEY = 'push_floating_tags'
 PLUGIN_ADD_CONTENT_SETS = 'add_content_sets'
+PLUGIN_ADD_IMAGE_CONTENT_MANIFEST = 'add_image_content_manifest'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.

--- a/atomic_reactor/plugins/pre_add_image_content_manifest.py
+++ b/atomic_reactor/plugins/pre_add_image_content_manifest.py
@@ -1,0 +1,214 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+import json
+import os
+
+from copy import deepcopy
+
+from osbs.utils import Labels
+
+from atomic_reactor.constants import (IMAGE_BUILD_INFO_DIR, INSPECT_ROOTFS,
+                                      INSPECT_ROOTFS_LAYERS,
+                                      PLUGIN_ADD_IMAGE_CONTENT_MANIFEST,
+                                      REPO_CONTENT_SETS_CONFIG)
+from atomic_reactor.plugin import PreBuildPlugin
+from atomic_reactor.plugins.pre_reactor_config import get_cachito
+from atomic_reactor.util import (base_image_is_scratch, df_parser, read_yaml,
+                                 read_yaml_from_file_path, get_retrying_requests_session,
+                                 )
+
+
+class AddImageContentManifestPlugin(PreBuildPlugin):
+    """
+    Add the ICM JSON file to the IMAGE_BUILD_INFO_DIR/content_manifests
+    directory, for the current platform. Filename will be '{IMAGE_NVR}.json'
+
+    ICM examples:
+
+    WITHOUT content_sets specified:
+
+    {
+      "metadata": {
+        "icm_version": 1,
+        "icm_spec": "https://link.to.icm.specification",
+        "image_layer_index": 3
+      },
+      "content_sets" : [],
+      "image_contents": [
+        {
+          "purl": "pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.0.2",
+          "dependencies": [{"purl": "pkg:golang/github.com%2Fop%2Fgo-logging@v0.0.0"}],
+          "sources": [{"purl": "pkg:golang/github.com%2FMasterminds%2Fsemver@v1.4.2"}]
+        }
+      ]
+    }
+
+    WITH content_sets specified:
+
+    {
+      "metadata": {
+        "icm_version": 1,
+        "icm_spec": "https://link.to.icm.specification",
+        "image_layer_index": 2
+      },
+      "content_sets": [
+          "rhel-8-for-x86_64-baseos-rpms",
+          "rhel-8-for-x86_64-appstream-rpms"
+      ],
+      "image_contents": [
+        {
+          "purl": "pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.0.2",
+          "dependencies": [{"purl": "pkg:golang/github.com%2Fop%2Fgo-logging@v0.0.0"}],
+          "sources": [{"purl": "pkg:golang/github.com%2FMasterminds%2Fsemver@v1.4.2"}]
+        }
+      ]
+    }
+    """
+    key = PLUGIN_ADD_IMAGE_CONTENT_MANIFEST
+    is_allowed_to_fail = False
+    minimal_icm = {
+        'metadata': {
+            'icm_version': 1,
+            'icm_spec': ('https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/'
+                         'master/atomic_reactor/schemas/content_manifest.json'),
+            'image_layer_index': 1
+        },
+        'content_sets': [],
+        'image_contents': [],
+    }
+
+    def __init__(self, tasker, workflow, remote_source_icm_url=None, destdir=IMAGE_BUILD_INFO_DIR):
+        """
+        :param tasker: ContainerTasker instance
+        :param workflow: DockerBuildWorkflow instance
+        :param icm_url: str, URL of the ICM from the Cachito request.
+        :param destdir: image path to carry content_manifests data dir
+        """
+        super(AddImageContentManifestPlugin, self).__init__(tasker, workflow)
+        self.content_manifests_dir = os.path.join(destdir, 'content_manifests')
+        self.icm_url = remote_source_icm_url
+        self.dfp = df_parser(self.workflow.builder.df_path, workflow=self.workflow)
+        labels = Labels(self.dfp.labels)
+        _, image_name = labels.get_name_and_value(Labels.LABEL_TYPE_COMPONENT)
+        _, image_version = labels.get_name_and_value(Labels.LABEL_TYPE_VERSION)
+        _, image_release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)
+        self.icm_file_name = '{}-{}-{}.json'.format(image_name, image_version, image_release)
+        self.content_sets = []
+        self._cachito_verify = None
+        self._layer_index = None
+        self._icm = None
+
+    @property
+    def layer_index(self):
+        if self._layer_index is None:
+            # Default layer index is 1, because base and 'FROM scratch' images
+            #     *always* have 2 layers
+            self._layer_index = 1
+        if not base_image_is_scratch(self.dfp.baseimage):
+            inspect = self.workflow.builder.base_image_inspect
+            self._layer_index = len(inspect[INSPECT_ROOTFS][INSPECT_ROOTFS_LAYERS])
+        return self._layer_index
+
+    @property
+    def cachito_verify(self):
+        if self._cachito_verify is None:
+            try:
+                cachito_conf = get_cachito(self.workflow)
+            except KeyError:
+                cachito_conf = {}
+            # Get the value of Cachito's 'insecure' key from the active reactor config map,
+            #    *flip it*, and let the result tell us whether to verify or not
+            self._cachito_verify = not cachito_conf.get('insecure', False)
+        return self._cachito_verify
+
+    @property
+    def icm(self):
+        """
+        Get and validate the ICM from the Cachito API `content-manifest` endpoint.
+
+        :return: dict, the ICM as a Python dict
+        """
+        if self.icm_url is None and self._icm is None:
+            self._icm = deepcopy(self.minimal_icm)
+        if self._icm is None:
+            session = get_retrying_requests_session()
+            session.verify = self.cachito_verify
+            self.log.debug('Making request to "%s"', self.icm_url)
+            response = session.get(self.icm_url)
+            response.raise_for_status()
+            self._icm = response.json()  # Returns dict
+            self.log.debug('Cachito ICM request response:\n%s', self._icm)
+
+            # Validate; `json.dumps()` converts `icm` to str. Confusingly, `read_yaml`
+            #     *will* validate JSON
+            read_yaml(json.dumps(self._icm), 'schemas/content_manifest.json')
+        return self._icm
+
+    def _populate_content_sets(self):
+        """
+        Get the list of the current platform's content_sets from
+        'content_sets.yml' in dist-git, and set `self.content_sets` to same.
+        """
+        current_platform = self.workflow.user_params['platform']
+        workdir = self.workflow.builder.df_dir
+        fpath = os.path.join(workdir, REPO_CONTENT_SETS_CONFIG)
+        if os.path.exists(fpath):
+            content_sets_yml = read_yaml_from_file_path(fpath, 'schemas/content_sets.json') or {}
+            if current_platform in content_sets_yml:
+                self.content_sets = content_sets_yml[current_platform]
+        self.log.debug('Output content_sets: %s', self.content_sets)
+
+    def _update_icm_data(self):
+        # Inject the content_sets data into the ICM JSON object
+        self.icm['content_sets'] = self.content_sets
+
+        # Inject the current image layer index number into the ICM JSON object metadata
+        self.icm['metadata']['image_layer_index'] = self.layer_index
+
+        # Convert dict -> str
+        icm_json = json.dumps(self.icm, indent=4)
+
+        # Validate the updated ICM with the ICM JSON Schema
+        read_yaml(icm_json, 'schemas/content_manifest.json')
+
+        self.log.debug('Output ICM: %s', icm_json)
+
+    def _write_json_file(self):
+        out_file_path = os.path.join(self.workflow.builder.df_dir,
+                                     self.icm_file_name)
+        if os.path.exists(out_file_path):
+            raise RuntimeError('File {} already exists in repo'.format(out_file_path))
+        with open(out_file_path, 'w') as outfile:
+            json.dump(self.icm, outfile, indent=4)
+        self.log.debug('ICM JSON saved to: %s', out_file_path)
+
+    def _add_to_dockerfile(self):
+        """
+        Put an ADD instruction into the Dockerfile (to include the ICM file
+        into the container image to be built)
+        """
+        dest_file_path = os.path.join(self.content_manifests_dir, self.icm_file_name)
+        content = 'ADD {0} {1}'.format(self.icm_file_name, dest_file_path)
+        lines = self.dfp.lines
+
+        # Put it before last instruction
+        lines.insert(-1, content + '\n')
+        self.dfp.lines = lines
+
+    def run(self):
+        """
+        run the plugin
+        """
+        self._populate_content_sets()
+        self._update_icm_data()
+        self._write_json_file()
+        self._add_to_dockerfile()
+        self.log.info('added "%s" to "%s"', self.icm_file_name, self.content_manifests_dir)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -183,6 +183,10 @@ containing the Dockerfile.
   - Status: Enabled
   - creates metadata_{current_layer_index}.json with content sets, and ADDs
     it to the built image
+- **add_image_content_manifest**
+  - Status: Enabled
+  - creates metadata_{current_layer_index}.json with Cachito ICM, content_sets,
+    and other metadata, and ADDs it to the built image
 - **add_dockerfile**
   - Status: Enabled
   - The Dockerfile used to build the image has a line added to ADD itself into

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -1,0 +1,300 @@
+"""
+Copyright (c) 2020 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+import os
+import sys
+
+from copy import deepcopy
+from textwrap import dedent
+
+import pytest
+import yaml
+
+from tests.mock_env import MockEnv
+from tests.utils.test_cachito import CACHITO_URL, CACHITO_REQUEST_ID
+
+from atomic_reactor import util
+from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
+from atomic_reactor.plugin import PluginFailedException
+from atomic_reactor.plugins.pre_add_image_content_manifest import AddImageContentManifestPlugin
+
+CONTENT_SETS = {
+    'x86_64': ['pulp-spamx86-rpms', 'pulp-baconx86-rpms'],
+    'ppc64': ['pulp-spamppc64-rpms', 'pulp-baconppc64-rpms'],
+    's390x': ['pulp-spams390x-rpms', 'pulp-bacons390x-rpms'],
+}
+CACHITO_ICM_URL = '{}/api/v1/requests/{}/content-manifest'.format(CACHITO_URL,
+                                                                  CACHITO_REQUEST_ID)
+ICM_MINIMAL_DICT = {
+    'metadata': {
+        'icm_version': 1,
+        'icm_spec': ('https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/'
+                     'master/atomic_reactor/schemas/content_manifest.json'),
+        'image_layer_index': 1
+    },
+    'content_sets': [],
+    'image_contents': [],
+}
+ICM_DICT = {
+    'metadata': {
+        'icm_version': 1,
+        'icm_spec': 'https://link.to.icm.specification',
+        'image_layer_index': 1,
+    },
+    'content_sets': [],
+    'image_contents': [
+        {
+            'purl':
+            'pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.0.2',
+            'dependencies': [
+                {
+                    'purl':
+                    'pkg:golang/github.com%2Fop%2Fgo-logging@v0.0.0'
+                },
+            ],
+            'sources': [
+                {
+                    'purl':
+                    'pkg:golang/github.com%2FMasterminds%2Fsemver@v1.4.2'
+                },
+            ]
+        },
+    ]
+}
+ICM_JSON = dedent(
+    '''\
+    {
+        "metadata": {
+        "icm_version": 1,
+        "icm_spec": "https://link.to.icm.specification",
+        "image_layer_index": 1
+        },
+        "content_sets": [],
+        "image_contents": [
+        {
+            "purl": "pkg:golang/github.com%2Frelease-engineering%2Fretrodep%2Fv2@v2.0.2",
+            "dependencies": [
+            {
+                "purl": "pkg:golang/github.com%2Fop%2Fgo-logging@v0.0.0"
+            }
+            ],
+            "sources": [
+            {
+                "purl": "pkg:golang/github.com%2FMasterminds%2Fsemver@v1.4.2"
+            }
+            ]
+        }
+        ]
+    }
+    '''
+)
+
+
+def setup_function(*args):
+    # IMPORTANT: This needs to be done to ensure mocks at the module
+    # level are reset between test cases.
+    sys.modules.pop('pre_add_image_content_manifest', None)
+
+
+def teardown_function(*args):
+    # IMPORTANT: This needs to be done to ensure mocks at the module
+    # level are reset between test cases.
+    sys.modules.pop('pre_add_image_content_manifest', None)
+
+
+def mock_content_sets_config(tmpdir, empty=False):
+    content_dict = {}
+    if not empty:
+        for arch, repos in CONTENT_SETS.items():
+            content_dict[arch] = repos
+    tmpdir.join('content_sets.yml').write(yaml.safe_dump(content_dict))
+
+
+def mock_get_icm(requests_mock):
+    requests_mock.register_uri('GET', CACHITO_ICM_URL, text=ICM_JSON)
+
+
+def mock_env(tmpdir, docker_tasker, platform='x86_64', base_layers=0,
+             icm_url=CACHITO_ICM_URL, r_c_m_override=None,
+             ):
+    inspection_data = {
+        INSPECT_ROOTFS: {
+            INSPECT_ROOTFS_LAYERS: list(range(base_layers))
+        }
+    }
+    if r_c_m_override is None:
+        r_c_m = {
+            'version': 1,
+            'cachito': {
+                'api_url': CACHITO_URL,
+                'auth': {
+                    'ssl_certs_dir': str(tmpdir),
+                },
+            },
+        }
+    else:
+        r_c_m = r_c_m_override
+    env = (MockEnv()
+           .for_plugin('prebuild', AddImageContentManifestPlugin.key,
+                       {'remote_source_icm_url': icm_url})
+           .set_reactor_config(r_c_m)
+           .make_orchestrator()
+           )
+    tmpdir.join('cert').write('')
+    env.workflow.builder.set_inspection_data(inspection_data)
+    env.workflow.user_params['platform'] = platform
+
+    return env.create_runner(docker_tasker)
+
+
+@pytest.mark.parametrize('manifest_file_exists', [True, False])
+@pytest.mark.parametrize('content_sets', [True, False])
+@pytest.mark.parametrize('platform', ['x86_64', 'ppc64', 's390x'])
+@pytest.mark.parametrize(
+    ('df_content, expected_df, base_layers, manifest_file'), [
+        (
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            ADD eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            2,
+            'eggs-1.0-42.json',
+        ),
+        (
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            ADD eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            3,
+            'eggs-1.0-42.json',
+        ),
+        (
+            dedent("""\
+            FROM scratch
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            dedent("""\
+            FROM scratch
+            CMD build /spam/eggs
+            ADD eggs-1.0-42.json /root/buildinfo/content_manifests/eggs-1.0-42.json
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            0,
+            'eggs-1.0-42.json',
+        ),
+    ])
+def test_add_image_content_manifest(requests_mock, tmpdir, docker_tasker, caplog,
+                                    manifest_file_exists, content_sets, platform,
+                                    df_content, expected_df, base_layers, manifest_file,
+                                    ):
+    mock_get_icm(requests_mock)
+    mock_content_sets_config(tmpdir, empty=(not content_sets))
+    dfp = util.df_parser(str(tmpdir))
+    dfp.content = df_content
+    if manifest_file_exists:
+        tmpdir.join(manifest_file).write("")
+    runner = mock_env(tmpdir, docker_tasker, platform, base_layers)
+    runner.workflow.builder.set_df_path(dfp.dockerfile_path)
+    if manifest_file_exists:
+        with pytest.raises(PluginFailedException):
+            runner.run()
+        log_msg = 'File {} already exists in repo'.format(os.path.join(str(tmpdir), manifest_file))
+        assert log_msg in caplog.text
+        return
+    expected_output = deepcopy(ICM_DICT)
+    if content_sets:
+        expected_output['content_sets'] = CONTENT_SETS[platform]
+    expected_output['metadata']['image_layer_index'] = base_layers if base_layers else 1
+    runner.run()
+    assert dfp.content == expected_df
+    output_file = os.path.join(str(tmpdir), manifest_file)
+    with open(output_file) as f:
+        json_data = f.read()
+    output = json.loads(json_data)
+    assert expected_output == output
+
+
+@pytest.mark.parametrize('content_sets', [True, False])
+@pytest.mark.parametrize(
+    ('df_content, base_layers, manifest_file'), [
+        (
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            2,
+            'eggs-1.0-42.json',
+        )])
+def test_none_remote_source_icm_url(requests_mock, tmpdir, docker_tasker, caplog,
+                                    content_sets,
+                                    df_content, base_layers, manifest_file,
+                                    ):
+    platform = 'x86_64'
+    mock_get_icm(requests_mock)
+    mock_content_sets_config(tmpdir, empty=(not content_sets))
+    dfp = util.df_parser(str(tmpdir))
+    dfp.content = df_content
+    runner = mock_env(tmpdir, docker_tasker, platform, base_layers, icm_url=None)
+    runner.workflow.builder.set_df_path(dfp.dockerfile_path)
+    expected_output = deepcopy(ICM_MINIMAL_DICT)
+    if content_sets:
+        expected_output['content_sets'] = CONTENT_SETS[platform]
+    expected_output['metadata']['image_layer_index'] = base_layers
+    runner.run()
+    output_file = os.path.join(str(tmpdir), manifest_file)
+    with open(output_file) as f:
+        json_data = f.read()
+    output = json.loads(json_data)
+    assert expected_output == output
+
+
+def test_missing_cachito_conf(requests_mock, tmpdir, docker_tasker, caplog,):
+    df_content = dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """)
+
+    # No 'cachito' conf in the reactor-config
+    r_c_m = {
+        'version': 1,
+    }
+    base_layers = 0
+    manifest_file = 'eggs-1.0-42.json'
+    mock_get_icm(requests_mock)
+    dfp = util.df_parser(str(tmpdir))
+    dfp.content = df_content
+    runner = mock_env(tmpdir, docker_tasker, r_c_m_override=r_c_m)
+    runner.workflow.builder.set_df_path(dfp.dockerfile_path)
+    expected_output = deepcopy(ICM_DICT)
+    expected_output['metadata']['image_layer_index'] = base_layers
+    runner.run()
+    output_file = os.path.join(str(tmpdir), manifest_file)
+    with open(output_file) as f:
+        json_data = f.read()
+    output = json.loads(json_data)
+    assert expected_output == output


### PR DESCRIPTION
- Loosely based on, and deprecates, `add_content_sets` pre-build
  plugin
- Receives 'remote_source_icm_url' from the 'resolve_remote_source'
  pre-build plugin
- Downloads the ICM using above
- Injects current layer number, and existing 'content_sets' metadata
  from dist git, into the ICM
- Validates the updated ICM
- Writes the ICM into the same directory as the Dockerfile
- Adds a COPY line to the Dockerfile, to put the ICM into the
  resulting container.

* CLOUDBLD-1133

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
