### PR TITLE
make packages required parameter

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -136,8 +136,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
 
     def source_request_to_json(self, source_request):
         """Create a relevant representation of the source request"""
-        required = ('ref', 'repo')
-        optional = ('dependencies', 'flags', 'packages', 'pkg_managers', 'environment_variables',
+        required = ('packages', 'ref', 'repo')
+        optional = ('dependencies', 'flags', 'pkg_managers', 'environment_variables',
                     'configuration_files', 'content_manifest')
 
         data = {}

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -50,6 +50,13 @@ CACHITO_ICM_URL = '{}/api/v1/requests/{}/content-manifest'.format(
 
 REMOTE_SOURCE_REPO = 'https://git.example.com/team/repo.git'
 REMOTE_SOURCE_REF = 'b55c00f45ec3dfee0c766cea3d395d6e21cc2e5a'
+REMOTE_SOURCE_PACKAGES = [
+        {
+            'name': 'test-package',
+            'type': 'npm',
+            'version': '0.0.1'
+        }
+    ]
 
 CACHITO_SOURCE_REQUEST = {
     'id': CACHITO_REQUEST_ID,
@@ -292,12 +299,13 @@ def test_no_koji_user(workflow, build_json, caplog):
     assert log_msg in caplog.text
 
 
-@pytest.mark.parametrize('pop_key', ('repo', 'ref'))
+@pytest.mark.parametrize('pop_key', ('repo', 'ref', 'packages'))
 def test_invalid_remote_source_structure(workflow, pop_key):
     source_request = {
         'id': CACHITO_REQUEST_ID,
         'repo': REMOTE_SOURCE_REPO,
         'ref': REMOTE_SOURCE_REF,
+        'packages': REMOTE_SOURCE_PACKAGES,
     }
     source_request.pop(pop_key)
     mock_cachito_api(workflow, source_request=source_request)


### PR DESCRIPTION
Cachito should always provide it, so making it
required to make sure that later tools built on top
of it are not accidentally broken if it is removed.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
