### PR TITLE
Update plugins to consume remote_sources parameter

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -224,6 +224,27 @@ class CachitoAPI(object):
                    f'but the response contains: {resp.content}.')
             raise ValueError(msg) from exc
 
+    def get_image_content_manifest(self, request_ids):
+        """
+        Get the image content manifest from endpoint /content-manifest
+        :param list[int] request_ids: cachito request ids
+        :return: image content manifest data
+        :rtype: dict
+        :raises: TypeError if the server does not response a JSON data to be
+            parsed.
+        :raises: HTTP error raised from the underlying requests library in any
+            case of the request cannot be completed.
+        """
+        endpoint = f'{self.api_url}/api/v1/content-manifest'
+        resp = self.session.get(endpoint, params={'requests': ','.join(map(str, request_ids))})
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except Exception as exc:
+            msg = (f'JSON data is expected from Cachito endpoint {endpoint}, '
+                   f'but the response contains: {resp.content}.')
+            raise ValueError(msg) from exc
+
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -41,7 +41,7 @@ CACHITO_REQUEST_CONFIG_URL = '{}/api/v1/requests/{}/configuration-files'.format(
     CACHITO_URL,
     CACHITO_REQUEST_ID
 )
-CACHITO_ICM_URL = '{}/api/v1/requests/{}/content-manifest'.format(
+CACHITO_ICM_URL = '{}/api/v1/content-manifest?requests={}'.format(
     CACHITO_URL,
     CACHITO_REQUEST_ID
 )
@@ -468,10 +468,14 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
         # Let's verify the expected side effects.
         orchestrator_build_workspace = workflow.plugin_workspace[OrchestrateBuildPlugin.key]
         worker_params = orchestrator_build_workspace[WORKSPACE_KEY_OVERRIDE_KWARGS][None]
-        assert worker_params['remote_source_url'] == CACHITO_REQUEST_DOWNLOAD_URL
-        assert worker_params['remote_source_configs'] == CACHITO_REQUEST_CONFIG_URL
-        expected = expected_build_args or CACHITO_BUILD_ARGS
-        assert worker_params['remote_source_build_args'] == expected
-        assert worker_params['remote_source_icm_url'] == CACHITO_ICM_URL
+        expected_build_args = expected_build_args or CACHITO_BUILD_ARGS
+        expected_worker_params = [{
+            'build_args': expected_build_args,
+            'configs': CACHITO_REQUEST_CONFIG_URL,
+            'request_id': CACHITO_REQUEST_ID,
+            'url': CACHITO_REQUEST_DOWNLOAD_URL,
+            'name': None,
+        }]
+        assert worker_params['remote_sources'] == expected_worker_params
 
     return results


### PR DESCRIPTION
CLOUDBLD-4449

Instead of receiving individual parameters related to
remote_sources such as build_args, configs, icm_url, url
plugins will now receive only one parameter that is a list of dicts
with these values.

For now only first element of the list will be used -
remote_sources[0] as multiple remote_sources are not yet supported.

This is in preparation for completing cachito-multiple-upstreams epic
CLOUDBLD-2838

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
