### PR TITLE
Fix: add operator_csv_modifications_url to schema

### DIFF
--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -63,6 +63,7 @@
         ".*": {"type": "string"}
       }
     },
+    "operator_csv_modifications_url": {"type": "string"},
     "operator_manifests_extract_platform": {"type": "string"},
     "orchestrator_deadline": {"type": "integer"},
     "platform": {"type": "string"},


### PR DESCRIPTION
User params can be validated by schema, adding there new param

* CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
