### PR TITLE
OperatorCSV minor fixes

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -216,7 +216,13 @@ def modify_dict_recursively(target, mods, append=False):
     for key, value in mods.items():
         if isinstance(value, dict):
             # recursive call
-            target[key] = modify_dict_recursively(target.get(key, {}), value, append=append)
+            nested = target.get(key, {})
+            if not isinstance(nested, dict):
+                raise CSVModifyError(
+                    f"Expected nested dictionary in CSV at '{key}' "
+                    f"but got '{nested}' for {mods}"
+                )
+            target[key] = modify_dict_recursively(nested, value, append=append)
         else:
             if append:
                 field = target.setdefault(key, [])
@@ -225,6 +231,10 @@ def modify_dict_recursively(target, mods, append=False):
                     # a list for appending.
                     raise CSVModifyError('CSV value to append to is not a list'
                                          f' (found {target[key]})')
+                if not isinstance(value, list):
+                    raise CSVModifyError('Modification value to append to is '
+                                         f'not a list (found {value})')
+
                 field.extend(value)
             else:
                 target[key] = value

--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -230,10 +230,10 @@ def modify_dict_recursively(target, mods, append=False):
                     # There's a type mismatch in the original CSV - we only *ever* allow
                     # a list for appending.
                     raise CSVModifyError('CSV value to append to is not a list'
-                                         f' (found {target[key]})')
+                                         f' (found {target[key]}) in {target}')
                 if not isinstance(value, list):
                     raise CSVModifyError('Modification value to append to is '
-                                         f'not a list (found {value})')
+                                         f'not a list (found {value}) in {mods}')
 
                 field.extend(value)
             else:

--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -786,7 +786,8 @@ class OperatorCSV(object):
 
         Also checks the result against schema.
 
-        :param append_mods: a dict
+        :param append_mods: a dict (or nested dictionaries) that contains changes to be
+                            applied to CSV. Values of terminal dict mus be lists.
         :return: None; this modifies 'self.data' in-place
         """
         modify_dict_recursively(self.data, append_mods, append=True)
@@ -797,7 +798,8 @@ class OperatorCSV(object):
 
         Also checks the result against schema.
 
-        :param update_mods: a dict
+        :param update_mods: a dict (or nested dictionaries) that contains changes to be
+                            applied to CSV.
         :return: None; this modifies 'self.data' in-place
         """
         modify_dict_recursively(self.data, update_mods)

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -1174,6 +1174,70 @@ class TestOperatorCSV(object):
         csv = OperatorCSV('csv.yaml', csv_content)
         assert expected_pullspecs == csv.get_related_image_pullspecs()
 
+    @pytest.mark.parametrize('csv_content,mods,expected', [
+        (
+            {}, {}, {}
+        ),
+        (
+            {}, {'t': 'this'}, {'t': 'this'}
+        ),
+        (
+            {'e': 'exists'}, {'a': 'another'}, {'e': 'exists', 'a': 'another'}
+        ),
+        (
+            {'e': 'exists'}, {'e': 'replaced'}, {'e': 'replaced'}
+        ),
+        (
+            {'n': {'t1': 1}},
+            {'n': {'t2': {'x': 'added'}}},
+            {'n': {'t1': 1, 't2': {'x': 'added'}}}
+        ),
+        (
+            {'n': {}},
+            {'n': {'nn': {'nnn': 'nested'}}},
+            {'n': {'nn': {'nnn': 'nested'}}}
+        ),
+    ])
+    def test_modifications_update(self, csv_content, mods, expected):
+        """Tests for modification_update"""
+        self._mock_check_csv()
+        csv = OperatorCSV('csv.yaml', csv_content)
+        csv.modifications_update(mods)
+        assert csv.data == expected
+
+    @pytest.mark.parametrize('csv_content,mods,expected', [
+        (
+            {}, {}, {}
+        ),
+        (
+            {}, {'t': ['this']}, {'t': ['this']}
+        ),
+        (
+            {'e': 'exists'}, {'a': ['another']}, {'e': 'exists', 'a': ['another']}
+        ),
+        (
+            {'e': ['exists']},
+            {'e': ['added1', 'added2']},
+            {'e': ['exists', 'added1', 'added2']}
+        ),
+        (
+            {'n': {'t1': 1}},
+            {'n': {'t2': {'x': ['added']}}},
+            {'n': {'t1': 1, 't2': {'x': ['added']}}}
+        ),
+        (
+            {'n': {}},
+            {'n': {'nn': {'nnn': ['nested']}}},
+            {'n': {'nn': {'nnn': ['nested']}}}
+        ),
+    ])
+    def test_modifications_append(self, csv_content, mods, expected):
+        """Tests for modification_append"""
+        self._mock_check_csv()
+        csv = OperatorCSV('csv.yaml', csv_content)
+        csv.modifications_append(mods)
+        assert csv.data == expected
+
 
 class TestOperatorManifest(object):
     def test_from_directory_multiple_csvs(self, tmpdir):

--- a/tests/utils/test_operator.py
+++ b/tests/utils/test_operator.py
@@ -1263,12 +1263,12 @@ class TestOperatorCSV(object):
         (
             {'t': 1},
             {'t': [2]},
-            "CSV value to append to is not a list (found 1)"
+            "CSV value to append to is not a list (found 1) in {'t': 1}"
         ),
         (
             {'t': [1]},
             {'t': 2},
-            "Modification value to append to is not a list (found 2)"
+            "Modification value to append to is not a list (found 2) in {'t': 2}"
         ),
     ])
     def test_modifications_append_failures(self, csv_content, mods, err_msg):


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
