### PR TITLE
Prevent broken regeneration of operator CSV YAML

### DIFF
--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -17,9 +17,29 @@ from atomic_reactor.util import chain_get, sha256sum
 from osbs.utils import ImageName
 from osbs.utils.yaml import validate_with_schema
 
-
-yaml = YAML()
 log = logging.getLogger(__name__)
+
+
+def get_yaml_parser():
+    """Returns tuned up YAML parser"""
+    yaml_parser = YAML()
+
+    # ruamel will introduce a line break if the yaml line is longer than
+    # yaml.width. Unfortunately, this causes issues for JSON values nested
+    # within a YAML file, e.g. metadata.annotations."alm-examples" in a CSV
+    # file. The default value is 80. Set it to a more forgiving higher
+    # number to avoid issues
+    yaml_parser.width = 200
+
+    # ruamel will also cause issues when normalizing a YAML object that contains
+    # a nested JSON object when it does not preserve quotes. Thus, it produces
+    # invalid YAML. Let's prevent this from happening at all.
+    yaml_parser.preserve_quotes = True
+
+    return yaml_parser
+
+
+yaml = get_yaml_parser()
 
 
 OPERATOR_CSV_KIND = "ClusterServiceVersion"


### PR DESCRIPTION
1)
ruamel will introduce a line break if the yaml line is longer than
yaml.width. Unfortunately, this causes issues for JSON values nested
within a YAML file, e.g. metadata.annotations."alm-examples" in a CSV
file. The default value is 80. Set it to a more forgivinng higher
number to avoid issues

2)
ruamel will also cause issues when normalizing a YAML object that contains
a nested JSON object when it does not preserve quotes. Thus, it produces
invalid YAML. Let's prevent this from happening at all.

CLOUDBLD-5749

Signed-off-by: Martin Bašti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
