### PR TITLE
[OCP3] Improve disk space usage for source container builds

### DIFF
--- a/atomic_reactor/build.py
+++ b/atomic_reactor/build.py
@@ -64,7 +64,7 @@ class BuildResult(object):
 
     def __init__(self, logs=None, fail_reason=None, image_id=None,
                  annotations=None, labels=None, skip_layer_squash=False,
-                 oci_image_path=None):
+                 source_docker_archive=None):
         """
         :param logs: iterable of log lines (without newlines)
         :param fail_reason: str, description of failure or None if successful
@@ -75,24 +75,24 @@ class BuildResult(object):
                        should be set as labels on OpenShift build
         :param skip_layer_squash: boolean, direct post-build plugins not
                                   to squash image layers for this build
-        :param oci_image_path: str, path to OCI image directory
+        :param source_docker_archive: str, path to docker image archive
         """
         assert fail_reason is None or bool(fail_reason), \
             "If fail_reason provided, can't be falsy"
         # must provide one, not both
         assert not (fail_reason and image_id), \
             "Either fail_reason or image_id should be provided, not both"
-        assert not (fail_reason and oci_image_path), \
-            "Either fail_reason or oci_image_path should be provided, not both"
-        assert not (image_id and oci_image_path), \
-            "Either image_id or oci_image_path should be provided, not both"
+        assert not (fail_reason and source_docker_archive), \
+            "Either fail_reason or source_docker_archive should be provided, not both"
+        assert not (image_id and source_docker_archive), \
+            "Either image_id or source_docker_archive should be provided, not both"
         self._logs = logs or []
         self._fail_reason = fail_reason
         self._image_id = image_id
         self._annotations = annotations
         self._labels = labels
         self._skip_layer_squash = skip_layer_squash
-        self._oci_image_path = oci_image_path
+        self._source_docker_archive = source_docker_archive
 
     @classmethod
     def make_remote_image_result(cls, annotations=None, labels=None):
@@ -129,8 +129,8 @@ class BuildResult(object):
         return self._skip_layer_squash
 
     @property
-    def oci_image_path(self):
-        return self._oci_image_path
+    def source_docker_archive(self):
+        return self._source_docker_archive
 
     def is_image_available(self):
         return self._image_id and self._image_id is not self.REMOTE_IMAGE

--- a/atomic_reactor/plugins/post_compress.py
+++ b/atomic_reactor/plugins/post_compress.py
@@ -50,7 +50,7 @@ class CompressPlugin(PostBuildPlugin):
         self.load_exported_image = load_exported_image
         self.method = method
         self.uncompressed_size = 0
-        self.source_build = bool(self.workflow.build_result.oci_image_path)
+        self.source_build = bool(self.workflow.build_result.source_docker_archive)
 
     def _compress_image_stream(self, stream):
         outfile = os.path.join(self.workflow.source.workdir,

--- a/tests/plugins/test_compress.py
+++ b/tests/plugins/test_compress.py
@@ -48,7 +48,7 @@ class TestCompress(object):
         exp_img = os.path.join(str(tmpdir), 'img.tar')
 
         if source_build:
-            workflow.build_result = BuildResult(oci_image_path="oci_path")
+            workflow.build_result = BuildResult(source_docker_archive="oci_path")
         else:
             workflow.build_result = BuildResult(image_id="12345")
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -2489,7 +2489,7 @@ class TestKojiImport(object):
                                             has_config=has_config,
                                             source_build=True)
 
-        workflow.build_result = BuildResult(oci_image_path="oci_path")
+        workflow.build_result = BuildResult(source_docker_archive="oci_path")
         workflow.koji_source_nvr = {'name': component, 'version': version, 'release': release}
         workflow.koji_source_source_url = 'git://hostname/path#123456'
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -320,13 +320,13 @@ def test_build_result():
         BuildResult(fail_reason='', image_id='spam')
 
     with pytest.raises(AssertionError):
-        BuildResult(fail_reason='it happens', oci_image_path='/somewhere')
+        BuildResult(fail_reason='it happens', source_docker_archive='/somewhere')
 
     with pytest.raises(AssertionError):
-        BuildResult(image_id='spam', oci_image_path='/somewhere')
+        BuildResult(image_id='spam', source_docker_archive='/somewhere')
 
     with pytest.raises(AssertionError):
-        BuildResult(image_id='spam', fail_reason='it happens', oci_image_path='/somewhere')
+        BuildResult(image_id='spam', fail_reason='it happens', source_docker_archive='/somewhere')
 
     assert BuildResult(fail_reason='it happens').is_failed()
     assert not BuildResult(image_id='spam').is_failed()
@@ -340,7 +340,7 @@ def test_build_result():
 
     assert BuildResult(image_id='spam', labels={'ham': 'mah'}).labels == {'ham': 'mah'}
 
-    assert BuildResult(oci_image_path='/somewhere').oci_image_path == '/somewhere'
+    assert BuildResult(source_docker_archive='/somewhere').source_docker_archive == '/somewhere'
 
     assert BuildResult(image_id='spam').is_image_available()
     assert not BuildResult(fail_reason='it happens').is_image_available()


### PR DESCRIPTION
Source container builds consume a lot of disk space, because they aren't
cleaning unnecessary things, they are now consuming 6 times of image
size.
With this change, source container builds will take less disk space
during build.
After running bsi command, it will remove bsi temp directory 'SrcImg',
and also all downloaded sources.
After exporting image into docker archive, it will also remove unpacked
docker image.
And resulting with consuming only 3 times of image size right after bsi
command finishes, and after that only 2 times of image size.

* CLOUDBLD-6672

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
