### PR TITLE
Fix ODCS API call for modular koji tags

### DIFF
--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -100,7 +100,7 @@ class ODCSClient(object):
             body['multilib_method'] = multilib_method or MULTILIB_METHOD_DEFAULT
 
         if modular_koji_tags:
-            body['modular_koji_tags'] = modular_koji_tags
+            body['source']['modular_koji_tags'] = modular_koji_tags
 
         logger.info("Starting compose: %s", body)
         response = self.session.post('{}composes/'.format(self.url),

--- a/tests/utils/test_odcs.py
+++ b/tests/utils/test_odcs.py
@@ -127,10 +127,10 @@ def test_create_compose(odcs_client, source, source_type, packages, expected_pac
         assert body_json['source']['source'] == source
         assert body_json['source'].get('packages') == expected_packages
         assert body_json['source'].get('sigkeys') == sigkeys
+        assert body_json['source'].get('modular_koji_tags') == expected_koji_tags
         assert body_json.get('flags') == flags
         assert body_json.get('arches') == arches
         assert body_json.get('multilib_arches') == multilib_arches
-        assert body_json.get('modular_koji_tags') == expected_koji_tags
         if expected_method is not None:
             assert sorted(body_json.get('multilib_method')) == sorted(expected_method)
         else:


### PR DESCRIPTION
ODCS API param for modular koji tags is expected in the source object,
as per the API post method [1] and its documentation.

[1] https://pagure.io/odcs/blob/5bbe27a76518937beef76b30a33450f18c544028/f/server/odcs/server/views.py#_418

* CLOUDBLD-1241

Signed-off-by: Athos Ribeiro <athos@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
