### PR TITLE
Fail cachito build if remote_sources was specified in container.yaml

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -71,6 +71,10 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
             self.log.info('Aborting plugin execution: missing Cachito configuration')
             return
 
+        if self.workflow.source.config.remote_sources:
+            raise ValueError('Multiple remote sources are not supported, use single '
+                             'remote source in container.yaml')
+
         remote_source_params = self.workflow.source.config.remote_source
         if not remote_source_params:
             self.log.info('Aborting plugin execution: missing remote_source configuration')

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -68,6 +68,7 @@ class SourceConfig(object):
                .format(meth, REPO_CONTAINER_CONFIG)
         )
         self.remote_source = self.data.get('remote_source')
+        self.remote_sources = self.data.get('remote_sources')
         self.operator_manifests = self.data.get('operator_manifests')
 
 

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -424,6 +424,23 @@ def test_bad_build_metadata(workflow, build_json, log_entry, caplog):
     assert 'unknown_user' in caplog.text
 
 
+def test_remote_sources_in_config_fail(workflow):
+    container_yaml_config = dedent("""\
+            remote_sources:
+            - name: a-remote-source
+              remote-_source:
+                repo: https://some.repo/here.git
+                ref: e1be527f39ec31323f0454f7d1422c6260b00580
+            """)
+    err_msg = (
+        "Multiple remote sources are not supported, "
+        "use single remote source in container.yaml"
+    )
+    mock_repo_config(workflow, data=container_yaml_config)
+    result = run_plugin_with_args(workflow, expect_result=False, expect_error=err_msg)
+    assert result is None
+
+
 def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=None,
                          expect_result=True, expected_build_args=None):
     runner = PreBuildPluginsRunner(


### PR DESCRIPTION
CLOUDBLD-4448

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
