### PR TITLE
No more todos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .coverage
 .coverage.*
 htmlcov
+__pytest_reports

--- a/.pylintrc
+++ b/.pylintrc
@@ -35,7 +35,6 @@ disable=I,
         broad-except,
         comprehension-escape, # throws false positives on 1.9.0 (Fedora 29)
         deprecated-lambda,  # nice to have
-        fixme,
         import-outside-toplevel,
         import-error,  # requires to having all modules installed
         invalid-name,

--- a/atomic_reactor/core.py
+++ b/atomic_reactor/core.py
@@ -99,9 +99,6 @@ class BuildContainerFactory(object):
             raise RuntimeError("Provided build image doesn't exist: '%s'" % image)
 
     def _obtain_source_from_path_if_needed(self, local_path, container_path=CONTAINER_SHARE_PATH):
-        # TODO: maybe we should do this for any provider? If we expand to various providers
-        # like mercurial, then we don't want to force the container to have mercurial
-        # installed, etc.
         build_json_path = os.path.join(local_path, BUILD_JSON)
         with open(build_json_path, 'r') as fp:
             build_json = json.load(fp)
@@ -515,7 +512,7 @@ class DockerTasker(CommonTasker):
         try:
             clone_git_repo(url, temp_dir, git_commit)
             build_file_path, build_file_dir = figure_out_build_file(temp_dir, git_path)
-            if copy_dockerfile_to:  # TODO: pre build plugin
+            if copy_dockerfile_to:
                 shutil.copyfile(build_file_path, copy_dockerfile_to)
             response = self.build_image_from_path(build_file_dir, image, use_cache=use_cache,
                                                   buildargs=buildargs)

--- a/atomic_reactor/outer.py
+++ b/atomic_reactor/outer.py
@@ -81,7 +81,6 @@ class BuildManager(BuilderStateMachine):
         """
         if self.temp_dir:
             dt = DockerTasker()
-            # FIXME: load results only when requested
             # results_path = os.path.join(self.temp_dir, RESULTS_JSON)
             # df_path = os.path.join(self.temp_dir, 'Dockerfile')
             # try:

--- a/atomic_reactor/plugins/build_imagebuilder.py
+++ b/atomic_reactor/plugins/build_imagebuilder.py
@@ -34,7 +34,6 @@ class ImagebuilderPlugin(BuildStepPlugin):
         builder = self.workflow.builder
 
         image = builder.image.to_str()
-        # TODO: directly invoke go imagebuilder library in shared object via python module
 
         allow_repo_dir_in_dockerignore(builder.df_dir)
 

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -229,7 +229,6 @@ class KojiImportBase(ExitPlugin):
             }
             extra.setdefault('typeinfo', {}).update(remote_source_typeinfo)
 
-            # TODO: is setting it in the image metadata also needed?
             extra['image']['remote_source_url'] = url
 
     def set_remote_source_file_metadata(self, extra):

--- a/atomic_reactor/plugins/exit_remove_built_image.py
+++ b/atomic_reactor/plugins/exit_remove_built_image.py
@@ -44,8 +44,6 @@ class GarbageCollectionPlugin(ExitPlugin):
             self.remove_image(image, force=True)
 
         if self.remove_base_image and self.workflow.pulled_base_images:
-            # FIXME: we may need to add force here, let's try it like this for now
-            # FIXME: when ID of pulled img matches an ID of an image already present, don't remove
             for base_image_tag in self.workflow.pulled_base_images:
                 self.remove_image(base_image_tag, force=False)
 

--- a/atomic_reactor/plugins/post_compress.py
+++ b/atomic_reactor/plugins/post_compress.py
@@ -39,7 +39,6 @@ class CompressPlugin(PostBuildPlugin):
     key = 'compress'
     is_allowed_to_fail = False
 
-    # TODO: add remove_former_image?
     def __init__(self, tasker, workflow, load_exported_image=False, method='gzip'):
         """
         :param tasker: ContainerTasker instance

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -79,7 +79,6 @@ class Source(object):
         self.uri = uri
         self.dockerfile_path = dockerfile_path
         self.provider_params = provider_params or {}
-        # TODO: do we want to delete tmpdir when destroying the object?
         self.tmpdir = tmpdir or tempfile.mkdtemp()
         logger.debug("workdir is %r", self.tmpdir)
         parsed_uri = urlparse(uri)
@@ -116,7 +115,6 @@ class Source(object):
         raise NotImplementedError('Must override in subclasses!')
 
     def get_build_file_path(self):
-        # TODO: will we need figure_out_build_file as a separate method?
         return util.figure_out_build_file(self.path, self.dockerfile_path)
 
     @property

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -272,10 +272,9 @@ def process_substitutions(mapping, substitutions):
         structure of given mapping.
     Also note: For non-plugin substitutions, additional dicts/key/value pairs
         are created on the way if they're missing. For plugin substitutions, only
-        existing values can be changed (TODO: do we want to change this behaviour?).
+        existing values can be changed.
     """
     def parse_val(v):
-        # TODO: do we need to recognize numbers,lists,dicts?
         if v.lower() == 'true':
             return True
         elif v.lower() == 'false':

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -332,7 +332,6 @@ class TestPinOperatorDigest(object):
         msg = "operator_manifests configuration missing in container.yaml"
         assert msg in str(exc_info.value)
 
-    # FIXME: !!!
     @pytest.mark.parametrize('orchestrator', [True, False])
     @pytest.mark.parametrize('manifests_dir, symlinks', [
         ('foo', {'foo': '/tmp/foo'}),
@@ -421,7 +420,6 @@ class TestPinOperatorDigest(object):
         assert "Missing ClusterServiceVersion in operator manifests" in str(exc_info.value)
 
     def test_orchestrator_disallowed_registry(self, docker_tasker, tmpdir):
-        # TODO: ImageName parses x/y as namespace/repo and not registry/repo - does it matter?
         pullspecs = ['allowed-registry/ns/foo:1', 'disallowed-registry/ns/bar:2']
         mock_operator_csv(tmpdir.join(OPERATOR_MANIFESTS_DIR).mkdir(), 'csv.yaml', pullspecs)
 

--- a/tests/test_tasker.py
+++ b/tests/test_tasker.py
@@ -39,7 +39,7 @@ input_image_name = ImageName.parse(INPUT_IMAGE)
 def setup_module(module):
     if MOCK:
         return
-    d = docker.Client()  # TODO: current version of python-docker does not have Client anymore
+    d = docker.Client()
     try:
         d.inspect_image(INPUT_IMAGE)
         setattr(module, 'HAS_IMAGE', True)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
