### PR TITLE
don't convert all metadata to str, but just sources_for_koji_build_id

### DIFF
--- a/atomic_reactor/metadata.py
+++ b/atomic_reactor/metadata.py
@@ -105,7 +105,7 @@ def _decorate_metadata(metadata_type, keys, match_keys):
                     raise RuntimeError('[{}] Already set: {!r}'.format(metadata_type, key))
 
                 if match_keys:
-                    metadata[key] = str(result[key])
+                    metadata[key] = result[key]
                 else:
                     metadata[key] = result
 

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -167,6 +167,9 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
         self._update_labels(labels, self.workflow.labels)
         self._update_labels(labels, self.workflow.build_result.labels)
 
+        if 'sources_for_koji_build_id' in labels:
+            labels['sources_for_koji_build_id'] = str(labels['sources_for_koji_build_id'])
+
         return labels
 
     def set_koji_task_annotations_whitelist(self, annotations):

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -261,7 +261,7 @@ def test_add_filesystem_plugin_generated(tmpdir, docker_tasker, scratch):
     assert 'base-image-id' in plugin_result
     assert 'filesystem-koji-task-id' in plugin_result
     assert plugin_result == expected_results
-    assert workflow.labels['filesystem-koji-task-id'] == str(FILESYSTEM_TASK_ID)
+    assert workflow.labels['filesystem-koji-task-id'] == FILESYSTEM_TASK_ID
 
 
 @pytest.mark.parametrize('scratch', [True, False])

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -315,7 +315,7 @@ class TestFetchSources(object):
             if custom_rcm:
                 assert get_srpm_url() in caplog.text
                 assert get_srpm_url('usedKey') not in caplog.text
-            assert runner.workflow.labels['sources_for_koji_build_id'] == '1'
+            assert runner.workflow.labels['sources_for_koji_build_id'] == 1
 
     @pytest.mark.parametrize('signing_intent', ('unsigned', 'empty', 'one', 'multiple', 'invalid'))
     def test_koji_signing_intent(self, requests_mock, docker_tasker, koji_session, tmpdir,

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -82,7 +82,7 @@ def test_store_metadata_map(metadata_map_decorator, metadata_attr):
     assert p2.run() is None
 
     other_attr = 'labels' if metadata_attr == 'annotations' else 'annotations'
-    assert getattr(workflow, metadata_attr) == {'foo': '1', 'bar': '2'}
+    assert getattr(workflow, metadata_attr) == {'foo': 1, 'bar': 2}
     assert getattr(workflow, other_attr) == {}
 
 
@@ -185,9 +185,9 @@ def test_store_metadata_combined():
     p.run()
     assert workflow.annotations == {
         'foo': {'bar': 1, 'eggs': 2},
-        'bar': '1'
+        'bar': 1
     }
     assert workflow.labels == {
         'spam': {'bar': 1, 'eggs': 2},
-        'eggs': '2'
+        'eggs': 2
     }


### PR DESCRIPTION
* CLOUDBLD-3343

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
