### PR TITLE
Fix reference to raw json for remote-source.json file

### DIFF
--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -388,7 +388,7 @@ def get_remote_sources_json_output(workflow):
         remote_source_json_filename = remote_source_json['filename']
         file_path = os.path.join(tmpdir, remote_source_json_filename)
         with open(file_path, 'w') as f:
-            json.dump(remote_source_json, f, indent=4, sort_keys=True)
+            json.dump(remote_source_json['json'], f, indent=4, sort_keys=True)
         metadata = get_output_metadata(file_path, remote_source_json_filename)
         output = Output(file=open(file_path), metadata=metadata)
         output_json_files.append(output)


### PR DESCRIPTION
A bug introduced in https://github.com/containerbuildsystem/atomic-reactor/pull/1624
caused that remote-source.json file in koji had unexpected content

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
