### PR TITLE
Avoid traceback in exit plugin if worker build doesn't exist

### DIFF
--- a/atomic_reactor/plugins/exit_remove_worker_metadata.py
+++ b/atomic_reactor/plugins/exit_remove_worker_metadata.py
@@ -25,7 +25,11 @@ class RemoveWorkerMetadataPlugin(ExitPlugin):
         """
         build_result = self.workflow.build_result
 
-        worker_builds = build_result.annotations['worker-builds']
+        if not build_result.annotations:
+            self.log.info("No build annotations found, skipping plugin")
+            return
+
+        worker_builds = build_result.annotations.get('worker-builds', {})
 
         for platform, build_annotations in worker_builds.items():
             try:

--- a/tests/plugins/test_remove_worker_metadata.py
+++ b/tests/plugins/test_remove_worker_metadata.py
@@ -161,3 +161,24 @@ def test_remove_worker_plugin(tmpdir, caplog, user_params,
             else:
                 msg = "ConfigMap {} on platform {} deleted". format(cm_name, platform)
                 assert msg in caplog.text
+
+
+def test_remove_worker_metadata_no_worker_build(tmpdir, caplog, user_params):
+    """Don't traceback with missing worker builds, without worker
+    builds plugin should just skip"""
+    workflow = mock_workflow(tmpdir)
+    annotations = None
+    workflow.build_result = BuildResult(annotations=annotations, image_id="id1234")
+
+    runner = ExitPluginsRunner(
+        None,
+        workflow,
+        [{
+            'name': PLUGIN_REMOVE_WORKER_METADATA_KEY,
+            "args": {}
+        }]
+    )
+    runner.run()
+
+    assert "No build annotations found, skipping plugin" in caplog.text
+    assert "Traceback" not in caplog.text


### PR DESCRIPTION
Following traceback is raised when worker builds are not available

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/atomic_reactor/plugin.py", line 265, in run
    plugin_response = plugin_instance.run()
  File "/usr/lib/python3.6/site-packages/atomic_reactor/plugins/exit_remove_worker_metadata.py", line 28, in run
    worker_builds = build_result.annotations['worker-builds']
TypeError: 'NoneType' object is not subscriptable
```

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
