### PR TITLE
Validate CSV modifications JSON from user

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -746,6 +746,25 @@
               "type": "string"
             },
             "examples": [null, ["centos-container", "rsyslog-container"]]
+          },
+          "csv_modifications": {
+              "description": "Section for configuration of operator CSV modifications",
+              "type": "object",
+              "properties": {
+                  "allowed_attributes": {
+                      "description": "Attributes allowed to be modified represented as sequence of nested keys",
+                      "examples": ["[[\"spec\", \"version\"], [\"metadata\", \"name\"]]"],
+                      "type": "array",
+                      "items": {
+                          "type": "array",
+                          "items": {
+                              "type": "string",
+                              "minItems": 1
+                          }
+                      }
+                  }
+              },
+              "additionalProperties": false
           }
         },
         "required": ["allowed_registries"],

--- a/atomic_reactor/schemas/operator_csv_modifications.json
+++ b/atomic_reactor/schemas/operator_csv_modifications.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "title": "Operator CSV modifications",
+
+  "type": ["object"],
+  "properties": {
+    "pullspec_replacements": {
+      "description": "Definition of the pullspecs replacements in CSV file",
+      "type": "array",
+      "items": { "$ref": "#/definitions/pullspec_replacement" }
+    },
+    "append": {
+      "type": "object",
+      "description": "A nested map of attributes and values to append into current value of their counterparts in the CSV file. Final value must be a list",
+      "examples": ["{\"spec\": { \"skips\": [\"1.0.0\"]}"],
+      "additionalProperties": {"$ref": "#/definitions/recursive_append"}
+    },
+    "update": {
+      "type": "object",
+      "description": "A nested map of attributes and values to update their counterparts in the CSV file",
+      "examples": ["\"metadata: {\"name\": \"app.v1.0.0-patched\"}\""],
+      "additionalProperties": {"$ref": "#/definitions/recursive_update"}
+    }
+  },
+  "required": ["pullspec_replacements"],
+  "additionalProperties": false,
+
+  "definitions": {
+    "pullspec_replacement": {
+      "description": "A single pullspec to be replaced",
+      "properties": {
+        "original": {
+          "type": "string",
+          "description": "An original pullspec in the CSV file",
+          "examples": ["registry.example.com/image:v1.5"]
+        },
+        "new": {
+          "type": "string",
+          "description": "An replacement of the original pullspec to be replaced in CSV file",
+          "examples": [
+            "registry.example.com/image@sha256:a0ae15b2c8b2c7ba115d37625e750848658b76bed7fa9f7e7f6a5e8ab3c71bac"
+          ]
+        },
+        "pinned": {
+          "type": "boolean",
+          "description": "true if the new pullspec has been pinned to its digest"
+        }
+      },
+      "required": ["original", "new", "pinned"]
+    },
+    "recursive_update": {
+      "description": "updates can be nested and done in recursion",
+      "anyOf": [
+        {
+          "type": ["string"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/definitions/recursive_update"}
+        }
+      ]
+    },
+    "recursive_append": {
+      "description": "appending can be nested and done in recursion",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": ["string"]
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/definitions/recursive_append"}
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
CLOUDBLD-3976

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
