### PR TITLE
Always export related images when a CSV has spec.relatedImages

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -431,11 +431,26 @@ class OperatorCSV(object):
         return pullspecs
 
     def _related_image_pullspecs(self):
+        """Get the pullspecs from spec.relatedImages section
+
+        :return: a list of pullspecs. It could be an empty if no spec.RelatedImage section.
+        :rtype: list[RelatedImage]
+        """
         related_images_path = ("spec", "relatedImages")
         return [
             RelatedImage(r)
             for r in chain_get(self.data, related_images_path, default=[])
         ]
+
+    def get_related_image_pullspecs(self):
+        """Get the related image pullspecs
+
+        :return: a list of related images pullspecs. It could be an empty list
+            if this CSV file does not have spec.relatedImages section.
+        :rtype: list[ImageName]
+        """
+        return [ImageName.parse(related_image.image)
+                for related_image in self._related_image_pullspecs()]
 
     def _deployments(self):
         deployments_path = ("spec", "install", "spec", "deployments")

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -1123,6 +1123,35 @@ class TestOperatorCSV(object):
         csv = OperatorCSV("original.yaml", data)
         assert csv.get_pullspecs() == set()
 
+    @pytest.mark.parametrize('csv_content, expected_pullspecs', [
+        [
+            {
+                'kind': 'ClusterServiceVersion',
+                'spec': {
+                    'relatedImages': [
+                        {'name': 'foo', 'image': 'repo/ns/foo@0.1'},
+                        {'name': 'bar', 'image': 'repo/ns/bar:sha256:123456'},
+                    ]
+                }
+            },
+            [
+                ImageName.parse('repo/ns/foo@0.1'),
+                ImageName.parse('repo/ns/bar:sha256:123456')
+            ]
+        ],
+        [
+            {'kind': 'ClusterServiceVersion', 'spec': {}},
+            []
+        ],
+        [
+            {'kind': 'ClusterServiceVersion', 'spec': {'relatedImages': []}},
+            []
+        ]
+    ])
+    def test_get_related_image_pullsepcs(self, csv_content, expected_pullspecs):
+        csv = OperatorCSV('csv.yaml', csv_content)
+        assert expected_pullspecs == csv.get_related_image_pullspecs()
+
 
 class TestOperatorManifest(object):
     def test_from_directory_multiple_csvs(self, tmpdir):


### PR DESCRIPTION
* CLOUDBLD-2244

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a - JSON/YAML configuration changes are updated in the relevant schema
- n/a - Changes to metadata also update the documentation for the metadata
- n/a - Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
