### PR TITLE
test_flatpak_create_oci.py: Use flatpak_metadata=both for most tests

### DIFF
--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -470,13 +470,13 @@ def write_docker_file(config, tmpdir):
 @pytest.mark.skipif(not MODULEMD_AVAILABLE,  # noqa - docker_tasker fixture
                     reason="libmodulemd not available")
 @pytest.mark.parametrize('config_name, flatpak_metadata, breakage', [
-    ('app', 'annotations', None),
-    ('app', 'annotations', 'copy_error'),
-    ('app', 'annotations', 'no_runtime'),
-    ('app', 'labels', None),
     ('app', 'both', None),
-    ('runtime', 'annotations', None),
-    ('sdk', 'annotations', None),
+    ('app', 'both', 'copy_error'),
+    ('app', 'both', 'no_runtime'),
+    ('app', 'annotations', None),
+    ('app', 'labels', None),
+    ('runtime', 'both', None),
+    ('sdk', 'both', None),
 ])
 def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, flatpak_metadata, breakage):
     # Check that we actually have flatpak available
@@ -660,9 +660,10 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, config_name, flatpak_metadata
 
         # Check that the expected files ended up in the flatpak
 
-        # Flatpak versions before 1.6 require annotations to be present, since we don't
-        # require such a new Flatpak, skip remaining checks in the label-only case
-        if flatpak_metadata == 'labels':
+        # Flatpak versions before 1.6 require annotations to be present, and Flatpak
+        # versions 1.6 and later require labels to be present. Skip the remaining
+        # checks unless we have both annotations and labels.
+        if flatpak_metadata != 'both':
             return
 
         inspector = DefaultInspector(tmpdir, dir_metadata)


### PR DESCRIPTION
Importing a Flatpak created with flatpak_metadata=annotations is only supported
for Flatpak < 1.6, and importing a Flatpak created with flatpak_metdata=labels
is only supported for for Flatpak >= 1.6, so run most tests with
flatpak_metadata=both, and only run basic tests with just labels/annotations.

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

* CLOUDBLD-1519

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
