### PR TITLE
Fix: requests.head doesn't follow redirects by default (2)

### DIFF
--- a/atomic_reactor/utils/manifest.py
+++ b/atomic_reactor/utils/manifest.py
@@ -96,7 +96,8 @@ class ManifestUtil(object):
 
         # Check that it exists in the source repository
         url = "/v2/{}/blobs/{}".format(source_repo, digest)
-        result = session.head(url)
+        # allow redirects, head call doesn't do it by default
+        result = session.head(url, allow_redirects=True)
         if result.status_code == requests.codes.NOT_FOUND:
             self.log.debug("%s: blob %s, not present in %s, skipping",
                            session.registry, digest, source_repo)


### PR DESCRIPTION
If redirect is in place, it provides false positive results because HEAD
doesn't follow redirects by default

Related issue  CLOUDBLD-5043

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
