### PR TITLE
Fix issues in resolve remote source plugin

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -123,7 +123,13 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
                     env_var,
                     build_arg_value,
                 )
+                build_args[env_var] = build_arg_value
             elif kind == 'literal':
+                self.log.debug(
+                    'Setting the Cachito environment variable "%s" to a literal value "%s"',
+                    env_var,
+                    build_arg_value,
+                )
                 build_args[env_var] = build_arg_value
             else:
                 raise RuntimeError(f'Unknown kind {kind} got from Cachito.')

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -453,8 +453,8 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
         worker_params = orchestrator_build_workspace[WORKSPACE_KEY_OVERRIDE_KWARGS][None]
         assert worker_params['remote_source_url'] == CACHITO_REQUEST_DOWNLOAD_URL
         assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIG_URL
-        assert worker_params['remote_source_build_args'] == \
-            expected_build_args or CACHITO_BUILD_ARGS
+        expected = expected_build_args or CACHITO_BUILD_ARGS
+        assert worker_params['remote_source_build_args'] == expected
         assert worker_params['remote_source_icm_url'] == CACHITO_ICM_URL
 
     return results


### PR DESCRIPTION
* Add the missing code to add the path value to build args.
* Logging for adding the literal environment variable to build args.
* Fix a wrong assertion in test.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
