### PR TITLE
Export remote_sources metadata

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -183,7 +183,8 @@ KOJI_BTYPE_REMOTE_SOURCE_FILE = 'remote-source-file'
 REMOTE_SOURCE_DIR = '/remote-source'
 
 # Name of downloaded remote sources tarball
-REMOTE_SOURCES_FILENAME = 'remote-source.tar.gz'
+REMOTE_SOURCE_TARBALL_FILENAME = 'remote-source.tar.gz'
+REMOTE_SOURCE_JSON_FILENAME = 'remote-source.json'
 
 # koji osbs_build metadata
 KOJI_KIND_IMAGE_BUILD = 'container_build'

--- a/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
+++ b/atomic_reactor/plugins/exit_store_metadata_in_osv3.py
@@ -195,10 +195,14 @@ class StoreMetadataInOSv3Plugin(ExitPlugin):
 
     def apply_remote_source_annotations(self, annotations):
         try:
-            rs_annotations = self.get_pre_result(PLUGIN_RESOLVE_REMOTE_SOURCE)['annotations']
+            remote_sources = self.get_pre_result(PLUGIN_RESOLVE_REMOTE_SOURCE)
+            remote_sources_annotations = [
+                {"name": remote_source["name"], "url": remote_source["url"]}
+                for remote_source in remote_sources
+            ]
         except (TypeError, KeyError):
             return
-        annotations.update(rs_annotations)
+        annotations.update(remote_sources_annotations)
 
     def run(self):
         metadata = get_build_json().get("metadata", {})

--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -28,6 +28,7 @@ from atomic_reactor.util import get_retrying_requests_session
 from atomic_reactor.download import download_url
 from atomic_reactor.metadata import label_map
 from atomic_reactor.utils.pnc import PNCUtil
+from atomic_reactor.constants import REMOTE_SOURCE_JSON_FILENAME
 
 
 @label_map('sources_for_koji_build_id')
@@ -235,7 +236,8 @@ class FetchSourcesPlugin(PreBuildPlugin):
                 dest_name = remote_source['dest']
                 remote_sources_urls.append(remote_source)
 
-            elif archive['type_name'] == 'json' and archive['filename'] == 'remote-source.json':
+            elif (archive['type_name'] == 'json'
+                  and archive['filename'] == REMOTE_SOURCE_JSON_FILENAME):
                 cachito_json_url = os.path.join(remote_sources_path, archive['filename'])
 
         # we will add entry to remote_json_map only when

--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -160,6 +160,10 @@ def get_cachito_session(workflow):
     return CachitoAPI(config['api_url'], **api_kwargs)
 
 
+def get_allow_multiple_remote_sources(workflow):
+    return get_value(workflow, 'allow_multiple_remote_sources', False)
+
+
 def get_arrangement_version(workflow, fallback=NO_FALLBACK):
     return get_value(workflow, 'arrangement_version', fallback)
 

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -611,6 +611,11 @@
         "type": "boolean",
         "default": true
     },
+    "allow_multiple_remote_sources": {
+        "description": "Allow using multiple remote sources",
+        "type": "boolean",
+        "default": false
+    },
     "required_secrets": {
         "description": "List of OpenShift secrets required by this configuration",
         "type": "array",

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -12,7 +12,7 @@ import logging
 import requests
 import time
 
-from atomic_reactor.constants import REMOTE_SOURCES_FILENAME
+from atomic_reactor.constants import REMOTE_SOURCE_TARBALL_FILENAME
 from atomic_reactor.download import download_url
 from atomic_reactor.util import get_retrying_requests_session
 
@@ -168,7 +168,7 @@ class CachitoAPI(object):
                 else:
                     time.sleep(burst_retry)
 
-    def download_sources(self, request, dest_dir='.', dest_filename=REMOTE_SOURCES_FILENAME):
+    def download_sources(self, request, dest_dir='.', dest_filename=REMOTE_SOURCE_TARBALL_FILENAME):
         """Download the sources from a Cachito request
 
         :param request: int or dict, either the Cachito request ID or a dict with 'id' key

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -15,7 +15,11 @@ import pytest
 import atomic_reactor.utils.koji as koji_util
 from atomic_reactor import util
 from atomic_reactor.utils.cachito import CachitoAPI
-from atomic_reactor.constants import PLUGIN_BUILD_ORCHESTRATE_KEY
+from atomic_reactor.constants import (
+    PLUGIN_BUILD_ORCHESTRATE_KEY,
+    REMOTE_SOURCE_TARBALL_FILENAME,
+    REMOTE_SOURCE_JSON_FILENAME,
+)
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins import pre_reactor_config
@@ -457,9 +461,12 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
     results = runner.run()[ResolveRemoteSourcePlugin.key]
 
     if expect_result:
-        assert results['annotations']['remote_source_url']
-        assert results['remote_source_json'] == REMOTE_SOURCE_JSON
-        assert results['remote_source_path'] == expected_dowload_path(workflow)
+        assert len(results) == 1
+        assert results[0]['url']
+        assert results[0]['remote_source_json']['json'] == REMOTE_SOURCE_JSON
+        assert results[0]['remote_source_json']['filename'] == REMOTE_SOURCE_JSON_FILENAME
+        assert results[0]['remote_source_tarball']['path'] == expected_dowload_path(workflow)
+        assert results[0]['remote_source_tarball']['filename'] == REMOTE_SOURCE_TARBALL_FILENAME
 
         # A result means the plugin was enabled and executed successfully.
         # Let's verify the expected side effects.


### PR DESCRIPTION
Update the metadata format and prepare it for
using multiple remote sources
CLOUDBLD-4453

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
