### PR TITLE
Require docker[-py] <4.3.0

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -62,7 +62,7 @@ infrastructure.
 Summary:        Python 3 Atomic Reactor library
 Group:          Development/Tools
 License:        BSD
-Requires:       python3-docker >= 1.3.0
+Requires:       python3-docker >= 1.3.0, python3-docker < 4.3.0
 Requires:       python3-requests
 Requires:       python3-setuptools
 Requires:       python3-dockerfile-parse >= 0.0.11
@@ -96,9 +96,9 @@ Summary:        Python 2 Atomic Reactor library
 Group:          Development/Tools
 License:        BSD
 %if 0%{?fedora}
-Requires:       python2-docker >= 1.3.0
+Requires:       python2-docker >= 1.3.0, python2-docker < 4.3.0
 %else
-Requires:       python-docker-py >= 1.3.0
+Requires:       python-docker-py >= 1.3.0, python-docker-py < 4.3.0
 %endif # fedora
 Requires:       python-requests
 Requires:       python-setuptools

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,5 +1,5 @@
 backports.lzma
-docker-py>=1.3.0
+docker-py>=1.3.0,<4.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker
+docker < 4.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11

--- a/test.sh
+++ b/test.sh
@@ -101,6 +101,9 @@ function setup_osbs() {
     # environment markers used by docker-squash's requirements, also
     # CentOS needs to have setuptools updates to make pytest-cov work
     $RUN "${PIP_INST[@]}" --upgrade setuptools
+    # newer versions of docker package doesn't support docker API older than 1.21
+    # install in advance to prevent deps to downlaod latest versions
+    $RUN "${PIP_INST[@]}" "docker<4.3.0"
   fi
 
   # Install other dependencies for tests


### PR DESCRIPTION
Latest python docker packages are dropping support for older docker
versions thatn 1.21.

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
