### PR TITLE
RHEL7: remove dependency range for python-docker

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -98,7 +98,8 @@ License:        BSD
 %if 0%{?fedora}
 Requires:       python2-docker >= 1.3.0, python2-docker < 4.3.0
 %else
-Requires:       python-docker-py >= 1.3.0, python-docker-py < 4.3.0
+# python-docker-py >= 1.3.0, python-docker-py < 4.3.0  # yum on RHEL7 cannot resolve this properly
+Requires:       python-docker-py >= 1.3.0
 %endif # fedora
 Requires:       python-requests
 Requires:       python-setuptools


### PR DESCRIPTION
Yum on RHEL7 cannot resolve this range properly

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
