### PR TITLE
pre_koji_parent: log incorrect build state

### DIFF
--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -307,12 +307,13 @@ class KojiParentPlugin(PreBuildPlugin):
         while time.time() - poll_start < self.poll_timeout:
             build = self.koji_session.getBuild(nvr)
             if build:
+                build_state = koji.BUILD_STATES[build['state']]
                 self.log.info('Parent image Koji build found with id %s', build.get('id'))
-                if build['state'] == koji.BUILD_STATES['COMPLETE']:
+                if build_state == 'COMPLETE':
                     return build
-                elif build['state'] != koji.BUILD_STATES['BUILDING']:
-                    exc_msg = ('Parent image Koji build for {} with id {} state is not COMPLETE.')
-                    raise KojiParentBuildMissing(exc_msg.format(nvr, build.get('id')))
+                elif build_state != 'BUILDING':
+                    exc_msg = ('Parent image Koji build {} state is {}, not COMPLETE.')
+                    raise KojiParentBuildMissing(exc_msg.format(nvr, build_state))
             time.sleep(self.poll_interval)
         raise KojiParentBuildMissing('Parent image Koji build NOT found for {}!'.format(nvr))
 

--- a/tests/plugins/test_koji_parent.py
+++ b/tests/plugins/test_koji_parent.py
@@ -176,7 +176,7 @@ class TestKojiParent(object):
         with pytest.raises(PluginFailedException) as exc_info:
             self.run_plugin_with_args(workflow)
         assert 'KojiParentBuildMissing' in str(exc_info.value)
-        assert 'state is not COMPLETE' in str(exc_info.value)
+        assert 'state is DELETED, not COMPLETE' in str(exc_info.value)
 
     def test_base_image_not_inspected(self, workflow, koji_session):  # noqa
         del workflow.builder.base_image_inspect[INSPECT_CONFIG]


### PR DESCRIPTION
When the koji parent build is not `COMPLETE`, log the build's incorrect state. This helps the user understand the problem without looking up the parent build manually.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file