### PR TITLE
User warning: "go" key deprecation in container.yaml

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -14,6 +14,7 @@ import time
 import logging
 from tempfile import NamedTemporaryFile
 
+from atomic_reactor.constants import REPO_CONTAINER_CONFIG
 from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.source import GitSource
@@ -173,6 +174,10 @@ class KojiImportBase(ExitPlugin):
     def set_go_metadata(self, extra):
         go = self.workflow.source.config.go
         if go:
+            self.log.user_warning(
+                f"Using 'go' key in {REPO_CONTAINER_CONFIG} is deprecated in favor of using "
+                f"Cachito integration"
+            )
             self.log.debug("Setting Go metadata: %s", go)
             extra['image']['go'] = go
 


### PR DESCRIPTION
"go" key is deprecated and users should slowly move to CAchito
integration

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
