### PR TITLE
Validate distgit config files earlier

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -161,6 +161,8 @@ MEDIA_TYPE_OCI_V1_INDEX = "application/vnd.oci.image.index.v1+json"
 
 REPO_CONTAINER_CONFIG = 'container.yaml'
 REPO_CONTENT_SETS_CONFIG = 'content_sets.yml'
+REPO_FETCH_ARTIFACTS_URL = 'fetch-artifacts-url.yaml'
+REPO_FETCH_ARTIFACTS_KOJI = 'fetch-artifacts-koji.yaml'
 
 DOCKERIGNORE = '.dockerignore'
 
@@ -189,3 +191,10 @@ DOCKER_STORAGE_TRANSPORT_NAME = 'docker-daemon'
 
 # location for build info directory in the image
 IMAGE_BUILD_INFO_DIR = '/root/buildinfo/'
+
+USER_CONFIG_FILES = {
+    # filename: json schema file
+    REPO_FETCH_ARTIFACTS_URL: 'schemas/fetch-artifacts-url.json',
+    REPO_FETCH_ARTIFACTS_KOJI: 'schemas/fetch-artifacts-nvr.json',
+    REPO_CONTENT_SETS_CONFIG: 'schemas/content_sets.json',
+}

--- a/atomic_reactor/plugins/pre_check_user_settings.py
+++ b/atomic_reactor/plugins/pre_check_user_settings.py
@@ -12,6 +12,9 @@ from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (
     has_operator_appregistry_manifest,
     has_operator_bundle_manifest,
+    read_content_sets,
+    read_fetch_artifacts_koji,
+    read_fetch_artifacts_url
 )
 
 
@@ -92,8 +95,15 @@ class CheckUserSettingsPlugin(PreBuildPlugin):
                   "with '{}'".format(CONTAINER_IMAGEBUILDER_BUILD_METHOD)
             raise RuntimeError(msg)
 
+    def validate_user_config_files(self):
+        """Validate some user config files"""
+        read_fetch_artifacts_koji(self.workflow)
+        read_fetch_artifacts_url(self.workflow)
+        read_content_sets(self.workflow)
+
     def run(self):
         """
         run the plugin
         """
         self.dockerfile_checks()
+        self.validate_user_config_files()

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -7,14 +7,15 @@ of the BSD license. See the LICENSE file for details.
 """
 from copy import deepcopy
 from datetime import datetime, timedelta
-import os
 from collections import defaultdict
 
+from atomic_reactor import util
 from atomic_reactor.utils.odcs import WaitComposeToFinishTimeout
 from osbs.repo_utils import ModuleSpec
 
-from atomic_reactor.constants import (PLUGIN_KOJI_PARENT_KEY, PLUGIN_RESOLVE_COMPOSES_KEY,
-                                      REPO_CONTENT_SETS_CONFIG, BASE_IMAGE_KOJI_BUILD)
+from atomic_reactor.constants import (PLUGIN_KOJI_PARENT_KEY,
+                                      PLUGIN_RESOLVE_COMPOSES_KEY,
+                                      BASE_IMAGE_KOJI_BUILD)
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
@@ -22,10 +23,7 @@ from atomic_reactor.plugins.pre_check_and_set_rebuild import is_rebuild
 from atomic_reactor.plugins.pre_reactor_config import (get_config,
                                                        get_odcs_session,
                                                        get_koji_session, get_koji)
-from atomic_reactor.util import (get_platforms,
-                                 is_isolated_build,
-                                 is_scratch_build,
-                                 read_yaml_from_file_path)
+from atomic_reactor.util import get_platforms, is_isolated_build, is_scratch_build
 
 ODCS_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 MINIMUM_TIME_TO_EXPIRE = timedelta(hours=2).total_seconds()
@@ -211,11 +209,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
         if not data and not self.all_compose_ids:
             raise SkipResolveComposesPlugin('"compose" config not set and compose_ids not given')
 
-        workdir = self.workflow.source.get_build_file_path()[1]
-        file_path = os.path.join(workdir, REPO_CONTENT_SETS_CONFIG)
-        pulp_data = None
-        if os.path.exists(file_path):
-            pulp_data = read_yaml_from_file_path(file_path, 'schemas/content_sets.json') or {}
+        pulp_data = util.read_content_sets(self.workflow) or {}
 
         platforms = get_platforms(self.workflow)
         if platforms:

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -14,6 +14,7 @@ import os
 import responses
 import yaml
 
+from atomic_reactor.constants import REPO_FETCH_ARTIFACTS_KOJI, REPO_FETCH_ARTIFACTS_URL
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_fetch_maven_artifacts import FetchMavenArtifactsPlugin
@@ -294,7 +295,7 @@ def mock_fetch_artifacts_by_nvr(tmpdir, contents=None):
             - nvr: com.sun.xml.bind.mvn-jaxb-parent-2.2.11.4-1
             """)
 
-    with open(os.path.join(tmpdir, FetchMavenArtifactsPlugin.NVR_REQUESTS_FILENAME), 'w') as f:
+    with open(os.path.join(tmpdir, REPO_FETCH_ARTIFACTS_KOJI), 'w') as f:
         f.write(contents)
         f.flush()
 
@@ -303,7 +304,7 @@ def mock_fetch_artifacts_by_url(tmpdir, contents=None):
     if contents is None:
         contents = yaml.safe_dump(DEFAULT_REMOTE_FILES)
 
-    with open(os.path.join(tmpdir, FetchMavenArtifactsPlugin.URL_REQUESTS_FILENAME), 'w') as f:
+    with open(os.path.join(tmpdir, REPO_FETCH_ARTIFACTS_URL), 'w') as f:
         f.write(contents)
         f.flush()
 

--- a/tests/plugins/test_resolve_composes.py
+++ b/tests/plugins/test_resolve_composes.py
@@ -1561,7 +1561,7 @@ class TestResolveComposes(object):
         # Ensure ODCSClient.wait_for_compose raises timeout error
         (flexmock(time)
          .should_receive('time')
-         .and_return(2 + ODCSClient.DEFAULT_WAIT_TIMEOUT, 1)
+         .and_return(1, 2 + ODCSClient.DEFAULT_WAIT_TIMEOUT)
          .one_by_one())
 
         # Ensure ODCS responses the compose is still waiting for process before


### PR DESCRIPTION
* CLOUDBLD-1989

This patch validates fetch-artifacts-*.yaml and content_sets.yml in the
pre_check_user_settings plugin.

Signed-off-by: Chenxiong Qi <qcxhome@gmail.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
