### PR TITLE
Get the Image Content Manifest URL from Cachito request...

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -94,7 +94,9 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
         remote_source_json = self.source_request_to_json(source_request)
         remote_source_url = self.cachito_session.assemble_download_url(source_request)
         remote_source_conf_url = remote_source_json.get('configuration_files')
-        self.set_worker_params(source_request, remote_source_url, remote_source_conf_url)
+        remote_source_icm_url = remote_source_json.get('content_manifest')
+        self.set_worker_params(source_request, remote_source_url, remote_source_conf_url,
+                               remote_source_icm_url)
 
         dest_dir = self.workflow.source.workdir
         dest_path = self.cachito_session.download_sources(source_request, dest_dir=dest_dir)
@@ -108,7 +110,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
             'remote_source_path': dest_path,
         }
 
-    def set_worker_params(self, source_request, remote_source_url, remote_source_conf_url):
+    def set_worker_params(self, source_request, remote_source_url, remote_source_conf_url,
+                          remote_source_icm_url):
         build_args = {}
         # This matches values such as 'deps/gomod' but not 'true'
         rel_path_regex = re.compile(r'^[^/]+/[^/]+(?:/[^/]+)*$')
@@ -129,12 +132,13 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
         override_build_kwarg(self.workflow, 'remote_source_url', remote_source_url)
         override_build_kwarg(self.workflow, 'remote_source_build_args', build_args)
         override_build_kwarg(self.workflow, 'remote_source_configs', remote_source_conf_url)
+        override_build_kwarg(self.workflow, 'remote_source_icm_url', remote_source_icm_url)
 
     def source_request_to_json(self, source_request):
         """Create a relevant representation of the source request"""
         required = ('ref', 'repo')
         optional = ('dependencies', 'flags', 'packages', 'pkg_managers', 'environment_variables',
-                    'configuration_files')
+                    'configuration_files', 'content_manifest')
 
         data = {}
         try:


### PR DESCRIPTION
...and update the build kwargs with it.

- 'pre_resolve_remote_source.py' adds the ICM URL as a param for
  `set_worker_params()` (which then updates the build kwargs)

* CLOUDBLD-1132

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
