### PR TITLE
Reuse read_content_sets in add_image_content_manifest

### DIFF
--- a/atomic_reactor/plugins/pre_add_image_content_manifest.py
+++ b/atomic_reactor/plugins/pre_add_image_content_manifest.py
@@ -15,12 +15,12 @@ from osbs.utils import Labels
 
 from atomic_reactor.constants import (IMAGE_BUILD_INFO_DIR, INSPECT_ROOTFS,
                                       INSPECT_ROOTFS_LAYERS,
-                                      PLUGIN_ADD_IMAGE_CONTENT_MANIFEST,
-                                      REPO_CONTENT_SETS_CONFIG)
+                                      PLUGIN_ADD_IMAGE_CONTENT_MANIFEST)
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_reactor_config import get_cachito
 from atomic_reactor.util import (base_image_is_scratch, df_parser, read_yaml,
-                                 read_yaml_from_file_path, get_retrying_requests_session,
+                                 get_retrying_requests_session,
+                                 read_content_sets
                                  )
 
 
@@ -155,12 +155,8 @@ class AddImageContentManifestPlugin(PreBuildPlugin):
         'content_sets.yml' in dist-git, and set `self.content_sets` to same.
         """
         current_platform = self.workflow.user_params['platform']
-        workdir = self.workflow.builder.df_dir
-        fpath = os.path.join(workdir, REPO_CONTENT_SETS_CONFIG)
-        if os.path.exists(fpath):
-            content_sets_yml = read_yaml_from_file_path(fpath, 'schemas/content_sets.json') or {}
-            if current_platform in content_sets_yml:
-                self.content_sets = content_sets_yml[current_platform]
+        content_sets = read_content_sets(self.workflow) or {}
+        self.content_sets = content_sets.get(current_platform, [])
         self.log.debug('Output content_sets: %s', self.content_sets)
 
     def _update_icm_data(self):

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -152,6 +152,9 @@ def mock_env(tmpdir, docker_tasker, platform='x86_64', base_layers=0,
     env.workflow.builder.set_inspection_data(inspection_data)
     env.workflow.user_params['platform'] = platform
 
+    # Ensure to succeed in reading the content_sets.yml
+    env.workflow.source.get_build_file_path = lambda: (str(tmpdir), str(tmpdir))
+
     return env.create_runner(docker_tasker)
 
 


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
