### PR TITLE
Export operator manifest metadata

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -226,18 +226,17 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
     def _get_replacement_pullspecs(self, pullspecs):
         self.log.info("Computing replacement pullspecs")
 
+        replacements = []
+
         pin_digest, replace_repo, replace_registry = self._are_features_enabled()
         if not any([pin_digest, replace_repo, replace_registry]):
-            self.log.warning("All replacement features disabled, skipping")
-            return {}
+            self.log.warning("All replacement features disabled")
 
         replacer = PullspecReplacer(user_config=self.user_config, workflow=self.workflow)
 
         for p in pullspecs:
             if not replacer.registry_is_allowed(p):
                 raise RuntimeError("Registry not allowed: {} (in {})".format(p.registry, p))
-
-        replacements = []
 
         for original in pullspecs:
             self.log.info("Computing replacement for %s", original)

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -120,6 +120,10 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
         if not operator_manifest.csv:
             raise RuntimeError("Missing ClusterServiceVersion in operator manifests")
 
+        if operator_manifest.csv.has_related_images():
+            # related images already exists
+            related_images_metadata['created_by_osbs'] = False
+
         pullspecs = self._get_pullspecs(operator_manifest.csv)
 
         if pullspecs:
@@ -127,6 +131,9 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
             self._set_worker_arg(replacement_pullspecs)
 
             related_images_metadata['pullspecs'] = replacement_pullspecs
+        else:
+            # no pullspecs don't create relatedImages section
+            related_images_metadata['created_by_osbs'] = False
 
         return operator_manifests_metadata
 

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -117,8 +117,6 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
         }
 
         operator_manifest = self._get_operator_manifest()
-        if not operator_manifest.csv:
-            raise RuntimeError("Missing ClusterServiceVersion in operator manifests")
 
         if operator_manifest.csv.has_related_images():
             # related images already exists
@@ -181,18 +179,7 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
 
         self.log.info("Looking for operator CSV files in %s", manifests_dir)
         operator_manifest = OperatorManifest.from_directory(manifests_dir)
-
-        if operator_manifest.files:
-            path_lines = "\n".join(f.path for f in operator_manifest.files)
-
-            if len(operator_manifest.files) > 1:
-                msg = "Operator bundle may contain only 1 CSV file, but contains more: {}".\
-                    format(path_lines)
-                raise RuntimeError(msg)
-
-            self.log.info("Found operator CSV file: %s", path_lines)
-        else:
-            self.log.info("No operator CSV files found")
+        self.log.info("Found operator CSV file: %s", operator_manifest.csv.path)
 
         return operator_manifest
 

--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -552,6 +552,16 @@ class OperatorManifest(object):
         """
         self.files = files
 
+    @property
+    def csv(self):
+        """
+        :return: ClusteredServiceVersion object of the operator manifests
+        :rtype: OperatorCSV
+        """
+        if len(self.files) > 1:
+            raise ValueError("Multiple CSV files found, only one CSV file is allowed")
+        return self.files[0] if self.files else None
+
     @classmethod
     def from_directory(cls, path, **kwargs):
         """

--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -388,6 +388,10 @@ class OperatorCSV(object):
         """
         named_pullspecs = self._named_pullspecs()
 
+        if not named_pullspecs:
+            log.info("No pullspecs, skipping updates of relatedImages section")
+            return
+
         by_name = OrderedDict()
         conflicts = []
 

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -87,6 +87,15 @@ Data which is placed here includes
   which this image is available, where "application/json" is for a Docker
   Registry HTTP API V1 image; currently this key is only set when Pulp
   integration is enabled
+- `build.extra.image.operator_manifests` (map): Operator bundle images metadata
+- `build.extra.image.operator_manifests.related_images` (map): Metadata about
+  related_images in operator bundle
+- `build.extra.image.operator_manifests.related_images.pullspecs` (map list):
+  list of used pullspecs. Map keys: `original` - original pullspec value in
+  CSV; `new` - new pullspec replaces by OSBS; `pinned` - boolean if pullspec
+  digest was pinned by OSBS
+- `build.extra.image.operator_manifests.related_images.created_by_osbs`
+  (boolean): True if `relatedImages` section in CSV file was created by OSBS
 - `build.extra.image.parent_build_id` (int): Koji build id of the parent image,
   if found
 - `build.extra.image.parent_image_builds` (map of maps): Keys are parent images

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -628,7 +628,7 @@ class TestPinOperatorDigest(object):
 
         runner = mock_env(docker_tasker, tmpdir, orchestrator=True,
                           user_config=user_config, site_config=site_config)
-        runner.run()
+        result = runner.run()
 
         if not pin_digest:
             assert "User disabled digest pinning" in caplog.text
@@ -641,10 +641,13 @@ class TestPinOperatorDigest(object):
             assert "Replacing registry" not in caplog.text
 
         if not any([pin_digest, replace_repo, replace_registry]):
-            assert "All replacement features disabled, skipping" in caplog.text
+            assert "All replacement features disabled" in caplog.text
             assert self._get_worker_arg(runner.workflow) == {}
         else:
             assert self._get_worker_arg(runner.workflow) == {original: replaced.to_str()}
+
+        # plugin must always retun pullspecs
+        assert result['pin_operator_digest']['related_images']['pullspecs']
 
     @pytest.mark.parametrize('has_envs', [True, False])
     def test_worker_exclude_csvs(self, docker_tasker, tmpdir, caplog, has_envs):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -352,7 +352,7 @@ class TestPinOperatorDigest(object):
         expected = {
             'related_images': {
                 'pullspecs': [],
-                'created_by_osbs': True,
+                'created_by_osbs': False,
             }
         }
         assert result['pin_operator_digest'] == expected
@@ -409,8 +409,9 @@ class TestPinOperatorDigest(object):
                         "automatically.".format(csv))
             assert expected in str(exc_info.value)
         else:
-            runner.run()
+            result = runner.run()
             assert "{} has a relatedImages section, skipping".format(csv) in caplog.text
+            assert not result['pin_operator_digest']['related_images']['created_by_osbs']
 
     @responses.activate
     def test_orchestrator(self, docker_tasker, tmpdir, caplog):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -345,12 +345,12 @@ class TestPinOperatorDigest(object):
 
         assert "Looking for operator CSV files in {}".format(tmpdir) in caplog_text
         if files:
-            assert "Found operator CSV files:" in caplog_text
+            assert "Found operator CSV file:" in caplog_text
             for f in files:
                 assert str(f) in caplog_text
+            assert "No pullspecs found" in caplog_text
         else:
             assert "No operator CSV files found" in caplog_text
-        assert "No pullspecs found" in caplog_text
         assert self._get_worker_arg(runner.workflow) is None
 
         expected = {
@@ -689,7 +689,7 @@ class TestPinOperatorDigest(object):
 
         caplog_text = "\n".join(rec.message for rec in caplog.records)
 
-        assert 'Found operator CSV files:\n{}'.format(gets_replaced) in caplog_text
+        assert 'Found operator CSV file: {}'.format(gets_replaced) in caplog_text
         assert str(reference) not in caplog_text
 
         assert 'Replacing pullspecs in {}'.format(gets_replaced) in caplog_text

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -1110,7 +1110,7 @@ class TestOperatorCSV(object):
 
 
 class TestOperatorManifest(object):
-    def test_from_directory(self, tmpdir):
+    def test_from_directory_multiple_csvs(self, tmpdir):
         subdir = tmpdir.mkdir("nested")
 
         original = tmpdir.join("original.yaml")
@@ -1128,6 +1128,25 @@ class TestOperatorManifest(object):
 
         assert original_csv.data == ORIGINAL.data
         assert replaced_csv.data == REPLACED.data
+
+        with pytest.raises(ValueError):
+            # only one manifest file can exist
+            assert not manifest.csv
+
+    def test_from_directory_single_csv(self, tmpdir):
+
+        original = tmpdir.join("original.yaml")
+        original.write(ORIGINAL.content)
+
+        manifest = OperatorManifest.from_directory(str(tmpdir))
+
+        original_csv = manifest.files[0]
+
+        assert original_csv.path == str(original)
+        assert original_csv.data == ORIGINAL.data
+
+        assert manifest.csv.path == str(original)
+        assert manifest.csv.data == ORIGINAL.data
 
     def test_from_directory_no_csvs(self, tmpdir):
         subdir = tmpdir.mkdir("nested")
@@ -1147,6 +1166,7 @@ class TestOperatorManifest(object):
 
         manifest = OperatorManifest.from_directory(str(tmpdir))
         assert manifest.files == []
+        assert manifest.csv is None
 
     def test_from_directory_yaml_list(self, tmpdir):
         yaml_list = tmpdir.join("list.yaml")
@@ -1157,6 +1177,7 @@ class TestOperatorManifest(object):
 
         manifest = OperatorManifest.from_directory(str(tmpdir))
         assert manifest.files == []
+        assert manifest.csv is None
 
     def test_directory_does_not_exist(self, tmpdir):
         nonexistent = tmpdir.join("nonexistent")

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -1006,6 +1006,21 @@ class TestOperatorCSV(object):
         csv = OperatorCSV('original.yaml', data)
         assert csv.has_related_image_envs() == does_have
 
+    def test_related_images_no_pullspecs(self, caplog):
+        """If no pullspecs are detected, skip creation of relatedImages"""
+        data = {
+            'kind': 'ClusterServiceVersion',
+            'metadata': {
+                'annotations': {
+                    'foo': 'test'
+                }
+            }
+        }
+        csv = OperatorCSV("original.yaml", data)
+        csv.set_related_images()
+        assert "" in caplog.text
+        assert 'relatedImages' not in csv.data.get("spec", {})
+
     @pytest.mark.parametrize('pullspecs, replacements, expected', [
         # 1st is a substring of 2nd
         (['a.b/c:1', 'a.b/c:1.1'],


### PR DESCRIPTION
<Updated description in the commit>

* CLOUDBLD-2230

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
