### PR TITLE
[OCP3] Cachito: report error as singleline

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -131,11 +131,12 @@ class CachitoAPI(object):
                    Request %s is in "%s" state: %s
                    Details: %s
                    """), request_id, state, state_reason, json.dumps(response_json, indent=4))
-                raise CachitoAPIUnsuccessfulRequest(dedent('''\
-                    Cachito request is in "{}" state, reason: {}
-                    Request {} ({}) tried to get repo '{}' at reference '{}'.
-                    '''.format(state, state_reason, request_id, url,
-                               response_json['repo'], response_json['ref']))
+                raise CachitoAPIUnsuccessfulRequest(
+                    "Cachito request is in \"{}\" state, reason: {}. "
+                    "Request {} ({}) tried to get repo '{}' at reference '{}'.".format(
+                        state, state_reason, request_id, url,
+                        response_json['repo'], response_json['ref']
+                    )
                 )
             if state == 'complete':
                 logger.debug(dedent("""\

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -259,12 +259,13 @@ def test_check_CachitoAPIUnsuccessfulRequest_text(error_state, error_reason, cap
         callback=handle_wait_for_request)
 
     burst_params = {'burst_retry': 0.001, 'burst_length': 0.5}
-    expected_exc_text = dedent('''\
-                               Cachito request is in "{}" state, reason: {}
-                               Request {} ({}) tried to get repo '{}' at reference '{}'.
-                               '''.format(error_state, error_reason, CACHITO_REQUEST_ID,
-                                          cachito_request_url, CACHITO_REQUEST_REPO,
-                                          CACHITO_REQUEST_REF))
+    expected_exc_text = (
+        "Cachito request is in \"{}\" state, reason: {}. "
+        "Request {} ({}) tried to get repo '{}' at reference '{}'.".format(
+            error_state, error_reason, CACHITO_REQUEST_ID,
+            cachito_request_url, CACHITO_REQUEST_REPO,
+            CACHITO_REQUEST_REF)
+    )
     with pytest.raises(CachitoAPIUnsuccessfulRequest) as excinfo:
         CachitoAPI(CACHITO_URL).wait_for_request(CACHITO_REQUEST_ID, **burst_params)
     assert len(responses.calls) == expected_total_responses_calls


### PR DESCRIPTION
Errors shouldn't be multiline for easier post processing

CLOUDBLD-7342

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

Backport https://github.com/containerbuildsystem/atomic-reactor/pull/1660
