### PR TITLE
Fix coveralls and refactor test_sh.yaml (separation of concerns)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,0 @@
-[run]
-omit = /tmp/*
-relative_files = True

--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -1,4 +1,4 @@
-name: Run bandit using test.sh
+name: Bandit via test.sh
 
 on: [pull_request]
 

--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -1,0 +1,32 @@
+name: Run bandit using test.sh
+
+on: [pull_request]
+
+jobs:
+  bandit:
+    name: Bandit analyzer for Python ${{ matrix.os.python }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os:
+          - name: centos
+            version: 7
+            python: 2
+            engine: docker
+
+          - name: fedora
+            version: 31
+            python: 3
+            engine: docker
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - run: ./test.sh
+        env:
+          OS: ${{ matrix.os.name }}
+          OS_VERSION: ${{ matrix.os.version }}
+          PYTHON_VERSION: ${{ matrix.os.python }}
+          ENGINE: ${{ matrix.os.engine }}
+          ACTION: bandit

--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,4 +1,4 @@
-name: Lint with flake8
+name: Flake8 linting
 
 on: [pull_request]
 

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,4 +1,4 @@
-name: markdownlint
+name: Markdownlint
 
 on: [pull_request]
 

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,4 +1,4 @@
-name: Run pylint using test.sh
+name: Pylint via test.sh
 
 on: [pull_request]
 

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,0 +1,32 @@
+name: Run pylint using test.sh
+
+on: [pull_request]
+
+jobs:
+  pylint:
+    name: Pylint analyzer for Python ${{ matrix.os.python }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os:
+          - name: fedora
+            version: 29
+            python: 2
+            engine: docker
+
+          - name: fedora
+            version: 31
+            python: 3
+            engine: docker
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: ./test.sh
+        env:
+          OS: ${{ matrix.os.name }}
+          OS_VERSION: ${{ matrix.os.version }}
+          PYTHON_VERSION: ${{ matrix.os.python }}
+          ENGINE: ${{ matrix.os.engine }}
+          ACTION: pylint

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -56,63 +56,9 @@ jobs:
     steps:
     - name: Finished
       run: |
+        pip3 install --upgrade pip
+        pip3 install --upgrade setuptools
         pip3 install --upgrade coveralls
         /home/runner/.local/bin/coveralls --finish
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  pylint:
-    name: Pylint analyzer for Python ${{ matrix.os.python }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        os:
-          - name: fedora
-            version: 29
-            python: 2
-            engine: docker
-
-          - name: fedora
-            version: 31
-            python: 3
-            engine: docker
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - run: ./test.sh
-        env:
-          OS: ${{ matrix.os.name }}
-          OS_VERSION: ${{ matrix.os.version }}
-          PYTHON_VERSION: ${{ matrix.os.python }}
-          ENGINE: ${{ matrix.os.engine }}
-          ACTION: pylint
-
-  bandit:
-    name: Bandit analyzer for Python ${{ matrix.os.python }}
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        os:
-          - name: centos
-            version: 7
-            python: 2
-            engine: docker
-
-          - name: fedora
-            version: 31
-            python: 3
-            engine: docker
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - run: ./test.sh
-        env:
-          OS: ${{ matrix.os.name }}
-          OS_VERSION: ${{ matrix.os.version }}
-          PYTHON_VERSION: ${{ matrix.os.python }}
-          ENGINE: ${{ matrix.os.engine }}
-          ACTION: bandit

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -1,4 +1,4 @@
-name: Run tests using test.sh
+name: Pytests via test.sh
 
 on: [pull_request]
 
@@ -30,7 +30,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v2
 
-      - name: test.sh
+      - name: pytests via test.sh
         env:
           OS: ${{ matrix.os.name }}
           OS_VERSION: ${{ matrix.os.version }}
@@ -38,19 +38,28 @@ jobs:
           ENGINE: ${{ matrix.os.engine }}
         run: ./test.sh
 
-      - name: Coveralls Python parallel
-        uses: AndreMiras/coveralls-python-action@master
-        with:
-          parallel: true
+      - name: Run coveralls-python
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: ${{ matrix.os.name }}-${{ matrix.os.version }}-python${{ matrix.os.python }}
+          COVERALLS_PARALLEL: true
+        run: |
+          pip3 install --upgrade pip
+          pip3 install --upgrade setuptools
+          pip3 install --upgrade coveralls
+          /home/runner/.local/bin/coveralls
 
-  coveralls_finish:
+  coveralls-finish:
+    name: Finish coveralls-python
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - name: Coveralls Python finish
-        uses: AndreMiras/coveralls-python-action@master
-        with:
-          parallel-finished: true
+    - name: Finished
+      run: |
+        pip3 install --upgrade coveralls
+        /home/runner/.local/bin/coveralls --finish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   pylint:
     name: Pylint analyzer for Python ${{ matrix.os.python }}


### PR DESCRIPTION
- Coveralls.io reporting works again
- pylint and bandit are able to truly run in parallel with everything else
    - pylint and bandit can be re-triggered separately from the pytests (and vice-versa)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
