### PR TITLE
Forward the "remote_source.packages" value to the Cachito request

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -56,7 +56,7 @@ class CachitoAPI(object):
         return session
 
     def request_sources(self, repo, ref, flags=None, pkg_managers=None, user=None,
-                        dependency_replacements=None):
+                        dependency_replacements=None, packages=None):
         """Start a new Cachito request
 
         :param repo: str, the URL to the SCM repository
@@ -67,6 +67,8 @@ class CachitoAPI(object):
         :param user: str, user the request is created on behalf of. This is reserved for privileged
                      users that can act as cachito representatives
         :param dependency_replacements: list<dict>, dependencies to be replaced by cachito
+        :param packages: dict, the packages configuration that allows to specify things such
+                         as subdirectories where packages reside in the source repository
 
         :return: dict, representation of the created Cachito request
         :raise CachitoAPIInvalidRequest: if Cachito determines the request is invalid
@@ -78,6 +80,7 @@ class CachitoAPI(object):
             'pkg_managers': pkg_managers,
             'user': user,
             'dependency_replacements': dependency_replacements,
+            'packages': packages,
         }
         # Remove None values
         payload = {k: v for k, v in payload.items() if v is not None}

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -284,6 +284,22 @@ class TestSourceConfigSchemaValidation(object):
                 'pkg_managers': ['gomod'],
             }}
         ), (
+            """\
+            remote_source:
+              repo: https://git.example.com/team/repo.git
+              ref: b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a
+              packages:
+                npm:
+                  - path: client
+                  - path: proxy
+            """,
+            {'remote_source': {
+                'repo': 'https://git.example.com/team/repo.git',
+                'ref': 'b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a',
+                'packages': {'npm': [{'path': 'client'},
+                                     {'path': 'proxy'}]},
+            }}
+        ), (
           """\
           operator_manifests:
             manifests_dir: path/to/manifests

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -44,6 +44,8 @@ CACHITO_REQUEST_REPO = 'https://github.com/release-engineering/retrodep.git'
         'version': '1.1.1',
         }]
      },
+    {'packages': {'npm': [{'path': 'client'}]}},
+    {'packages': None},
 ))
 def test_request_sources(additional_params, caplog):
     response_data = {'id': CACHITO_REQUEST_ID}


### PR DESCRIPTION
This is to support forwarding new parameters to Cachito to support multiple packages in a single source repository.

Relates to CLOUDBLD-1598 and https://github.com/containerbuildsystem/osbs-docs/pull/162

Signed-off-by: mprahl <mprahl@users.noreply.github.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
