### PR TITLE
Require flexmock>=0.10.6

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-flexmock>=0.10.3
+flexmock>=0.10.6
 responses>=0.9.0,<0.10.8
 pypng
 # 5.0 is the minimum version required by latest version of pytest-html. As of


### PR DESCRIPTION
Version 0.10.5 is broken and doesn't work properly with mocking `__new__`
methods

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
