### PR TITLE
Refactor handling of DockerfileImages

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -156,7 +156,7 @@ class InsideBuilder(LastLogger, BuilderStateMachine):
         # configuration of source_registy and pull_registries with insecure and
         # dockercfg_path, by registry key
         self.pull_registries = {}
-        self.dockerfile_images = None
+        self.dockerfile_images = DockerfileImages([])
         self._base_image_inspect = None
         self.parents_pulled = False
         self._parent_images_inspect = {}  # locally available image => inspect

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -217,27 +217,21 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
             except AttributeError:
                 commit_id = ""
 
-            # for early flatpak failure before it creates Dockerfile and creates dockerfile_images
-            if self.workflow.builder.dockerfile_images is None:
+            base_image = self.workflow.builder.dockerfile_images.original_base_image
+            if (base_image is not None and
+                    not self.workflow.builder.dockerfile_images.base_from_scratch):
+                base_image_name = base_image
+                try:
+                    base_image_id = self.workflow.builder.base_image_inspect.get('Id', "")
+                except KeyError:
+                    base_image_id = ""
+            else:
                 base_image_name = ""
                 base_image_id = ""
-                parent_images_strings = {}
-            else:
-                base_image = self.workflow.builder.dockerfile_images.original_base_image
-                if (base_image is not None and
-                        not self.workflow.builder.dockerfile_images.base_from_scratch):
-                    base_image_name = base_image
-                    try:
-                        base_image_id = self.workflow.builder.base_image_inspect['Id']
-                    except KeyError:
-                        base_image_id = ""
-                else:
-                    base_image_name = ""
-                    base_image_id = ""
 
-                parent_images_strings = self.workflow.builder.parent_images_to_str()
-                if self.workflow.builder.dockerfile_images.base_from_scratch:
-                    parent_images_strings[SCRATCH_FROM] = SCRATCH_FROM
+            parent_images_strings = self.workflow.builder.parent_images_to_str()
+            if self.workflow.builder.dockerfile_images.base_from_scratch:
+                parent_images_strings[SCRATCH_FROM] = SCRATCH_FROM
 
             try:
                 with open(self.workflow.builder.df_path) as f:

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -367,8 +367,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
             self.repos.append(compose_info['result_repofile'])
 
     def run(self):
-        if (self.workflow.builder.dockerfile_images is None or
-                not self.workflow.builder.dockerfile_images.custom_parent_image):
+        if not self.workflow.builder.dockerfile_images.custom_parent_image:
             self.log.info('Nothing to do for non-custom base images')
             return
 

--- a/atomic_reactor/plugins/pre_check_and_set_rebuild.py
+++ b/atomic_reactor/plugins/pre_check_and_set_rebuild.py
@@ -81,12 +81,10 @@ class CheckAndSetRebuildPlugin(PreBuildPlugin):
             self.log.info('isolated build, skipping plugin')
             return False
 
-        if (self.workflow.builder.dockerfile_images is not None and
-                self.workflow.builder.dockerfile_images.base_from_scratch):
+        if self.workflow.builder.dockerfile_images.base_from_scratch:
             self.log.info("Skipping check and set rebuild: unsupported for FROM-scratch images")
             return False
-        if (self.workflow.builder.dockerfile_images is not None and
-                self.workflow.builder.dockerfile_images.custom_base_image):
+        if self.workflow.builder.dockerfile_images.custom_base_image:
             self.log.info("Skipping check and set rebuild: unsupported for custom base images")
             return False
 

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -649,7 +649,7 @@ class ReactorConfigPlugin(PreBuildPlugin):
                                                      default_image_build_method)
 
         # set source registry and organization
-        if self.workflow.builder.dockerfile_images is not None:
+        if self.workflow.builder.dockerfile_images:
             source_registry_docker_uri = get_source_registry(self.workflow)['uri'].docker_uri
             organization = get_registries_organization(self.workflow)
             self.workflow.builder.dockerfile_images.set_source_registry(source_registry_docker_uri,

--- a/tests/plugins/test_reactor_config.py
+++ b/tests/plugins/test_reactor_config.py
@@ -2138,7 +2138,7 @@ source_registry:
             assert len(workflow.builder.dockerfile_images) == 2
             assert workflow.builder.dockerfile_images.keys() == expect_images
         else:
-            assert workflow.builder.dockerfile_images is None
+            assert not workflow.builder.dockerfile_images
 
     @pytest.mark.parametrize(('config', 'expect'), [
         ("""\

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -69,7 +69,7 @@ class XBeforeDockerfile(object):
         self.source = Y()
         self.source.dockerfile_path = None
         self.source.path = None
-        self.dockerfile_images = None
+        self.dockerfile_images = DockerfileImages([])
         self.df_dir = None
 
     def parent_images_to_str(self):

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -52,7 +52,7 @@ class StubInsideBuilder(object):
     """
 
     def __init__(self):
-        self.dockerfile_images = None
+        self.dockerfile_images = DockerfileImages([])
         self.parent_images_digests = {}
         self.df_path = None
         self.df_dir = None


### PR DESCRIPTION
Initialize DockerfileImages with empty list to avoid surprises like
```
AttributeError: 'NoneType' object has no attribute 'base_from_scratch'
```
when flatpak build is running.

It also reduces cyclomatic complexity, less ifs on random places due
flatpak builds.

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
