### PR TITLE
Cancel all ODCS composes on timeout

### DIFF
--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -217,3 +217,9 @@ class ODCSClient(object):
         except Exception as e:
             logger.warning('Failed to cancel compose %s. ODCS responses: %s',
                            compose_id, str(e))
+
+    def get_compose_status(self, compose_id):
+        """Retrieve compose status by sending a GET request with compose id"""
+        response = self.session.get(self._get_compose_url(compose_id))
+        response.raise_for_status()
+        return response.json()['state_name']


### PR DESCRIPTION
Part of CLOUDBLD-2590

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
