### PR TITLE
Log ODCS request ID after creation

### DIFF
--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -130,8 +130,10 @@ class ODCSClient(object):
         response = self.session.post('{}/composes/'.format(self.url.rstrip('/')),
                                      json=body)
         response.raise_for_status()
+        odcs_resp = response.json()
+        logger.info("Started compose: %s", odcs_resp['id'])
 
-        return response.json()
+        return odcs_resp
 
     def renew_compose(self, compose_id, sigkeys=None):
         """Renew, or extend, existing compose


### PR DESCRIPTION
For easier identification of the request in logs

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
