### PR TITLE
Pass operator_csv_modifications_url param to worker build

### DIFF
--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -400,6 +400,10 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
         if self.platforms:
             self.build_kwargs['operator_manifests_extract_platform'] = list(self.platforms)[0]
 
+        op_csv_mods_url = self.workflow.user_params.get('operator_csv_modifications_url')
+        if op_csv_mods_url:
+            self.build_kwargs['operator_csv_modifications_url'] = op_csv_mods_url
+
     def validate_arrangement_version(self):
         """Validate if the arrangement_version is supported
 


### PR DESCRIPTION
Worker build also needs that param to be able fetch modifications. We
cannot distribute content directly because content may be too big and OCP
may reject it.

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
