### PR TITLE
add purl-spec for middleware artifacts

### DIFF
--- a/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
+++ b/atomic_reactor/plugins/pre_fetch_maven_artifacts.py
@@ -65,6 +65,16 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
             self._pnc_util = PNCUtil(pnc_map)
         return self._pnc_util
 
+    def get_pnc_artifact_ids(self, pnc_requests):
+        artifact_ids = []
+        builds = pnc_requests.get('builds', [])
+
+        for build in builds:
+            for artifact in build['artifacts']:
+                artifact_ids.append(artifact['id'])
+
+        return artifact_ids
+
     def process_by_nvr(self, nvr_requests):
         download_queue = []
         errors = []
@@ -177,4 +187,7 @@ class FetchMavenArtifactsPlugin(PreBuildPlugin):
 
         self.download_files(download_queue)
 
-        return download_queue
+        pnc_artifact_ids = self.get_pnc_artifact_ids(pnc_requests)
+
+        return {'download_queue': download_queue,
+                'pnc_artifact_ids': pnc_artifact_ids}

--- a/atomic_reactor/utils/pnc.py
+++ b/atomic_reactor/utils/pnc.py
@@ -57,6 +57,23 @@ class PNCUtil(object):
 
         return url, checksums
 
+    def get_artifact_purl_specs(self, artifact_ids):
+        """
+        Return a Package URLs for all artifact ids
+        :param artifact_ids: list[str]; PNC artifact ids
+        :return list[str]; Package URLs of the artifacts corresponding to artifact ids
+        :rtype list[str]; Package URLs
+        """
+        purl_specs = []
+        for artifact_id in artifact_ids:
+            response = self.session.get(self.artifact_request_url.format(artifact_id))
+            response.raise_for_status()
+
+            artifact = response.json()
+            purl_specs.append(artifact['purl'])
+
+        return purl_specs
+
     def get_scm_archive_from_build_id(self, build_id: str):
         """
         Return a scm archive URL and filename from PNC REST API.

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -20,7 +20,7 @@ from tests.mock_env import MockEnv
 from tests.utils.test_cachito import CACHITO_URL, CACHITO_REQUEST_ID
 
 from atomic_reactor import util
-from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS
+from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS, PLUGIN_FETCH_MAVEN_KEY
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_add_image_content_manifest import AddImageContentManifestPlugin
 
@@ -33,6 +33,16 @@ CONTENT_SETS = {
 }
 CACHITO_ICM_URL = '{}/api/v1/content-manifest?requests={}'.format(CACHITO_URL,
                                                                   CACHITO_REQUEST_ID)
+PNC_ARTIFACT = {
+            'id': 1234,
+            'publicUrl': 'http://test.com/artifact.jar',
+            'md5': 'abcd',
+            'sha1': 'abcd',
+            'sha256': 'abcd',
+            'purl': 'pkg:maven/org.example.artifact/artifact-common@0.0.1.redhat-00001?type=jar',
+        }
+PNC_ROOT = 'http://pnc.example.com/pnc-rest/v2'
+PNC_ARTIFACT_URL = f"{PNC_ROOT}/artifacts/{PNC_ARTIFACT['id']}"
 ICM_MINIMAL_DICT = {
     'metadata': {
         'icm_version': 1,
@@ -67,6 +77,9 @@ ICM_DICT = {
                 },
             ]
         },
+        {
+            'purl': PNC_ARTIFACT['purl'],
+        }
     ]
 }
 ICM_JSON = dedent(
@@ -128,10 +141,11 @@ def mock_content_sets_config(tmpdir, empty=False):
 
 def mock_get_icm(requests_mock):
     requests_mock.register_uri('GET', CACHITO_ICM_URL, text=ICM_JSON)
+    requests_mock.register_uri('GET', PNC_ARTIFACT_URL, text=json.dumps(PNC_ARTIFACT))
 
 
 def mock_env(tmpdir, docker_tasker, platform='x86_64', base_layers=0,
-             remote_sources=REMOTE_SOURCES, r_c_m_override=None,
+             remote_sources=REMOTE_SOURCES, r_c_m_override=None, pnc_artifacts=True,
              ):  # pylint: disable=W0102
     inspection_data = {
         INSPECT_ROOTFS: {
@@ -147,6 +161,10 @@ def mock_env(tmpdir, docker_tasker, platform='x86_64', base_layers=0,
                     'ssl_certs_dir': str(tmpdir),
                 },
             },
+            'pnc': {
+                'base_api_url': PNC_ROOT,
+                'get_artifact_path': 'artifacts/{}',
+            },
         }
     else:
         r_c_m = r_c_m_override
@@ -157,6 +175,10 @@ def mock_env(tmpdir, docker_tasker, platform='x86_64', base_layers=0,
            .set_reactor_config(r_c_m)
            .make_orchestrator()
            )
+    if pnc_artifacts:
+        env.set_plugin_result(
+            'prebuild', PLUGIN_FETCH_MAVEN_KEY, {'pnc_artifact_ids': [PNC_ARTIFACT['id']]}
+        )
     tmpdir.join('cert').write('')
     env.workflow.builder.set_inspection_data(inspection_data)
     env.workflow.user_params['platform'] = platform
@@ -249,6 +271,34 @@ def test_add_image_content_manifest(requests_mock, tmpdir, docker_tasker, caplog
     assert expected_output == output
 
 
+def test_fetch_maven_artifacts_no_pnc_config(requests_mock, tmpdir, docker_tasker, caplog,
+                                             user_params):
+    mock_get_icm(requests_mock)
+    dfp = util.df_parser(str(tmpdir))
+    dfp.content = dedent("""\
+                            FROM base_image
+                            CMD build /spam/eggs
+                            LABEL com.redhat.component=eggs version=1.0 release=42
+                        """)
+    r_c_m = {
+        'version': 1,
+        'cachito': {
+            'api_url': CACHITO_URL,
+            'auth': {
+                'ssl_certs_dir': str(tmpdir),
+            },
+        },
+    }
+
+    with pytest.raises(PluginFailedException):
+        runner = mock_env(tmpdir, docker_tasker, r_c_m_override=r_c_m)
+        runner.workflow.builder.set_df_path(dfp.dockerfile_path)
+        runner.run()
+
+    msg = 'No PNC configuration found in reactor config map'
+    assert msg in caplog.text
+
+
 @pytest.mark.parametrize('content_sets', [True, False])
 @pytest.mark.parametrize(
     ('df_content, base_layers, manifest_file'), [
@@ -273,6 +323,41 @@ def test_none_remote_source_icm_url(requests_mock, tmpdir, docker_tasker, caplog
     runner = mock_env(tmpdir, docker_tasker, platform, base_layers, remote_sources=None)
     runner.workflow.builder.set_df_path(dfp.dockerfile_path)
     expected_output = deepcopy(ICM_MINIMAL_DICT)
+    expected_output['image_contents'].append({'purl': PNC_ARTIFACT['purl']})
+    if content_sets:
+        expected_output['content_sets'] = CONTENT_SETS[platform]
+    expected_output['metadata']['image_layer_index'] = base_layers
+    runner.run()
+    output_file = os.path.join(str(tmpdir), manifest_file)
+    with open(output_file) as f:
+        json_data = f.read()
+    output = json.loads(json_data)
+    assert expected_output == output
+
+
+@pytest.mark.parametrize('content_sets', [True, False])
+@pytest.mark.parametrize(
+    ('df_content, base_layers, manifest_file'), [
+        (
+            dedent("""\
+            FROM base_image
+            CMD build /spam/eggs
+            LABEL com.redhat.component=eggs version=1.0 release=42
+        """),
+            2,
+            'eggs-1.0-42.json',
+        )])
+def test_no_pnc_artifacts(requests_mock, tmpdir, docker_tasker, caplog, content_sets, df_content,
+                          base_layers, manifest_file):
+    platform = 'x86_64'
+    mock_get_icm(requests_mock)
+    mock_content_sets_config(tmpdir, empty=(not content_sets))
+    dfp = util.df_parser(str(tmpdir))
+    dfp.content = df_content
+    runner = mock_env(tmpdir, docker_tasker, platform, base_layers, pnc_artifacts=False)
+    runner.workflow.builder.set_df_path(dfp.dockerfile_path)
+    expected_output = deepcopy(ICM_DICT)
+    expected_output['image_contents'] = expected_output['image_contents'][:-1]
     if content_sets:
         expected_output['content_sets'] = CONTENT_SETS[platform]
     expected_output['metadata']['image_layer_index'] = base_layers

--- a/tests/plugins/test_fetch_maven_artifacts.py
+++ b/tests/plugins/test_fetch_maven_artifacts.py
@@ -473,9 +473,10 @@ def test_fetch_maven_artifacts(tmpdir, docker_tasker, user_params):
 
     plugin_result = results[FetchMavenArtifactsPlugin.key]
 
-    assert len(plugin_result) == (len(DEFAULT_ARCHIVES) + len(DEFAULT_REMOTE_FILES)
-                                  + len(DEFAULT_PNC_ARTIFACTS['builds']))
-    for download in plugin_result:
+    assert len(plugin_result['download_queue']) == (len(DEFAULT_ARCHIVES) + len(
+        DEFAULT_REMOTE_FILES) + len(DEFAULT_PNC_ARTIFACTS['builds']))
+    assert len(plugin_result['pnc_artifact_ids']) == len(DEFAULT_PNC_ARTIFACTS['builds'])
+    for download in plugin_result['download_queue']:
         dest = os.path.join(tmpdir, FetchMavenArtifactsPlugin.DOWNLOAD_DIR, download.dest)
         assert os.path.exists(dest)
 
@@ -519,12 +520,12 @@ def test_fetch_maven_artifacts_nvr_filtering(tmpdir, docker_tasker, user_params,
 
     plugin_result = results[FetchMavenArtifactsPlugin.key]
 
-    assert len(plugin_result) == len(expected)
-    for download in plugin_result:
+    assert len(plugin_result['download_queue']) == len(expected)
+    for download in plugin_result['download_queue']:
         assert len(download.checksums.values()) == 1
-    assert (set(list(download.checksums.values())[0] for download in plugin_result) ==
-            set(expectation['checksum'] for expectation in expected))
-    for download in plugin_result:
+    assert (set(list(download.checksums.values())[0] for download in plugin_result[
+        'download_queue']) == set(expectation['checksum'] for expectation in expected))
+    for download in plugin_result['download_queue']:
         dest = os.path.join(tmpdir, FetchMavenArtifactsPlugin.DOWNLOAD_DIR, download.dest)
         assert os.path.exists(dest)
 
@@ -732,12 +733,12 @@ def test_fetch_maven_artifacts_url_with_target(tmpdir, docker_tasker, user_param
     results = mock_env(tmpdir).create_runner(docker_tasker).run()
     plugin_result = results[FetchMavenArtifactsPlugin.key]
 
-    assert len(plugin_result) == len(expected)
+    assert len(plugin_result['download_queue']) == len(expected)
 
     if not expected:
         return
 
-    download = plugin_result[0]
+    download = plugin_result['download_queue'][0]
     dest = os.path.join(tmpdir, FetchMavenArtifactsPlugin.DOWNLOAD_DIR, download.dest)
     assert os.path.exists(dest)
     assert download.dest == REMOTE_FILE_WITH_TARGET['target']
@@ -852,7 +853,7 @@ def test_fetch_maven_artifacts_url_allowed_domains(tmpdir, docker_tasker, user_p
     else:
         results = runner.run()
         plugin_result = results[FetchMavenArtifactsPlugin.key]
-        for download in plugin_result:
+        for download in plugin_result['download_queue']:
             dest = os.path.join(tmpdir, FetchMavenArtifactsPlugin.DOWNLOAD_DIR, download.dest)
             assert os.path.exists(dest)
 
@@ -875,6 +876,6 @@ def test_fetch_maven_artifacts_commented_out_files(tmpdir, docker_tasker, user_p
     results = mock_env(tmpdir).create_runner(docker_tasker).run()
     plugin_result = results[FetchMavenArtifactsPlugin.key]
 
-    assert len(plugin_result) == 0
+    assert len(plugin_result['download_queue']) == 0
     artifacts_dir = os.path.join(tmpdir, FetchMavenArtifactsPlugin.DOWNLOAD_DIR)
     assert not os.path.exists(artifacts_dir)

--- a/tests/utils/test_pnc.py
+++ b/tests/utils/test_pnc.py
@@ -58,6 +58,31 @@ class TestPNCUtil(object):
         assert checksums == {'md5': 'abcd', 'sha1': 'abcd', 'sha256': 'abcd'}
 
     @responses.activate
+    def test_get_artifact_purl_specs(self):
+        artifact_id = '12345'
+        public_url = 'https://code.example.com/artifact.jar'
+        purl_spec = 'pkg:maven/org.example.artifact/artifact-common@0.0.1.redhat-00001?type=jar'
+        artifact_response = {
+            'id': artifact_id,
+            'publicUrl': public_url,
+            'md5': 'abcd',
+            'sha1': 'abcd',
+            'sha256': 'abcd',
+            'purl': purl_spec
+        }
+        pnc_util = PNCUtil(mock_pnc_map())
+
+        # to mock this URL we have to construct it manually first
+        get_artifact_request_url = PNC_BASE_API_URL + '/' + PNC_GET_ARTIFACT_PATH
+
+        responses.add(responses.GET, get_artifact_request_url.format(artifact_id),
+                      body=json.dumps(artifact_response), status=200)
+
+        pnc_artifact_purl_specs = pnc_util.get_artifact_purl_specs([artifact_id])
+
+        assert pnc_artifact_purl_specs == [purl_spec]
+
+    @responses.activate
     def test_get_scm_archive_filename_in_header(self):
         build_id = '1234'
         filename = 'source.tar.gz'


### PR DESCRIPTION
For Product Security to be able to scan middleware artifacts
for any vulnerabilities, they must be added to the image
content manifest. This change will add all artifacts fetched
via fetch-artifacts-pnc to the manifest.

All artifacts are identified by their Package URLs(aka purl-specs)

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Ports #1647
