### PR TITLE
fetch kojifile sources from middleware builds and add them layer by layer to source image

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -160,6 +160,9 @@ MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST = "application/vnd.docker.distribution.manife
 MEDIA_TYPE_OCI_V1 = "application/vnd.oci.image.manifest.v1+json"
 MEDIA_TYPE_OCI_V1_INDEX = "application/vnd.oci.image.index.v1+json"
 
+# PNC related constants
+PNC_SYSTEM_USER = "newcastle"
+
 REPO_CONTAINER_CONFIG = 'container.yaml'
 REPO_CONTENT_SETS_CONFIG = 'content_sets.yml'
 REPO_FETCH_ARTIFACTS_URL = 'fetch-artifacts-url.yaml'

--- a/atomic_reactor/plugins/post_generate_maven_metadata.py
+++ b/atomic_reactor/plugins/post_generate_maven_metadata.py
@@ -123,7 +123,7 @@ class GenerateMavenMetadataPlugin(PostBuildPlugin):
         for index, download in enumerate(download_queue):
             dest_filename = download.dest
             if not re.fullmatch(r'^[\w\-.]+$', dest_filename):
-                dest_filename = session.get(download.url).headers.get(
+                dest_filename = session.head(download.url).headers.get(
                     "Content-disposition").split("filename=")[1].replace('"', '')
 
             dest_path = os.path.join(downloads_path, dest_filename)

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -65,6 +65,10 @@ def get_koji(workflow):
     return koji_map
 
 
+def get_pnc(workflow):
+    return get_value(workflow, 'pnc', NO_FALLBACK)
+
+
 def get_koji_session(workflow):
     config = get_koji(workflow)
 

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -135,6 +135,22 @@
         "additionalProperties": false,
         "required": ["hub_url", "root_url", "auth"]
     },
+    "pnc": {
+        "description": "Project Newcastle instance",
+        "type": "object",
+        "properties": {
+            "base_api_url": {
+                "description": "Project Newcastle API base url",
+                "type": "string"
+            },
+            "get_scm_archive_path": {
+                "description": "Project Newcastle API path to get scm archive for given build ID",
+                "type": "string"
+            }
+        },
+        "additionalProperties": false,
+        "required": ["base_api_url", "get_scm_archive_path"]
+    },
     "pulp": {
         "description": "Pulp registry instance (deprecated)",
         "type": "object",

--- a/atomic_reactor/utils/pnc.py
+++ b/atomic_reactor/utils/pnc.py
@@ -1,0 +1,41 @@
+"""
+Copyright (c) 2021 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import os
+import re
+
+from atomic_reactor.util import get_retrying_requests_session
+
+
+def get_scm_archive_from_build_id(api_request_url: str, build_id: str, session=None):
+    """
+    Return a scm archive URL and filename from PNC REST API.
+    :param api_request_url: str, format string to form request url
+    :param build_id: str PNC build id
+    :param session: existing requests session to use
+    :return str, str URL and filename of the scm archive
+    :rtype str, str, URL and filename
+    """
+    if not session:
+        session = get_retrying_requests_session()
+
+    # This endpoint for the API is redirected to the actual source URL which
+    #  we don't want to download yet, so we're disabling the redirect to just
+    #  get the redirect location in response header
+    response = session.get(api_request_url.format(build_id), allow_redirects=False)
+    response.raise_for_status()
+
+    url = response.headers.get('Location')
+    dest_filename = os.path.basename(url)
+
+    # Often the SCM URL will be gerrit URL which do no have the filename in URL
+    # So we'll have to get the filename from the header if it's not valid.
+    if not re.fullmatch(r'^[\w\-.]+$', dest_filename):
+        dest_filename = session.head(url).headers.get(
+            "Content-disposition").split("filename=")[1].replace('"', '')
+
+    return url, dest_filename

--- a/tests/plugins/test_generate_maven_metadata.py
+++ b/tests/plugins/test_generate_maven_metadata.py
@@ -327,6 +327,10 @@ def mock_url_downloads(remote_files=None, overrides=None):
         body = remote_file_overrides.get('body', url)
         headers = remote_file_overrides.get('headers', {})
         status = remote_file_overrides.get('status', 200)
+        head = remote_file_overrides.get('head', False)
+        if head:
+            responses.add(responses.HEAD, url, body='', status=status,
+                          headers=headers)
         responses.add(responses.GET, url, body=body, status=status,
                       headers=headers)
 
@@ -403,7 +407,8 @@ def test_generate_maven_metadata_source_url_no_headers(tmpdir, docker_tasker, us
                    'md5': 'b1605c846e03035a6538873e993847e5',
                    'source-md5': '927c5b0c62a57921978de1a0421247ea'}
     mock_fetch_artifacts_by_url(tmpdir, contents=yaml.safe_dump([remote_file]))
-    mock_url_downloads(remote_files=[remote_file])
+    mock_url_downloads(remote_files=[remote_file],
+                       overrides={remote_file['source-url']: {'head': True}})
 
     with pytest.raises(PluginFailedException) as e:
         mock_env(tmpdir).create_runner(docker_tasker).run()
@@ -425,7 +430,8 @@ def test_generate_maven_metadata_source_url_no_filename_in_headers(tmpdir, docke
     mock_fetch_artifacts_by_url(tmpdir, contents=yaml.safe_dump([remote_file]))
     mock_url_downloads(remote_files=[remote_file],
                        overrides={remote_file['source-url']:
-                                  {'headers': {'Content-disposition': 'no filename'}}})
+                                  {'headers': {'Content-disposition': 'no filename'},
+                                   'head': True}})
 
     with pytest.raises(PluginFailedException) as e:
         mock_env(tmpdir).create_runner(docker_tasker).run()

--- a/tests/utils/test_pnc.py
+++ b/tests/utils/test_pnc.py
@@ -1,0 +1,61 @@
+"""
+Copyright (c) 2021 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from io import BufferedReader, BytesIO
+
+import pytest
+import requests
+import responses
+from flexmock import flexmock
+
+from atomic_reactor.util import get_retrying_requests_session
+from atomic_reactor.utils.pnc import get_scm_archive_from_build_id
+
+
+class TestGetSCMArchiveFromBuildID(object):
+    @responses.activate
+    def test_connection_filename_in_header(self):
+        base_api_url = 'https://example.com/{}/scm_archive'
+        build_id = '1234'
+        filename = 'source.tar.gz'
+        scm_url = f'https://code.example.com/{filename};sf=tgz'
+        content = b'abc'
+        reader = BufferedReader(BytesIO(content), buffer_size=1)
+        responses.add(responses.GET, base_api_url.format(build_id), body=reader, status=302,
+                      headers={'Location': scm_url})
+        responses.add(responses.HEAD, scm_url, body='', status=200,
+                      headers={'Content-disposition': f'filename="{filename}"'})
+        url, dest_filename = get_scm_archive_from_build_id(base_api_url, build_id)
+
+        assert url == scm_url
+        assert dest_filename == filename
+
+    @responses.activate
+    def test_connection_filename_in_url(self):
+        base_api_url = 'https://example.com/{}/scm_archive'
+        build_id = '1234'
+        filename = 'source.tar.gz'
+        scm_url = f'https://code.example.com/{filename}'
+
+        responses.add(responses.GET, base_api_url.format(build_id), body='', status=302,
+                      headers={'Location': scm_url})
+
+        url, dest_filename = get_scm_archive_from_build_id(base_api_url, build_id)
+
+        assert url == scm_url
+        assert dest_filename == filename
+
+    def test_connection_failure(self):
+        base_api_url = 'https://example.com/{}/scm_archive'
+        build_id = '1234'
+        session = get_retrying_requests_session()
+        (flexmock(session)
+         .should_receive('get')
+         .and_raise(requests.exceptions.RetryError))
+        with pytest.raises(requests.exceptions.RetryError):
+            get_scm_archive_from_build_id(base_api_url, build_id, session=session)


### PR DESCRIPTION
Fetch middleware sources using kojifile component metadata in image output and build source image using those sources

Epic MMENG-829
Story MMENG-1276

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
