### PR TITLE
Support headless-only signed RPMs.

### DIFF
--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -590,6 +590,8 @@ def get_rpms():
         'SIGMD5',
         'SIGPGP:pgpsig',
         'SIGGPG:pgpsig',
+        'DSAHEADER:pgpsig',
+        'RSAHEADER:pgpsig',
     ]
 
     output = get_rpm_list(tags)

--- a/atomic_reactor/utils/rpm.py
+++ b/atomic_reactor/utils/rpm.py
@@ -18,6 +18,8 @@ image_component_rpm_tags = [
     'BUILDTIME',
     'SIGPGP:pgpsig',
     'SIGGPG:pgpsig',
+    'DSAHEADER:pgpsig',
+    'RSAHEADER:pgpsig',
 ]
 
 
@@ -81,7 +83,7 @@ def parse_rpm_output(output, tags=None, separator=';'):
         if len(fields) < len(tags):
             continue
 
-        signature = field('SIGPGP:pgpsig') or field('SIGGPG:pgpsig')
+        signature = field('SIGPGP:pgpsig') or field('SIGGPG:pgpsig') or field('DSAHEADER:pgpsig') or field('RSAHEADER:pgpsig')
         if signature:
             parts = signature.split(sigmarker, 1)
             if len(parts) > 1:


### PR DESCRIPTION
Signed-off-by: Jan Kaluza <jkaluza@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
