### PR TITLE
Remove unused self.host_repos_path from plugin InjectYumRepoPlugin

### DIFF
--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -55,17 +55,6 @@ class InjectYumRepoPlugin(PreBuildPlugin):
     key = "inject_yum_repo"
     is_allowed_to_fail = False
 
-    def __init__(self, tasker, workflow):
-        """
-        constructor
-
-        :param tasker: ContainerTasker instance
-        :param workflow: DockerBuildWorkflow instance
-        """
-        # call parent constructor
-        super(InjectYumRepoPlugin, self).__init__(tasker, workflow)
-        self.host_repos_path = os.path.join(self.workflow.builder.df_dir, RELATIVE_REPOS_PATH)
-
     def run(self):
         """
         run the plugin


### PR DESCRIPTION
After this removal, no need to keep __init__ there. So, removed as well.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
