### PR TITLE
Remove ordereddict from tests requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,4 @@
 flexmock>=0.10.3
-ordereddict
 responses>=0.9.0,<0.10.8
 pypng
 pytest>=4.1.0,<5


### PR DESCRIPTION
atomic-reactor is Python 3 only. collections.OrderedDict has been
available for use and it is being used already in the test code.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
