### PR TITLE
fail early in check_and_set_platforms when platforms in limits are empty

### DIFF
--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -87,4 +87,9 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
         final_platforms = get_platforms_in_limits(self.workflow, enabled_platforms)
 
         self.log.info("platforms in limits : %s", final_platforms)
+
+        if not final_platforms:
+            self.log.error("platforms in limits are empty")
+            raise RuntimeError("No platforms to build for")
+
         return final_platforms


### PR DESCRIPTION
* CLOUDBLD-1794

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
