### PR TITLE
Don't log cachito request response, which is polluting build logs

### DIFF
--- a/atomic_reactor/plugins/pre_add_image_content_manifest.py
+++ b/atomic_reactor/plugins/pre_add_image_content_manifest.py
@@ -145,7 +145,6 @@ class AddImageContentManifestPlugin(PreBuildPlugin):
             response = session.get(self.icm_url)
             response.raise_for_status()
             self._icm = response.json()  # Returns dict
-            self.log.debug('Cachito ICM request response:\n%s', self._icm)
 
             # Validate; `json.dumps()` converts `icm` to str. Confusingly, `read_yaml`
             #     *will* validate JSON
@@ -179,7 +178,8 @@ class AddImageContentManifestPlugin(PreBuildPlugin):
         # Validate the updated ICM with the ICM JSON Schema
         read_yaml(icm_json, 'schemas/content_manifest.json')
 
-        self.log.debug('Output ICM: %s', icm_json)
+        self.log.debug('Output ICM content_sets: %s', self.icm['content_sets'])
+        self.log.debug('Output ICM metadata: %s', self.icm['metadata'])
 
     def _write_json_file(self):
         out_file_path = os.path.join(self.workflow.builder.df_dir,

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -142,8 +142,8 @@ class CachitoAPI(object):
             if state == 'complete':
                 logger.debug(dedent("""\
                     Request %s is complete
-                    Details: %s
-                    """), request_id, json.dumps(response_json, indent=4))
+                    Request url: %s
+                    """), request_id, url)
                 return response_json
 
             # All other states are expected to be transient and are not checked.

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -127,9 +127,10 @@ def test_wait_for_request(burst_params, cachito_request, caplog):
         state = states.pop(0)
         return (200, {}, json.dumps({'id': CACHITO_REQUEST_ID, 'state': state, 'updated': updated}))
 
+    request_url = '{}/api/v1/requests/{}'.format(CACHITO_URL, CACHITO_REQUEST_ID)
     responses.add_callback(
         responses.GET,
-        '{}/api/v1/requests/{}'.format(CACHITO_URL, CACHITO_REQUEST_ID),
+        request_url,
         content_type='application/json',
         callback=handle_wait_for_request)
 
@@ -138,16 +139,12 @@ def test_wait_for_request(burst_params, cachito_request, caplog):
     assert response['state'] == expected_final_state
     assert len(responses.calls) == expected_total_responses_calls
 
-    finished_response_json = json.dumps(
-        {'id': CACHITO_REQUEST_ID, 'state': expected_final_state, 'updated': updated},
-        indent=4
-    )
     expect_in_logs = dedent(
         """\
         Request {} is complete
-        Details: {}
+        Request url: {}
         """
-    ).format(CACHITO_REQUEST_ID, finished_response_json)
+    ).format(CACHITO_REQUEST_ID, request_url)
     # Since Python 3.7 logger adds additional whitespaces by default -> checking without them
     assert re.sub(r'\s+', " ", expect_in_logs) in re.sub(r'\s+', r" ", caplog.text)
 


### PR DESCRIPTION
* CLOUDBLD-2261

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
