### PR TITLE
Trap exception when contructing OperatorCSV, if YAML isn't an object

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -308,8 +308,11 @@ class OperatorCSV(object):
             implementation will be used. For more information, see the
             default_pullspec_heuristic() function in this module.
         """
-        if data.get("kind") != OPERATOR_CSV_KIND:
-            raise NotOperatorCSV("Not a ClusterServiceVersion")
+        try:
+            if data.get("kind") != OPERATOR_CSV_KIND:
+                raise NotOperatorCSV("Not a ClusterServiceVersion")
+        except AttributeError:
+            raise NotOperatorCSV("File does not contain a YAML object")
         self.path = path
         self.data = data
         self._pullspec_heuristic = pullspec_heuristic


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

* CLOUDBLD-1971

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
