### PR TITLE
Defaults to Python 3 in Fedora test container

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -5,10 +5,14 @@ set -eux
 ENGINE=${ENGINE:="podman"}
 OS=${OS:="centos"}
 OS_VERSION=${OS_VERSION:="7"}
-PYTHON_VERSION=${PYTHON_VERSION:="2"}
-ACTION=${ACTION:="test"}
 IMAGE="$OS:$OS_VERSION"
+if [[ "$OS" == "fedora" ]]; then
+    PYTHON_VERSION=3
+else
+    PYTHON_VERSION=2
+fi
 CONTAINER_NAME="atomic-reactor-$OS-$OS_VERSION-py$PYTHON_VERSION"
+ACTION=${ACTION:="test"}
 
 # Use arrays to prevent globbing and word splitting
 engine_mounts=(-v "$PWD":"$PWD":z)


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
