### PR TITLE
Update operator pinning plugin - other metadata replacements

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -7,7 +7,6 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import logging
-from typing import Iterator, Sequence
 
 from osbs.utils import Labels, ImageName
 
@@ -20,7 +19,8 @@ from atomic_reactor.constants import (
 from atomic_reactor.util import (RegistrySession,
                                  RegistryClient,
                                  has_operator_bundle_manifest,
-                                 read_yaml_from_url, df_parser)
+                                 read_yaml_from_url, df_parser,
+                                 terminal_key_paths,)
 from osbs.utils.yaml import (
     load_schema,
     validate_with_schema,
@@ -29,24 +29,6 @@ from atomic_reactor.plugins.pre_reactor_config import get_operator_manifests
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.utils.operator import OperatorManifest
 from atomic_reactor.utils.retries import get_retrying_requests_session
-
-
-def terminal_key_paths(obj: dict) -> Iterator[Sequence]:
-    """Generates path to all terminal keys of nested dicts by yielding
-    tuples of nested dict keys represented as path
-
-    From `{'a': {'b': {'c': 1, 'd': 2}}}` yields `('a', 'b', 'c')`, `('a', 'b', 'd')`
-    """
-    stack = [
-        (obj, tuple())
-    ]
-    while stack:
-        data, path = stack.pop()
-        if isinstance(data, dict):
-            for k, v in data.items():
-                stack.append((v, path + (k, )))
-        else:
-            yield path
 
 
 class PinOperatorDigestsPlugin(PreBuildPlugin):

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -302,6 +302,13 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
             self.log.info("Creating relatedImages section in %s", operator_csv.path)
             operator_csv.set_related_images()
 
+            operator_csv_modifications = self._fetch_operator_csv_modifications()
+            if operator_csv_modifications:
+                operator_csv.modifications_append(
+                    operator_csv_modifications.get('append', {}))
+                operator_csv.modifications_update(
+                    operator_csv_modifications.get('update', {}))
+
             operator_csv.dump()
         else:
             self.log.warning("%s has a relatedImages section, skipping", operator_csv.path)

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -16,6 +16,7 @@ import requests
 from requests.exceptions import SSLError, HTTPError, RetryError
 import shutil
 import tempfile
+from typing import Iterator, Sequence
 import logging
 import uuid
 import yaml
@@ -1870,3 +1871,21 @@ def read_fetch_artifacts_koji(workflow):
 
 def read_content_sets(workflow):
     return read_user_config_file(workflow, REPO_CONTENT_SETS_CONFIG)
+
+
+def terminal_key_paths(obj: dict) -> Iterator[Sequence]:
+    """Generates path to all terminal keys of nested dicts by yielding
+    tuples of nested dict keys represented as path
+
+    From `{'a': {'b': {'c': 1, 'd': 2}}}` yields `('a', 'b', 'c')`, `('a', 'b', 'd')`
+    """
+    stack = [
+        (obj, tuple())
+    ]
+    while stack:
+        data, path = stack.pop()
+        if isinstance(data, dict):
+            for k, v in data.items():
+                stack.append((v, path + (k, )))
+        else:
+            yield path

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -62,6 +62,7 @@ from atomic_reactor.util import (wait_for_command,
                                  allow_repo_dir_in_dockerignore,
                                  has_operator_appregistry_manifest,
                                  has_operator_bundle_manifest, DockerfileImages,
+                                 terminal_key_paths,
                                  )
 from tests.constants import (DOCKERFILE_GIT,
                              INPUT_IMAGE, MOCK, MOCK_SOURCE,
@@ -1939,3 +1940,20 @@ def test_dockerfile_images(source_registry, organization, dockerfile_images, bas
     # setting non-existing image
     with pytest.raises(KeyError):
         df_image['non-existing'] = 'test'
+
+
+@pytest.mark.parametrize('data,expected', [
+    (
+        {},
+        set()
+    ), (
+        {'a': 1},
+        {('a',)}
+    ), (
+        {'a': {'b': {'c': {'d1': 1, 'd2': 2}, 'c2': []}}},
+        {('a', 'b', 'c2'), ('a', 'b', 'c', 'd1'), ('a', 'b', 'c', 'd2')}
+    )
+])
+def test_terminal_key_paths(data, expected):
+    """Unittest for terminal_key_paths data"""
+    assert set(terminal_key_paths(data)) == expected


### PR DESCRIPTION
Take non-pullspec metadata from _fetch_operator_csv_modifications and use it to add/append/update/replace data in the OperatorManifest

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

- CLOUDBLD-4179

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
