### PR TITLE
Operator CSV modifications: record it in koji build metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -189,12 +189,15 @@ class KojiImportBase(ExitPlugin):
                 }
                 for p in op_related_images['pullspecs']
             ]
-            extra['image']['operator_manifests'] = {
+            koji_operator_manifests = {
+                'custom_csv_modifications_applied': op_bundle_metadata[
+                    'custom_csv_modifications_applied'],
                 'related_images': {
                     'pullspecs': pullspecs,
                     'created_by_osbs': op_related_images['created_by_osbs'],
                 }
             }
+            extra['image']['operator_manifests'] = koji_operator_manifests
 
         # update push plugin and uploaded manifests file independently as push plugin may fail
         op_push_res = self.workflow.postbuild_results.get(PLUGIN_PUSH_OPERATOR_MANIFESTS_KEY)

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -233,7 +233,8 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
             'created_by_osbs': True,
         }
         operator_manifests_metadata = {
-            'related_images': related_images_metadata
+            'related_images': related_images_metadata,
+            'custom_csv_modifications_applied': bool(self.operator_csv_modifications_url)
         }
 
         operator_manifest = self._get_operator_manifest()

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -88,6 +88,8 @@ Data which is placed here includes
   Registry HTTP API V1 image; currently this key is only set when Pulp
   integration is enabled
 - `build.extra.image.operator_manifests` (map): Operator bundle images metadata
+- `build.extra.image.operator_manifests.custom_csv_modifications_applied` (boolean):
+  indicates if custom user modifications were done to operator bundle images metadata
 - `build.extra.image.operator_manifests.related_images` (map): Metadata about
   related_images in operator bundle
 - `build.extra.image.operator_manifests.related_images.pullspecs` (map list):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -397,6 +397,7 @@ class TestPinOperatorDigest(object):
         assert self._get_worker_arg(runner.workflow) is None
 
         expected = {
+            'custom_csv_modifications_applied': False,
             'related_images': {
                 'pullspecs': [],
                 'created_by_osbs': False,
@@ -577,6 +578,7 @@ class TestPinOperatorDigest(object):
         assert self._get_worker_arg(runner.workflow) == replacement_pullspecs
 
         expected_result = {
+            'custom_csv_modifications_applied': False,
             'related_images': {
                 'pullspecs': [
                     {
@@ -1208,6 +1210,7 @@ class TestOperatorCSVModifications:
         result = runner.run()
 
         expected = {
+            'custom_csv_modifications_applied': True,
             'related_images': {
                 'created_by_osbs': True,
                 'pullspecs': [


### PR DESCRIPTION
If user provides custom modifications to operator CSV file (isolated
builds, option --operator-csv-modifications-url) record this fact in
koji build metadata

CLOUDBLD-4623

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
