### PR TITLE
Fix: requests.head doesn't follow redirects by default

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -341,7 +341,8 @@ class FetchSourcesPlugin(PreBuildPlugin):
             for sigkey in sigkeys:
                 # koji uses lowercase for paths. We make sure the sigkey is in lower case
                 url_candidate = self.assemble_srpm_url(base_url, srpm_filename, sigkey.lower())
-                request = req_session.head(url_candidate, verify=not insecure)
+                # allow redirects, head call doesn't do it by default
+                request = req_session.head(url_candidate, verify=not insecure, allow_redirects=True)
                 if request.ok:
                     srpm_urls.append({'url': url_candidate})
                     self.log.debug('%s is available for signing key "%s"', srpm_filename, sigkey)


### PR DESCRIPTION
If redirect is in place, it provides false positive results because HEAD
doesn't follow redirects by default

CLOUDBLD-5043

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
