### PR TITLE
fetch-artifacts-pnc: implement source download

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -153,7 +153,7 @@
             }
         },
         "additionalProperties": false,
-        "required": ["base_api_url", "get_scm_archive_path"]
+        "required": ["base_api_url", "get_scm_archive_path", "get_artifact_path"]
     },
     "pulp": {
         "description": "Pulp registry instance (deprecated)",


### PR DESCRIPTION
download sources using build IDs for fetch-artifacts-pnc

MMENG-1484

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
