### PR TITLE
Fix flake8 line length complaints due to schema embedded in operator.py

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -102,17 +102,17 @@ _mini_csv_schema = {
                                                                                         [
                                                                                             'name'
                                                                                         ],
-                                                                                        'properties':
+                                                                                        'properties':  # noqa E501
                                                                                         {
                                                                                             'name':
                                                                                             {
-                                                                                                'type':
-                                                                                                'string'
+                                                                                                'type':  # noqa E501
+                                                                                                'string'  # noqa E501
                                                                                             },
                                                                                             'value':
                                                                                             {
-                                                                                                'type':
-                                                                                                'string'
+                                                                                                'type':  # noqa E501
+                                                                                                'string'  # noqa E501
                                                                                             }
                                                                                         }
                                                                                     }


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
