### PR TITLE
Delete compose when timeout

### DIFF
--- a/tests/utils/test_odcs.py
+++ b/tests/utils/test_odcs.py
@@ -8,7 +8,8 @@ of the BSD license. See the LICENSE file for details.
 
 from __future__ import absolute_import
 
-from atomic_reactor.utils.odcs import ODCSClient, MULTILIB_METHOD_DEFAULT
+from atomic_reactor.utils.odcs import (ODCSClient, MULTILIB_METHOD_DEFAULT,
+                                       WaitComposeToFinishTimeout)
 from tests.retry_mock import mock_get_retry_session
 
 import flexmock
@@ -219,6 +220,6 @@ def test_wait_for_compose_timeout(timeout):
         .one_by_one())
 
     odcs_client = ODCSClient(ODCS_URL, timeout=timeout)
-    expected_error = 'Retrieving {} timed out after {} seconds'.format(compose_url, timeout)
-    with pytest.raises(RuntimeError, match=expected_error):
+    expected_error = r'Timeout of waiting for compose \d+'
+    with pytest.raises(WaitComposeToFinishTimeout, match=expected_error):
         odcs_client.wait_for_compose(COMPOSE_ID)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file