### PR TITLE
fetch-artifacts-pnc: allow IDs to be strings

### DIFF
--- a/atomic_reactor/schemas/fetch-artifacts-pnc.json
+++ b/atomic_reactor/schemas/fetch-artifacts-pnc.json
@@ -16,7 +16,7 @@
         "properties": {
           "build_id": {
             "description": "The Build ID of a PNC build",
-            "type": "integer"
+            "type": "string"
           },
           "artifacts": {
             "type": "array",
@@ -26,7 +26,7 @@
               "properties": {
                 "id": {
                   "description": "Match by artifact id",
-                  "type": "integer"
+                  "type": "string"
                 },
                 "target": {
                   "description": "Name and or destination path to be used when saving artifact to disk",

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -207,65 +207,65 @@ DEFAULT_REMOTE_FILES = [REMOTE_FILE_SPAM, REMOTE_FILE_BACON, REMOTE_FILE_WITH_TA
                         REMOTE_FILE_SHA1, REMOTE_FILE_SHA256, REMOTE_FILE_MULTI_HASH]
 
 ARTIFACT_MD5 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 122,
+            'id': '122',
             'target': 'md5.jar'
         }
     ]
 }
 
 ARTIFACT_SHA1 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 123,
+            'id': '123',
             'target': 'sha1.jar'
         }
     ]
 }
 
 ARTIFACT_SHA256 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 124,
+            'id': '124',
             'target': 'sha256.jar'
         }
     ]
 }
 
 ARTIFACT_MULTI_HASH = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 125,
+            'id': '125',
             'target': 'multi-hash.jar'
         }
     ]
 }
 
 RESPONSE_MD5 = {
-    'id': 122,
+    'id': '122',
     'publicUrl': FILER_ROOT + '/md5.jar',
     'md5': '900150983cd24fb0d6963f7d28e17f72'
 }
 
 RESPONSE_SHA1 = {
-    'id': 123,
+    'id': '123',
     'publicUrl': FILER_ROOT + '/sha1.jar',
     'sha1': 'a9993e364706816aba3e25717850c26c9cd0d89d'
 }
 
 RESPONSE_SHA256 = {
-    'id': 124,
+    'id': '124',
     'publicUrl': FILER_ROOT + '/sha256.jar',
     'sha256': 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
 }
 
 RESPONSE_MULTI_HASH = {
-    'id': 125,
+    'id': '125',
     'publicUrl': FILER_ROOT + '/multi-hash.jar',
     'sha256': 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
     'sha1': 'a9993e364706816aba3e25717850c26c9cd0d89d',

--- a/tests/plugins/test_generate_maven_metadata.py
+++ b/tests/plugins/test_generate_maven_metadata.py
@@ -204,65 +204,65 @@ DEFAULT_REMOTE_FILES = [REMOTE_FILE_SPAM, REMOTE_FILE_BACON, REMOTE_FILE_WITH_TA
                         REMOTE_FILE_SHA1, REMOTE_FILE_SHA256, REMOTE_FILE_MULTI_HASH]
 
 ARTIFACT_MD5 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 122,
+            'id': '122',
             'target': 'md5.jar'
         }
     ]
 }
 
 ARTIFACT_SHA1 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 123,
+            'id': '123',
             'target': 'sha1.jar'
         }
     ]
 }
 
 ARTIFACT_SHA256 = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 124,
+            'id': '124',
             'target': 'sha256.jar'
         }
     ]
 }
 
 ARTIFACT_MULTI_HASH = {
-    'build_id': 12,
+    'build_id': '12',
     'artifacts': [
         {
-            'id': 125,
+            'id': '125',
             'target': 'multi-hash.jar'
         }
     ]
 }
 
 RESPONSE_MD5 = {
-    'id': 122,
+    'id': '122',
     'publicUrl': FILER_ROOT + '/md5.jar',
     'md5': '900150983cd24fb0d6963f7d28e17f72'
 }
 
 RESPONSE_SHA1 = {
-    'id': 123,
+    'id': '123',
     'publicUrl': FILER_ROOT + '/sha1.jar',
     'sha1': 'a9993e364706816aba3e25717850c26c9cd0d89d'
 }
 
 RESPONSE_SHA256 = {
-    'id': 124,
+    'id': '124',
     'publicUrl': FILER_ROOT + '/sha256.jar',
     'sha256': 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
 }
 
 RESPONSE_MULTI_HASH = {
-    'id': 125,
+    'id': '125',
     'publicUrl': FILER_ROOT + '/multi-hash.jar',
     'sha256': 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
     'sha1': 'a9993e364706816aba3e25717850c26c9cd0d89d',


### PR DESCRIPTION
MMENG-1976

The new PNC IDs are base32 long int represented as
string. This is causing a failure in parsing
fetch-artifacts-pnc.yaml. We need to allow string
so that it can process both int and string IDs

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
