### PR TITLE
Run 'export_operator_manifests' plugin for scratch builds

### DIFF
--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -15,7 +15,6 @@ from atomic_reactor.constants import (PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY,
                                       OPERATOR_MANIFESTS_ARCHIVE)
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import (
-    is_scratch_build,
     has_operator_appregistry_manifest,
     has_operator_bundle_manifest,
 )
@@ -59,9 +58,6 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
         if self.operator_manifests_extract_platform != self.platform:
             self.log.info("Only platform [%s] will upload operators metadata. Skipping",
                           self.operator_manifests_extract_platform)
-            return False
-        if is_scratch_build(self.workflow):
-            self.log.info("Scratch build. Skipping")
             return False
         if not (
             has_operator_bundle_manifest(self.workflow) or

--- a/tests/plugins/test_download_remote_source.py
+++ b/tests/plugins/test_download_remote_source.py
@@ -68,7 +68,7 @@ def mock_repo_config(workflow, tmpdir, multiple_remote_sources=False):
         data = dedent("""\
             remote_sources:
             - name: first
-              remote-source:
+              remote_source:
                 repo: test_repo
                 ref: e1be527f39ec31323f0454f7d1422c6260b00580
             """)

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -172,14 +172,13 @@ def mock_env(tmpdir, docker_tasker,
 
 
 class TestExportOperatorManifests(object):
-    @pytest.mark.parametrize('scratch', [True, False])
     @pytest.mark.parametrize('has_appregistry_label', [True, False])
     @pytest.mark.parametrize('appregistry_label', [True, False])
     @pytest.mark.parametrize('has_bundle_label', [True, False])
     @pytest.mark.parametrize('bundle_label', [True, False])
     @pytest.mark.parametrize('orchestrator', [True, False])
     @pytest.mark.parametrize('selected_platform', [True, False])
-    def test_skip(self, docker_tasker, tmpdir, caplog, scratch,
+    def test_skip(self, docker_tasker, tmpdir, caplog,
                   has_appregistry_label, appregistry_label,
                   has_bundle_label, bundle_label,
                   orchestrator, selected_platform):
@@ -189,7 +188,6 @@ class TestExportOperatorManifests(object):
             has_appregistry_label=has_appregistry_label,
             has_bundle_label=has_bundle_label, bundle_label=bundle_label,
             appregistry_label=appregistry_label,
-            scratch=scratch,
             orchestrator=orchestrator, selected_platform=selected_platform
         )
         result = runner.run()
@@ -198,7 +196,6 @@ class TestExportOperatorManifests(object):
                 (has_appregistry_label and appregistry_label) or
                 (has_bundle_label and bundle_label)
             ),
-            scratch,
             orchestrator,
             not selected_platform
         ]):
@@ -207,10 +204,12 @@ class TestExportOperatorManifests(object):
         else:
             assert 'Skipping' not in caplog.text
 
-    def test_export_archive(self, docker_tasker, tmpdir):
-        runner = mock_env(tmpdir, docker_tasker)
+    @pytest.mark.parametrize('scratch', [True, False])
+    def test_export_archive(self, docker_tasker, tmpdir, scratch):
+        runner = mock_env(tmpdir, docker_tasker, scratch=scratch)
         result = runner.run()
         archive = result[PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY]
+
         assert archive
         assert archive.split('/')[-1] == 'operator_manifests.zip'
         assert zipfile.is_zipfile(archive)


### PR DESCRIPTION
*CLOUDBLD-6050

Scratch builds passes with unverified CSV file. We have to check them
just like non-scratch builds in 'export_operator_manifests' plugin,
but not save manifest files to zip file.

Signed-off-by: Serhii Salatskyi <ssalatsk@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
