### PR TITLE
Feature to allow bypassing all OSBS operator processing

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -723,6 +723,14 @@
               "required": ["old", "new"],
               "additionalProperties": false
             }
+          },
+          "skip_all_allow_list": {
+            "description": "Koji packages allowed to use skip_all option in container.yaml, add also comment for each package about the Vault Exception ID",
+            "type": ["array", "null"],
+            "items": {
+              "type": "string"
+            },
+            "examples": [null, ["centos-container", "rsyslog-container"]]
           }
         },
         "required": ["allowed_registries"],


### PR DESCRIPTION
by defining skip_all option in operator_manifests in container.yaml
for allowed koji packages from skip_all_allow_list in reactor config
map, don't touch operator's CSV file

* CLOUDBLD-2425

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
