### PR TITLE
Get cachito request env vars from cachito API

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -115,14 +115,18 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
 
         for env_var, value_info in env_vars.items():
             build_arg_value = value_info['value']
-            if value_info['kind'] == 'path':
+            kind = value_info['kind']
+            if kind == 'path':
                 build_arg_value = os.path.join(REMOTE_SOURCE_DIR, value_info['value'])
                 self.log.debug(
                     'Setting the Cachito environment variable "%s" to the absolute path "%s"',
                     env_var,
                     build_arg_value,
                 )
-            build_args[env_var] = build_arg_value
+            elif kind == 'literal':
+                build_args[env_var] = build_arg_value
+            else:
+                raise RuntimeError(f'Unknown kind {kind} got from Cachito.')
 
         # Alias for absolute path to cachito.env script added into buildargs
         build_args[CACHITO_ENV_ARG_ALIAS] = os.path.join(REMOTE_SOURCE_DIR, CACHITO_ENV_FILENAME)

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -201,6 +201,29 @@ class CachitoAPI(object):
             return request['id']
         raise ValueError('Unexpected request type: {}'.format(request))
 
+    def get_request_env_vars(self, rid):
+        """Get the environment variables from endpoint /requests/$id/environment-variables
+
+        :param int rid: the Cachito request id whose environment variables will
+            be returned.
+        :return: a mapping containing the environment variables. For example:
+            ``{"GOCACHE": {"kind": "path", "value": "deps/gomod"}, ...}``.
+        :rtype: dict[str, dict[str, str]]
+        :raises: TypeError if the server does not response a JSON data to be
+            parsed.
+        :raises: HTTP error raised from the underlying requests library in any
+            case of the request cannot be completed.
+        """
+        endpoint = f'{self.api_url}/api/v1/requests/{rid}/environment-variables'
+        resp = self.session.get(endpoint)
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except Exception as exc:
+            msg = (f'JSON data is expected from Cachito endpoint {endpoint}, '
+                   f'but the response contains: {resp.content}.')
+            raise ValueError(msg) from exc
+
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -319,6 +319,22 @@ def test_resolve_remote_source(workflow, scratch, dr_strs, dependency_replacemen
     )
 
 
+@pytest.mark.parametrize(
+    'env_vars_json',
+    [
+        {
+            'GOPATH': {'kind': 'path', 'value': 'deps/gomod'},
+            'GOCACHE': {'kind': 'path', 'value': 'deps/gomod'},
+            'GO111MODULE': {'kind': 'literal', 'value': 'on'},
+            'GOX': {'kind': 'new', 'value': 'new-kind'},
+        },
+    ]
+)
+def test_fail_build_if_unknown_kind(workflow, env_vars_json):
+    mock_cachito_api(workflow, env_vars_json=env_vars_json)
+    run_plugin_with_args(workflow, expect_error=r'.*Unknown kind new got from Cachito')
+
+
 @pytest.mark.parametrize('build_json', ({}, {'metadata': {}}))
 def test_no_koji_user(workflow, build_json, caplog):
     reactor_config = dedent("""\


### PR DESCRIPTION
* CLOUDBLD-3961

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
