### PR TITLE
Clarify fetching manifest list error

### DIFF
--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -148,8 +148,10 @@ class PullBaseImagePlugin(PreBuildPlugin):
             try:
                 manifest_digest_response = digests_dict['v2']
             except KeyError:
-                raise RuntimeError('Unable to fetch manifest list or '
-                                   'v2 schema 2 digest for {}'.format(image_str))
+                raise RuntimeError(
+                    'Unable to fetch manifest list or '
+                    'v2 schema 2 digest for {} (Does image exist?)'.format(image_str)
+                )
 
             digest_dict = get_checksums(BytesIO(manifest_digest_response.content), ['sha256'])
 


### PR DESCRIPTION
In most cases following error means "Image doesn't exist"
```
'Unable to fetch manifest list or '
'v2 schema 2 digest for ...'
```

Adding clarification to the end of emsg:
```
Does image exist?
```

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
