### PR TITLE
Fail build when multiple CSV files exist in operator bundle

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -150,6 +150,12 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
 
         if operator_manifest.files:
             path_lines = "\n".join(f.path for f in operator_manifest.files)
+
+            if len(operator_manifest.files) > 1:
+                msg = "Operator bundle may contain only 1 CSV file, but contains more: {}".\
+                    format(path_lines)
+                raise RuntimeError(msg)
+
             self.log.info("Found operator CSV files:\n%s", path_lines)
         else:
             self.log.info("No operator CSV files found")

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -319,6 +319,8 @@ class TestPinOperatorDigest(object):
 
     @pytest.mark.parametrize('filepaths', [
         [],
+        ['csv1.yaml'],
+        ['csv2.yaml'],
         ['csv1.yaml', 'csv2.yaml']
     ])
     def test_orchestrator_no_pullspecs(self, filepaths, docker_tasker, tmpdir, caplog):
@@ -329,6 +331,14 @@ class TestPinOperatorDigest(object):
 
         runner = mock_env(docker_tasker, tmpdir, orchestrator=True,
                           user_config=user_config, site_config=site_config)
+
+        if len(filepaths) > 1:
+            with pytest.raises(PluginFailedException) as exc_info:
+                runner.run()
+            msg = "Operator bundle may contain only 1 CSV file, but contains more:"
+            assert msg in str(exc_info.value)
+            return
+
         runner.run()
 
         caplog_text = "\n".join(rec.message for rec in caplog.records)


### PR DESCRIPTION
* CLOUDBLD-2239

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
