### PR TITLE
use sources_for_koji_build_id instead of sources_for_nvr as build label

### DIFF
--- a/atomic_reactor/metadata.py
+++ b/atomic_reactor/metadata.py
@@ -105,7 +105,7 @@ def _decorate_metadata(metadata_type, keys, match_keys):
                     raise RuntimeError('[{}] Already set: {!r}'.format(metadata_type, key))
 
                 if match_keys:
-                    metadata[key] = result[key]
+                    metadata[key] = str(result[key])
                 else:
                     metadata[key] = result
 

--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -31,7 +31,7 @@ from atomic_reactor.download import download_url
 from atomic_reactor.metadata import label_map
 
 
-@label_map('sources_for_nvr')
+@label_map('sources_for_koji_build_id')
 class FetchSourcesPlugin(PreBuildPlugin):
     """Download sources that may be used in further steps to compose Source Containers"""
     key = PLUGIN_FETCH_SOURCES_KEY

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -261,7 +261,7 @@ def test_add_filesystem_plugin_generated(tmpdir, docker_tasker, scratch):
     assert 'base-image-id' in plugin_result
     assert 'filesystem-koji-task-id' in plugin_result
     assert plugin_result == expected_results
-    assert workflow.labels['filesystem-koji-task-id'] == FILESYSTEM_TASK_ID
+    assert workflow.labels['filesystem-koji-task-id'] == str(FILESYSTEM_TASK_ID)
 
 
 @pytest.mark.parametrize('scratch', [True, False])

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -315,7 +315,7 @@ class TestFetchSources(object):
             if custom_rcm:
                 assert get_srpm_url() in caplog.text
                 assert get_srpm_url('usedKey') not in caplog.text
-            assert runner.workflow.labels['sources_for_nvr'] == 'foobar-1-1'
+            assert runner.workflow.labels['sources_for_koji_build_id'] == '1'
 
     @pytest.mark.parametrize('signing_intent', ('unsigned', 'empty', 'one', 'multiple', 'invalid'))
     def test_koji_signing_intent(self, requests_mock, docker_tasker, koji_session, tmpdir,

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -410,10 +410,11 @@ def test_metadata_plugin_source(image_id, br_annotations, expected_br_annotation
         workflow.koji_source_manifest = {'config': {'digest': image_id}}
 
     sources_for_nvr = 'image_build'
-    workflow.labels['sources_for_nvr'] = sources_for_nvr
+    sources_for_koji_build_id = '12345'
+    workflow.labels['sources_for_koji_build_id'] = sources_for_koji_build_id
     workflow.prebuild_results = {
         PLUGIN_FETCH_SOURCES_KEY: {
-            'sources_for_koji_build_id': '12345',
+            'sources_for_koji_build_id': sources_for_koji_build_id,
             'sources_for_nvr': sources_for_nvr,
             'image_sources_dir': 'source_dir',
         }
@@ -532,8 +533,8 @@ def test_metadata_plugin_source(image_id, br_annotations, expected_br_annotation
         assert labels['br_labels'] == expected_br_labels
     else:
         assert 'br_labels' not in labels
-    assert 'sources_for_nvr' in labels
-    assert labels['sources_for_nvr'] == sources_for_nvr
+    assert 'sources_for_koji_build_id' in labels
+    assert labels['sources_for_koji_build_id'] == sources_for_koji_build_id
 
     if expected_media_results:
         media_types = expected_media_results

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -82,7 +82,7 @@ def test_store_metadata_map(metadata_map_decorator, metadata_attr):
     assert p2.run() is None
 
     other_attr = 'labels' if metadata_attr == 'annotations' else 'annotations'
-    assert getattr(workflow, metadata_attr) == {'foo': 1, 'bar': 2}
+    assert getattr(workflow, metadata_attr) == {'foo': '1', 'bar': '2'}
     assert getattr(workflow, other_attr) == {}
 
 
@@ -185,9 +185,9 @@ def test_store_metadata_combined():
     p.run()
     assert workflow.annotations == {
         'foo': {'bar': 1, 'eggs': 2},
-        'bar': 1
+        'bar': '1'
     }
     assert workflow.labels == {
         'spam': {'bar': 1, 'eggs': 2},
-        'eggs': 2
+        'eggs': '2'
     }


### PR DESCRIPTION
* CLOUDBLD-3343

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
