### PR TITLE
Better pytest output

### DIFF
--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -45,6 +45,13 @@ jobs:
           ENGINE: ${{ matrix.os.engine }}
         run: ./test.sh
 
+      - name: Upload pytest html report
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          path: __pytest_reports/atomic-reactor-unit-tests.html
+          name: atomic-reactor-unit-tests_${{ matrix.os.name }}_${{ matrix.os.version }}.python${{ matrix.os.python }}.html
+
       - name: Run coveralls-python
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-addopts = -ra --color=auto
+addopts = -ra --color=auto --html=__pytest_reports/atomic-reactor-unit-tests.html --self-contained-html
+render_collapsed = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -ra --color=auto

--- a/test.sh
+++ b/test.sh
@@ -138,7 +138,7 @@ function setup_osbs() {
 case ${ACTION} in
 "test")
   setup_osbs
-  TEST_CMD="coverage run --source=atomic_reactor -m pytest --color=yes tests"
+  TEST_CMD="coverage run --source=atomic_reactor -m pytest tests"
   ;;
 "pylint")
   setup_osbs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,3 +71,9 @@ def inspect_only(request):
 @pytest.fixture
 def workflow():
     return DockerBuildWorkflow('test-image', source=MOCK_SOURCE)
+
+
+@pytest.mark.optionalhook
+def pytest_html_results_table_row(report, cells):
+    if report.passed or report.skipped:
+        del cells[:]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,8 +2,9 @@ flexmock>=0.10.3
 ordereddict
 responses>=0.9.0,<0.10.8
 pypng
-pytest>=4.1.0
+pytest>=4.1.0,<5
 pytest-cov
+pytest-html
 flake8
 koji
 requests-mock


### PR DESCRIPTION
- HTML output for failed tests only, uploaded as GitHub artifacts
- Make final pytest console output a summary of non-passing tests
- Pytest color output set to "auto"
- Parameterize pytest using pytest.ini (easier to tweak locally if so desired)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
