### PR TITLE
Replace f31 with f33 in CI workflow

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -23,12 +23,12 @@ jobs:
             engine: docker
 
           - name: fedora
-            version: 31
+            version: 32
             python: 3
             engine: docker
 
           - name: fedora
-            version: 32
+            version: 33
             python: 3
             engine: docker
 

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -488,7 +488,7 @@ class TestReactorConfigPlugin(object):
         tasker, workflow = self.prepare()
         plugin = ReactorConfigPlugin(tasker, workflow, config_path=str(tmpdir))
 
-        with caplog.at_level(logging.ERROR), pytest.raises(OsbsValidationException):
+        with caplog.at_level(logging.DEBUG, logger='osbs'), pytest.raises(OsbsValidationException):
             plugin.run()
 
         os.environ.pop('REACTOR_CONFIG', None)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,9 @@ flexmock>=0.10.3
 ordereddict
 responses>=0.9.0,<0.10.8
 pypng
-pytest>=4.1.0,<5
+# 5.0 is the minimum version required by latest version of pytest-html. As of
+# this update, it is 3.1.1.
+pytest>=5.0
 pytest-cov
 pytest-html
 flake8


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
