### PR TITLE
Remove py2 compatible code from YumRepo.is_valid

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -106,6 +106,13 @@ function setup_osbs() {
   # Setuptools install atomic-reactor from source
   $RUN $PYTHON setup.py install
 
+  if (( "$OS_VERSION" < "33" )); then
+    # Since 0.13, flatpak_module_tools uses functools.cache which is only
+    # available since Python 3.9
+    $RUN "$PIP" uninstall -y flatpak_module_tools
+    $RUN "${PIP_INST[@]}" 'flatpak_module_tools<0.13'
+  fi
+
   # Pip install packages for unit tests
   $RUN "${PIP_INST[@]}" -r tests/requirements.txt
 }

--- a/tests/utils/test_yum.py
+++ b/tests/utils/test_yum.py
@@ -10,7 +10,6 @@ is done in test_add_yum_repo_by_url
 """
 from fnmatch import fnmatch
 import os
-import sys
 from atomic_reactor.utils.yum import YumRepo
 import pytest
 
@@ -32,10 +31,7 @@ def test_add_repo_to_url(repourl, add_hash, pattern):
 
 def test_invalid_config():
     repo = YumRepo('http://example.com/a/b/c/myrepo.repo', 'line noise')
-    if (sys.version_info < (3, 0)):
-        assert not repo.is_valid()
-    else:
-        assert True
+    assert not repo.is_valid()
 
 
 def test_write_content(tmpdir):


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
