### PR TITLE
when skipping check_and_set_rebuild plugin return False,

### DIFF
--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -78,10 +78,10 @@ class CheckAndSetRebuildPlugin(PreBuildPlugin):
         """
         if is_scratch_build(self.workflow):
             self.log.info('scratch build, skipping plugin')
-            return
+            return False
         if is_isolated_build(self.workflow):
             self.log.info('isolated build, skipping plugin')
-            return
+            return False
 
         if (self.workflow.builder.dockerfile_images is not None and
                 self.workflow.builder.dockerfile_images.base_from_scratch):


### PR DESCRIPTION
so is_rebuild method will actually return False and not None,
and in koji build metadata for isolated build will be autorebuild: False
instead of autorebuild: None

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
