### PR TITLE
Remove everything related to arrangement version

### DIFF
--- a/atomic_reactor/schemas/source_containers_user_params.json
+++ b/atomic_reactor/schemas/source_containers_user_params.json
@@ -5,7 +5,6 @@
 
   "type": "object",
   "properties": {
-    "arrangement_version": {"type": "integer"},
     "build_from": {"type": "string"},
     "build_image": {"type": "string"},
     "build_imagestream": {"type": "string"},

--- a/atomic_reactor/schemas/user_params.json
+++ b/atomic_reactor/schemas/user_params.json
@@ -9,7 +9,6 @@
       "type": "array",
       "items": {"type": "string"}
     },
-    "arrangement_version": {"type": "integer"},
     "base_image": {"type": "string"},
     "build_from": {"type": "string"},
     "build_image": {"type": "string"},

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -91,8 +91,6 @@ smtp:
     send_to_submitter: True
     send_to_pkg_owner: True
 
-arrangement_version: 6
-
 artifacts_allowed_domains:
 - download.example.com/released
 - download.example.com/candidates

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -226,8 +226,7 @@ def test_add_labels_plugin(tmpdir, docker_tasker, workflow,
 
 @pytest.mark.parametrize('use_reactor', [True, False])  # noqa
 @pytest.mark.parametrize('release', [None, 'test'])
-def test_add_labels_arrangement6(tmpdir, docker_tasker, workflow, release, use_reactor):
-    # explicitly test arrangement 6's handling of reactor config
+def test_add_labels(tmpdir, docker_tasker, workflow, release, use_reactor):
     df = df_parser(str(tmpdir))
     df.content = DF_CONTENT
 

--- a/tests/plugins/test_orchestrate_build.py
+++ b/tests/plugins/test_orchestrate_build.py
@@ -266,7 +266,6 @@ def make_worker_build_kwargs(**overrides):
         'git_ref': 'master',
         'git_branch': 'master',
         'user': 'bacon',
-        'arrangement_version': 6
     }
     kwargs.update(overrides)
     return kwargs
@@ -319,7 +318,7 @@ def test_orchestrate_build(tmpdir, caplog,
 
     clusters = deepcopy(DEFAULT_CLUSTERS)
 
-    reactor_dict = {'version': 1, 'arrangement_version': 6}
+    reactor_dict = {'version': 1}
     if config_kwargs and 'sources_command' in config_kwargs:
         reactor_dict['sources_command'] = 'fedpkg source'
 
@@ -982,7 +981,6 @@ def test_orchestrate_build_worker_build_kwargs(tmpdir, caplog):
         'user': 'bacon',
         'platform': 'x86_64',
         'release': '10',
-        'arrangement_version': 6,
         'parent_images_digests': {},
         'operator_manifests_extract_platform': 'x86_64',
     }
@@ -1029,7 +1027,6 @@ def test_orchestrate_override_build_kwarg(tmpdir, overrides):
         'user': 'bacon',
         'platform': 'x86_64',
         'release': '4242',
-        'arrangement_version': 6,
         'parent_images_digests': {},
         'operator_manifests_extract_platform': 'x86_64',
     }
@@ -1079,7 +1076,6 @@ def test_orchestrate_override_content_versions(tmpdir, caplog, content_versions)
         'user': 'bacon',
         'platform': 'x86_64',
         'release': '10',
-        'arrangement_version': 6,
         'parent_images_digests': {},
         'operator_manifests_extract_platform': 'x86_64',
     }
@@ -1143,7 +1139,6 @@ def test_orchestrate_operator_csv_modifications_url(tmpdir):
         'user': 'bacon',
         'platform': 'x86_64',
         'release': '10',
-        'arrangement_version': 6,
         'parent_images_digests': {},
         'operator_csv_modifications_url': csv_mods_url,
         'operator_manifests_extract_platform': 'x86_64',
@@ -1572,7 +1567,6 @@ def test_parent_images_digests(tmpdir, caplog):
         'user': 'bacon',
         'platform': 'x86_64',
         'release': '10',
-        'arrangement_version': 6,
         'parent_images_digests': PARENT_IMAGES_DIGESTS,
         'operator_manifests_extract_platform': 'x86_64',
     }


### PR DESCRIPTION
Cleanup for tekton

* CLOUDBLD-6299

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
