### PR TITLE
Avoid flatpak_module_tools v0.13, requires python3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 docker < 4.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13
-flatpak-module-tools >= 0.11
+flatpak-module-tools >= 0.11,<0.13;python_version<"3.9"
+flatpak-module-tools >= 0.11;python_version>="3.9"
 jsonschema
 PyYAML
 ruamel.yaml

--- a/test.sh
+++ b/test.sh
@@ -106,13 +106,6 @@ function setup_osbs() {
   # Setuptools install atomic-reactor from source
   $RUN $PYTHON setup.py install
 
-  if (( "$OS_VERSION" < "33" )); then
-    # Since 0.13, flatpak_module_tools uses functools.cache which is only
-    # available since Python 3.9
-    $RUN "$PIP" uninstall -y flatpak_module_tools
-    $RUN "${PIP_INST[@]}" 'flatpak_module_tools<0.13'
-  fi
-
   # Pip install packages for unit tests
   $RUN "${PIP_INST[@]}" -r tests/requirements.txt
 }


### PR DESCRIPTION
This mirrors a change in test.sh.

Signed-off-by: mike kingsbury <mike.kingsbury@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
