### PR TITLE
store build ids in build extra metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -221,6 +221,14 @@ class KojiImportBase(ExitPlugin):
 
                     return  # only one worker can process operator manifests
 
+    def set_pnc_build_metadata(self, extra):
+        plugin_results = self.workflow.postbuild_results.get(PLUGIN_GENERATE_MAVEN_METADATA_KEY) \
+                         or {}
+        pnc_build_metadata = plugin_results.get('pnc_build_metadata')
+
+        if pnc_build_metadata:
+            extra['image']['pnc'] = pnc_build_metadata
+
     def set_remote_sources_metadata(self, extra):
         remote_source_result = self.workflow.prebuild_results.get(PLUGIN_RESOLVE_REMOTE_SOURCE)
         if remote_source_result:
@@ -673,6 +681,7 @@ class KojiImportPlugin(KojiImportBase):
 
         self.set_help(extra, worker_metadatas)
         self.set_operators_metadata(extra, worker_metadatas)
+        self.set_pnc_build_metadata(extra)
         self.set_remote_sources_metadata(extra)
         self.set_remote_source_file_metadata(extra)
 

--- a/docs/koji.md
+++ b/docs/koji.md
@@ -132,6 +132,8 @@ Data which is placed here includes
 - `build.extra.operator_manifests_archive` (string): Name of the archive
   containing operator manifest files. Included here for legacy reasons.
   `build.extra.typeinfo.operator-manifests.archive` Should be preferred
+- `build.extra.image.pnc` (map): Information about middleware artifacts fetched
+  using fetch-artifacts-pnc
 
 The index map has these entries
 


### PR DESCRIPTION
This metadata will be later useful to build source images
for artifacts fetched using fetch-artifacts-pnc

Story - MMENG-1442
Epic - MMENG-1282

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
