### PR TITLE
convert utils/pnc.py to a class and initialize only when needed

### DIFF
--- a/atomic_reactor/utils/pnc.py
+++ b/atomic_reactor/utils/pnc.py
@@ -11,31 +11,39 @@ import re
 from atomic_reactor.util import get_retrying_requests_session
 
 
-def get_scm_archive_from_build_id(api_request_url: str, build_id: str, session=None):
-    """
-    Return a scm archive URL and filename from PNC REST API.
-    :param api_request_url: str, format string to form request url
-    :param build_id: str PNC build id
-    :param session: existing requests session to use
-    :return str, str URL and filename of the scm archive
-    :rtype str, str, URL and filename
-    """
-    if not session:
-        session = get_retrying_requests_session()
+class PNCUtil(object):
 
-    # This endpoint for the API is redirected to the actual source URL which
-    #  we don't want to download yet, so we're disabling the redirect to just
-    #  get the redirect location in response header
-    response = session.get(api_request_url.format(build_id), allow_redirects=False)
-    response.raise_for_status()
+    def __init__(self, pnc_map, session=None):
+        if not session:
+            self.session = get_retrying_requests_session()
+        else:
+            self.session = session
+        self.base_api_url = pnc_map['base_api_url']
+        # using urljoin here causes the API path in the base_api_url to be removed
+        self.get_scm_archive_request_url = self.base_api_url + '/' + pnc_map['get_scm_archive_path']
 
-    url = response.headers.get('Location')
-    dest_filename = os.path.basename(url)
+    def get_scm_archive_from_build_id(self, build_id: str):
+        """
+        Return a scm archive URL and filename from PNC REST API.
+        :param build_id: str PNC build id
+        :return str, str URL and filename of the scm archive
+        :rtype str, str, URL and filename
+        """
 
-    # Often the SCM URL will be gerrit URL which do no have the filename in URL
-    # So we'll have to get the filename from the header if it's not valid.
-    if not re.fullmatch(r'^[\w\-.]+$', dest_filename):
-        dest_filename = session.head(url).headers.get(
-            "Content-disposition").split("filename=")[1].replace('"', '')
+        # This endpoint for the API is redirected to the actual source URL which
+        #  we don't want to download yet, so we're disabling the redirect to just
+        #  get the redirect location in response header
+        response = self.session.get(self.get_scm_archive_request_url.format(build_id),
+                                    allow_redirects=False)
+        response.raise_for_status()
 
-    return url, dest_filename
+        url = response.headers.get('Location')
+        dest_filename = os.path.basename(url)
+
+        # Often the SCM URL will be gerrit URL which do no have the filename in URL
+        # So we'll have to get the filename from the header if it's not valid.
+        if not re.fullmatch(r'^[\w\-.]+$', dest_filename):
+            dest_filename = self.session.head(url).headers.get(
+                "Content-disposition").split("filename=")[1].replace('"', '')
+
+        return url, dest_filename

--- a/tests/plugins/test_fetch_sources.py
+++ b/tests/plugins/test_fetch_sources.py
@@ -574,6 +574,26 @@ class TestFetchSources(object):
 
         assert msg in str(exc.value)
 
+    def test_no_pnc_config_for_pnc_build(self, requests_mock, docker_tasker, koji_session, tmpdir):
+        mock_koji_manifest_download(tmpdir, requests_mock)
+
+        r_c_m = dedent("""\
+            version: 1
+            koji:
+               hub_url: {}
+               root_url: {}
+               auth:
+                   ssl_certs_dir: not_needed_here
+            """.format(KOJI_HUB, KOJI_ROOT))
+
+        with pytest.raises(PluginFailedException) as exc:
+            mock_env(tmpdir, docker_tasker, koji_build_id=KOJI_PNC_BUILD['build_id'],
+                     config_map=r_c_m).run()
+
+        msg = 'No PNC configuration found in reactor config map'
+
+        assert msg in str(exc.value)
+
     @pytest.mark.parametrize('signing_key', [None, 'usedKey'])
     @pytest.mark.parametrize('srpm_filename', [
         'baz-1-1.src.rpm',

--- a/tests/utils/test_pnc.py
+++ b/tests/utils/test_pnc.py
@@ -14,48 +14,69 @@ import responses
 from flexmock import flexmock
 
 from atomic_reactor.util import get_retrying_requests_session
-from atomic_reactor.utils.pnc import get_scm_archive_from_build_id
+from atomic_reactor.utils.pnc import PNCUtil
+
+PNC_BASE_API_URL = 'http://pnc.localhost/pnc-rest/v2'
+PNC_GET_SCM_ARCHIVE_PATH = 'builds/{}/scm-archive'
 
 
+def mock_pnc_map():
+    return {'base_api_url': PNC_BASE_API_URL,
+            'get_scm_archive_path': PNC_GET_SCM_ARCHIVE_PATH}
+
+
+@pytest.mark.usefixtures('user_params')
 class TestGetSCMArchiveFromBuildID(object):
+
     @responses.activate
     def test_connection_filename_in_header(self):
-        base_api_url = 'https://example.com/{}/scm_archive'
         build_id = '1234'
         filename = 'source.tar.gz'
         scm_url = f'https://code.example.com/{filename};sf=tgz'
         content = b'abc'
         reader = BufferedReader(BytesIO(content), buffer_size=1)
-        responses.add(responses.GET, base_api_url.format(build_id), body=reader, status=302,
-                      headers={'Location': scm_url})
+        # to mock this URL we have to construct it manually first
+        get_scm_archive_request_url = PNC_BASE_API_URL + '/' + PNC_GET_SCM_ARCHIVE_PATH
+
+        responses.add(responses.GET, get_scm_archive_request_url.format(build_id), body=reader,
+                      status=302, headers={'Location': scm_url})
         responses.add(responses.HEAD, scm_url, body='', status=200,
                       headers={'Content-disposition': f'filename="{filename}"'})
-        url, dest_filename = get_scm_archive_from_build_id(base_api_url, build_id)
+
+        pnc_util = PNCUtil(mock_pnc_map())
+
+        url, dest_filename = pnc_util.get_scm_archive_from_build_id(build_id)
 
         assert url == scm_url
         assert dest_filename == filename
 
     @responses.activate
     def test_connection_filename_in_url(self):
-        base_api_url = 'https://example.com/{}/scm_archive'
         build_id = '1234'
         filename = 'source.tar.gz'
         scm_url = f'https://code.example.com/{filename}'
+        # to mock this URL we have to construct it manually first
+        get_scm_archive_request_url = PNC_BASE_API_URL + '/' + PNC_GET_SCM_ARCHIVE_PATH
 
-        responses.add(responses.GET, base_api_url.format(build_id), body='', status=302,
-                      headers={'Location': scm_url})
+        responses.add(responses.GET, get_scm_archive_request_url.format(build_id), body='',
+                      status=302, headers={'Location': scm_url})
 
-        url, dest_filename = get_scm_archive_from_build_id(base_api_url, build_id)
+        pnc_util = PNCUtil(mock_pnc_map())
+
+        url, dest_filename = pnc_util.get_scm_archive_from_build_id(build_id)
 
         assert url == scm_url
         assert dest_filename == filename
 
     def test_connection_failure(self):
-        base_api_url = 'https://example.com/{}/scm_archive'
         build_id = '1234'
         session = get_retrying_requests_session()
+
         (flexmock(session)
          .should_receive('get')
          .and_raise(requests.exceptions.RetryError))
+
+        pnc_util = PNCUtil(mock_pnc_map(), session)
+
         with pytest.raises(requests.exceptions.RetryError):
-            get_scm_archive_from_build_id(base_api_url, build_id, session=session)
+            pnc_util.get_scm_archive_from_build_id(build_id)


### PR DESCRIPTION
MMENG-1276

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
