### PR TITLE
fail early multistage build when build method is docker_api

### DIFF
--- a/tests/mock_env.py
+++ b/tests/mock_env.py
@@ -82,6 +82,7 @@ class MockEnv(object):
             raise ValueError('No plugin configured (use for_plugin() to configure one)')
         runner_cls = self._runner_for_phase[self._phase]
         plugins_conf = getattr(self.workflow, self._plugins_for_phase[self._phase])
+        self.workflow.builder.tasker = docker_tasker
         return runner_cls(docker_tasker, self.workflow, plugins_conf)
 
     def for_plugin(self, phase, plugin_key, args=None):


### PR DESCRIPTION
* CLOUDBLD-638

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
