### PR TITLE
Check operator CSV file with schema before processing

### DIFF
--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -75,7 +75,6 @@ def generate_archive(tmpdir, empty=False, change_csv_content=False, multiple_csv
         csv = FAKE_CSV
         if change_csv_content:
             csv += dedent('''\
-                spec:
                   customresourcedefinitions:
             ''')
         manifests_dir.join('operator.clusterserviceversion.yaml').write(csv)
@@ -84,7 +83,9 @@ def generate_archive(tmpdir, empty=False, change_csv_content=False, multiple_csv
             manifests_dir.join('extra.csv.yaml').write(dedent('''\
                 apiVersion: operators.coreos.com/v1alpha1
                 kind: ClusterServiceVersion
+                metadata: {}
                 spec:
+                    install: {}
             '''))
 
     archive_path = tmpdir.join('temp.tar')

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -140,6 +140,7 @@ def mock_operator_csv(tmpdir, filename, pullspecs, for_ocp_44=False,
         containers[0]['env'] = [{'name': 'RELATED_IMAGE_XYZ', 'value': 'xyz'}]
     data = {
         'kind': 'ClusterServiceVersion',
+        'metadata': {},
         'spec': {
             'relatedImages': [],
             # It does not really matter where in the CSV these pullspecs go

--- a/tests/util.py
+++ b/tests/util.py
@@ -89,7 +89,9 @@ requires_internet = pytest.mark.skipif(not has_connection(), reason="requires in
 FAKE_CSV = '''\
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
-metadata:
+metadata: {}
+spec:
+    install: {}
 '''
 
 OPERATOR_MANIFESTS_DIR = 'operator-manifests'


### PR DESCRIPTION
- Uses a reduced schema which only checks the parts of the CSV which we
    really care about
- The schema is embedded in the source as a Python Dict

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

CLOUDBLD-2830

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
