### PR TITLE
Update CI to Fedora 32 and drop F30

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -23,7 +23,7 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -23,7 +23,7 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 

--- a/.github/workflows/test_sh.yaml
+++ b/.github/workflows/test_sh.yaml
@@ -24,12 +24,12 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 30
+            version: 31
             python: 3
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 


### PR DESCRIPTION
Keep F29 for Py2 Pylint for now.

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

* CLOUDBLD-1521

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
