### PR TITLE
[OCP3] Retry skopeo operations

### DIFF
--- a/atomic-reactor.spec
+++ b/atomic-reactor.spec
@@ -34,6 +34,7 @@ infrastructure.
 Summary:        Python 3 Atomic Reactor library
 Group:          Development/Tools
 License:        BSD
+Requires:       python3-backoff
 Requires:       python3-docker >= 1.3.0, python3-docker < 4.3.0
 Requires:       python3-requests
 Requires:       python3-setuptools

--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -152,6 +152,10 @@ KOJI_RESERVE_RETRY_DELAY = 2
 KOJI_MAX_RETRIES = 120
 KOJI_RETRY_INTERVAL = 60
 KOJI_OFFLINE_RETRY_INTERVAL = 120
+# max retries for subprocesses (see utils.retries.run_cmd())
+SUBPROCESS_MAX_RETRIES = 5
+# the factor for the exponential backoff series - 5, 10, 20, 40, 80 seconds of waiting
+SUBPROCESS_BACKOFF_FACTOR = 5
 
 # Media types
 MEDIA_TYPE_DOCKER_V2_SCHEMA1 = "application/vnd.docker.distribution.manifest.v1+json"

--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -15,6 +15,7 @@ from atomic_reactor.constants import (PLUGIN_SOURCE_CONTAINER_KEY, EXPORTED_SQUA
                                       IMAGE_TYPE_DOCKER_ARCHIVE, PLUGIN_FETCH_SOURCES_KEY)
 from atomic_reactor.plugin import BuildStepPlugin
 from atomic_reactor.util import get_exported_image_metadata
+from atomic_reactor.utils import retries
 
 
 class SourceContainerPlugin(BuildStepPlugin):
@@ -33,9 +34,8 @@ class SourceContainerPlugin(BuildStepPlugin):
         dest_img = 'docker-archive:{}'.format(output_path)
         cmd += [source_img, dest_img]
 
-        self.log.info("Calling: %s", ' '.join(cmd))
         try:
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            retries.run_cmd(cmd)
         except subprocess.CalledProcessError as e:
             self.log.error("failed to save docker-archive :\n%s", e.output)
             raise

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -23,6 +23,7 @@ from atomic_reactor.plugins.pre_reactor_config import (get_registries, get_group
 from atomic_reactor.plugins.pre_fetch_sources import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.util import (get_manifest_digests, get_config_from_registry, Dockercfg,
                                  get_all_manifests)
+from atomic_reactor.utils import retries
 from osbs.utils import ImageName
 import osbs.utils
 from osbs.constants import RAND_DIGITS
@@ -104,9 +105,8 @@ class TagAndPushPlugin(PostBuildPlugin):
 
         cmd += [source_img, dest_img]
 
-        self.log.info("Calling: %s", ' '.join(cmd))
         try:
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            retries.run_cmd(cmd)
         except subprocess.CalledProcessError as e:
             self.log.error("push failed with output:\n%s", e.output)
             raise

--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -7,6 +7,10 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import logging
+import subprocess
+from typing import List
+
+import backoff
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
@@ -14,7 +18,9 @@ from urllib3.util import Retry
 from atomic_reactor.constants import (HTTP_CLIENT_STATUS_RETRY,
                                       HTTP_MAX_RETRIES,
                                       HTTP_BACKOFF_FACTOR,
-                                      HTTP_REQUEST_TIMEOUT)
+                                      HTTP_REQUEST_TIMEOUT,
+                                      SUBPROCESS_MAX_RETRIES,
+                                      SUBPROCESS_BACKOFF_FACTOR)
 
 logger = logging.getLogger(__name__)
 
@@ -71,3 +77,27 @@ def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
     session.hooks['response'] = [hook_log_error_response_content]
 
     return session
+
+
+@backoff.on_exception(
+    backoff.expo,
+    subprocess.CalledProcessError,
+    factor=SUBPROCESS_BACKOFF_FACTOR,
+    max_tries=SUBPROCESS_MAX_RETRIES + 1,  # total tries is N retries + 1 initial attempt
+    jitter=None,  # use deterministic backoff, do not apply random jitter
+)
+def run_cmd(cmd: List[str]) -> bytes:
+    """Run a subprocess command, retry on any non-zero exit status.
+
+    Whenever an attempt fails, the stdout and stderr of the failed command will be logged.
+    If all attempts fail, the raised exception will also provide the combined stdout and stderr
+    in the `output` attribute.
+
+    :return: bytes, the combined stdout and stderr (if any) of the command
+    """
+    logger.debug("Running %s", " ".join(cmd))
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        logger.warning("%s failed with:\n%s", cmd[0], e.output.decode())
+        raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff
 docker < 4.3.0
 docker-squash>=1.0.7
 dockerfile-parse>=0.0.13

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -15,9 +15,10 @@ import pytest
 import re
 import subprocess
 import tarfile
+import time
 from textwrap import dedent
 
-from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
+from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR, SUBPROCESS_MAX_RETRIES
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PrePublishPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_reactor_config import (ReactorConfigPlugin,
@@ -554,6 +555,8 @@ def test_flatpak_create_oci(tmpdir, docker_tasker, user_params,
     elif breakage == 'copy_error':
         workflow.storage_transport = 'idontexist'
         expected_exception = 'CalledProcessError'
+        # mock the time.sleep() call between skopeo retries, otherwise test would take too long
+        flexmock(time).should_receive('sleep').times(SUBPROCESS_MAX_RETRIES)
     else:
         assert breakage is None
         expected_exception = None


### PR DESCRIPTION
Cherry-picks #1653

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
