### PR TITLE
Unpin 'jsonschema' to allow version from RHEL 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ docker-py>=1.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11
-jsonschema==2.3.0  # to match available in RHEL/CentOS 7
+jsonschema
 PyYAML
 ruamel.yaml
 six


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

* CLOUDBLD-1877

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
