### PR TITLE
fix failure when worker_metadatas are not available

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -376,12 +376,6 @@ class KojiImportBase(ExitPlugin):
         worker_metadatas = self.workflow.postbuild_results.get(PLUGIN_FETCH_WORKER_METADATA_KEY)
         maven_components = get_maven_components(self.workflow)
 
-        # add maven components alongside RPM components
-        for platform in worker_metadatas.keys():
-            for worker_output in worker_metadatas[platform]['output']:
-                if worker_output['type'] == 'docker-image':
-                    worker_output['components'] += maven_components
-
         build = self.get_build(metadata, worker_metadatas)
         buildroot = self.get_buildroot(worker_metadatas)
         buildroot_id = buildroot[0]['id']
@@ -393,6 +387,11 @@ class KojiImportBase(ExitPlugin):
         output.extend([of.metadata for of in output_files])
         if output_file:
             output_files.append(output_file)
+
+        # add maven components alongside RPM components
+        for worker_output in output:
+            if worker_output['type'] == 'docker-image':
+                worker_output['components'] += maven_components
 
         # add remote source tarball and remote-source.json files to output
         for remote_source_output in [


### PR DESCRIPTION
During source image build worker_metadatas are NoneType

Append components to process output instead to avoid this
error.

MMENG-1275

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
