### PR TITLE
No need to call raise_for_status in get_config_and_id_from_registry

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -945,13 +945,11 @@ class RegistryClient(object):
         """
         response = query_registry(
             self._session, image, digest=digest, version=version)
-        response.raise_for_status()
         manifest_config = response.json()
         config_digest = manifest_config['config']['digest']
 
         config_response = query_registry(
             self._session, image, digest=config_digest, version=version, is_blob=True)
-        config_response.raise_for_status()
 
         blob_config = config_response.json()
 


### PR DESCRIPTION
query_registry already calls requests.Response.raise_for_status. So, no
need to call it again in get_config_and_id_from_registry.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
