### PR TITLE
exclude package from sources only based on key/value from denylist wi…

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -408,8 +408,12 @@ class FetchSourcesPlugin(PreBuildPlugin):
 
     def _check_if_package_excluded(self, packages, denylist_sources, remote_archive):
         # check if any package in cachito json matches excluded entry
+        # strip leading os.sep as package names can include git path with '/' before package name
+        # or just package name, or package name with leading '@' depending on package type
+        denylist_packages = {k.lstrip(os.sep) for k in denylist_sources}
+
         for package in packages:
-            for exclude_path in denylist_sources:
+            for exclude_path in denylist_packages:
                 if package.get('name').endswith(exclude_path):
                     self.log.debug('Package excluded: "%s" from "%s"', package.get('name'),
                                    remote_archive)

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -193,7 +193,8 @@ def get_remote_url(koji_build, file_name=REMOTE_SOURCES_FILE):
 
 
 def mock_koji_manifest_download(tmpdir, requests_mock, retries=0, dirs_in_remote=('app', 'deps'),
-                                files_in_remote=(), cachito_package_names=None):
+                                files_in_remote=(), cachito_package_names=None,
+                                change_package_names=True):
     class MockBytesIO(io.BytesIO):
         reads = 0
 
@@ -249,7 +250,10 @@ def mock_koji_manifest_download(tmpdir, requests_mock, retries=0, dirs_in_remote
         remote_json = {'packages': []}
         if cachito_package_names:
             for pkg in cachito_package_names:
-                remote_json['packages'].append({'name': os.path.join('github.com', pkg)})
+                if change_package_names:
+                    remote_json['packages'].append({'name': os.path.join('github.com', pkg)})
+                else:
+                    remote_json['packages'].append({'name': pkg})
         remote_cont = json.dumps(remote_json)
 
         if six.PY2:
@@ -646,20 +650,37 @@ class TestFetchSources(object):
         ({'denylist_sources': 'http://excludelist_url'},
          {'dir1': ['appname']},
          [os.path.join('dir1', 'appname')],
-         ['Removing app', 'Keeping vendor in app'],
+         ['Removing app', 'Keeping vendor in app',
+          'Package excluded: "{}"'.format(os.path.join('dir1', 'appname'))],
+         None),
+
+        ({'denylist_sources': 'http://excludelist_url'},
+         {'dir1': ['appname']},
+         [os.path.join('github.com', 'dir1', 'appname')],
+         ['Removing app', 'Keeping vendor in app',
+          'Package excluded: "{}"'.format(os.path.join('github.com', 'dir1', 'appname'))],
+         None),
+
+        ({'denylist_sources': 'http://excludelist_url'},
+         {'dir1': ['appname']},
+         [os.path.join('@dir1', 'appname')],
+         ['Removing app', 'Keeping vendor in app',
+          'Package excluded: "{}"'.format(os.path.join('@dir1', 'appname'))],
          None),
 
         ({'denylist_sources': 'http://excludelist_url'},
          {'dir1': ['appname', 'toremovefile']},
          [os.path.join('dir1', 'appname')],
-         ['Removing app', 'Removing excluded file', 'Keeping vendor in app'],
+         ['Removing app', 'Removing excluded file', 'Keeping vendor in app',
+          'Package excluded: "{}"'.format(os.path.join('dir1', 'appname'))],
          None),
 
         ({'denylist_sources': 'http://excludelist_url'},
          {'dir1': ['appname', 'toremovefile', 'toremovedir']},
          [os.path.join('dir1', 'appname')],
          ['Removing app', 'Removing excluded file', 'Removing excluded directory',
-          'Keeping vendor in app'],
+          'Keeping vendor in app',
+          'Package excluded: "{}"'.format(os.path.join('dir1', 'appname'))],
          None),
 
         ({'denylist_sources': 'http://excludelist_url'},
@@ -750,7 +771,8 @@ class TestFetchSources(object):
 
         mock_koji_manifest_download(tmpdir, requests_mock, dirs_in_remote=dirs_to_create,
                                     files_in_remote=files_to_create,
-                                    cachito_package_names=cachito_pkg_names)
+                                    cachito_package_names=cachito_pkg_names,
+                                    change_package_names=False)
         runner = mock_env(tmpdir, docker_tasker, koji_build_id=1,
                           config_map=yaml.safe_dump(rcm_json))
 


### PR DESCRIPTION
…thout leading '/'

as package names from cachito can have differnt form of names (depedning on package types):
github.com/some/package
some/package
@some/package

* CLOUDBLD-3411

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
