### PR TITLE
If all clusters for required platform are disabled, fail the build

### DIFF
--- a/atomic_reactor/plugins/pre_reactor_config.py
+++ b/atomic_reactor/plugins/pre_reactor_config.py
@@ -509,11 +509,15 @@ class ReactorConfig(object):
                                                 {}).items():
             cluster_configs = [ClusterConfig(priority=priority, **cluster)
                                for priority, cluster in enumerate(clusters)]
-            self.cluster_configs[platform] = [conf for conf in cluster_configs
-                                              if conf.enabled]
+            self.cluster_configs[platform] = cluster_configs
 
     def get_enabled_clusters_for_platform(self, platform):
-        return self.cluster_configs.get(platform, [])
+        if platform not in self.cluster_configs:
+            return []
+        return [conf for conf in self.cluster_configs[platform] if conf.enabled]
+
+    def cluster_defined_for_platform(self, platform):
+        return platform in self.cluster_configs
 
     def get_odcs_config(self):
         """


### PR DESCRIPTION
When build requires platform which is defined in config map, but
all clusters for that platform are disabled fail the build.
This changes current behavior, which was just silently skipping
such platform.

* CLOUDBLD-6076

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
