### PR TITLE
Read plugin args from userparams

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -73,8 +73,6 @@ TOOLS_USED = (
 
 DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024  # 10Mb
 
-TAG_NAME_REGEX = r'^[\w][\w.-]{0,127}$'
-
 IMAGE_TYPE_DOCKER_ARCHIVE = 'docker-archive'
 IMAGE_TYPE_OCI = 'oci'
 IMAGE_TYPE_OCI_TAR = 'oci-tar'

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -104,6 +104,14 @@ class BuildPlugin(Plugin):
         """
         return self.workflow.is_orchestrator_build()
 
+    @staticmethod
+    def args_from_user_params(user_params: dict) -> dict:
+        """Get keyword arguments for this plugin based on values in user params.
+
+        Plugin runners will set these automatically for all plugins.
+        """
+        return {}
+
 
 class PluginsRunner(object):
 
@@ -390,8 +398,9 @@ class BuildPluginsRunner(PluginsRunner):
         return known_plugin_conf
 
     def create_instance_from_plugin(self, plugin_class, plugin_conf):
-        plugin_conf = self._translate_special_values(plugin_conf)
         plugin_conf = self._remove_unknown_args(plugin_class, plugin_conf)
+        plugin_conf.update(plugin_class.args_from_user_params(self.workflow.user_params))
+        plugin_conf = self._translate_special_values(plugin_conf)
         logger.info("running plugin instance with args: '%s'", plugin_conf)
         plugin_instance = plugin_class(self.workflow, **plugin_conf)
         return plugin_instance

--- a/atomic_reactor/plugins/exit_koji_tag_build.py
+++ b/atomic_reactor/plugins/exit_koji_tag_build.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from atomic_reactor.constants import PLUGIN_KOJI_TAG_BUILD_KEY
 from atomic_reactor.config import get_koji_session
 from atomic_reactor.utils.koji import tag_koji_build
-from atomic_reactor.util import is_scratch_build
+from atomic_reactor.util import is_scratch_build, map_to_user_params
 from atomic_reactor.plugin import ExitPlugin
 from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
 
@@ -32,6 +32,8 @@ class KojiTagBuildPlugin(ExitPlugin):
 
     key = PLUGIN_KOJI_TAG_BUILD_KEY
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("target:koji_target")
 
     def __init__(self, workflow, target=None, poll_interval=5):
         """

--- a/atomic_reactor/plugins/post_export_operator_manifests.py
+++ b/atomic_reactor/plugins/post_export_operator_manifests.py
@@ -17,6 +17,7 @@ from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import (
     has_operator_appregistry_manifest,
     has_operator_bundle_manifest,
+    map_to_user_params,
 )
 from atomic_reactor.utils.operator import OperatorManifest
 from platform import machine
@@ -35,6 +36,8 @@ class ExportOperatorManifestsPlugin(PostBuildPlugin):
 
     key = PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("operator_manifests_extract_platform", "platform")
 
     def __init__(self, workflow, operator_manifests_extract_platform=None, platform=None):
         super(ExportOperatorManifestsPlugin, self).__init__(workflow)

--- a/atomic_reactor/plugins/post_koji_upload.py
+++ b/atomic_reactor/plugins/post_koji_upload.py
@@ -13,7 +13,7 @@ from tempfile import NamedTemporaryFile
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.constants import PLUGIN_KOJI_UPLOAD_PLUGIN_KEY
 from atomic_reactor.config import get_koji_session, get_openshift_session
-from atomic_reactor.util import (get_build_json, is_scratch_build)
+from atomic_reactor.util import get_build_json, is_scratch_build, map_to_user_params
 from atomic_reactor.utils.koji import get_buildroot, get_output, get_output_metadata
 from osbs.exceptions import OsbsException
 from osbs.utils import ImageName
@@ -68,8 +68,9 @@ class KojiUploadPlugin(PostBuildPlugin):
     key = PLUGIN_KOJI_UPLOAD_PLUGIN_KEY
     is_allowed_to_fail = False
 
-    def __init__(self, workflow, koji_upload_dir, blocksize=None,
-                 platform='x86_64', report_multiple_digests=False):
+    args_from_user_params = map_to_user_params("koji_upload_dir", "platform")
+
+    def __init__(self, workflow, koji_upload_dir, blocksize=None, platform='x86_64'):
         """
         constructor
 
@@ -77,14 +78,11 @@ class KojiUploadPlugin(PostBuildPlugin):
         :param koji_upload_dir: str, path to use when uploading to hub
         :param blocksize: int, blocksize to use for uploading files
         :param platform: str, platform name for this build
-        :param report_multiple_digests: bool, whether to report both schema 1
-            and schema 2 digests
         """
         super(KojiUploadPlugin, self).__init__(workflow)
 
         self.blocksize = blocksize
         self.koji_upload_dir = koji_upload_dir
-        self.report_multiple_digests = report_multiple_digests
 
         self.osbs = get_openshift_session(self.workflow.conf,
                                           self.workflow.user_params.get('namespace'))

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -18,7 +18,7 @@ from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.plugins.pre_fetch_sources import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.util import (get_manifest_digests, get_config_from_registry, Dockercfg,
-                                 get_all_manifests)
+                                 get_all_manifests, map_to_user_params)
 from atomic_reactor.utils import retries
 from osbs.utils import ImageName
 import osbs.utils
@@ -39,6 +39,8 @@ class TagAndPushPlugin(PostBuildPlugin):
 
     key = "tag_and_push"
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("koji_target")
 
     def __init__(self, workflow, koji_target=None):
         """

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -20,7 +20,7 @@ from atomic_reactor.plugin import PreBuildPlugin, BuildCanceledException
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.utils.koji import TaskWatcher, stream_task_output
 from atomic_reactor.utils.yum import YumRepo
-from atomic_reactor.util import get_platforms, df_parser, base_image_is_custom
+from atomic_reactor.util import get_platforms, df_parser, base_image_is_custom, map_to_user_params
 from atomic_reactor.metadata import label_map
 from atomic_reactor import util
 from osbs.utils import Labels, ImageName
@@ -70,6 +70,13 @@ class AddFilesystemPlugin(PreBuildPlugin):
         [factory-parameters]
         create_docker_metadata = False
         ''')
+
+    args_from_user_params = map_to_user_params(
+        "from_task_id:filesystem_koji_task_id",
+        "repos:yum_repourls",
+        "architecture:platform",
+        "koji_target",
+    )
 
     def __init__(self, workflow, from_task_id=None, poll_interval=5,
                  blocksize=DEFAULT_DOWNLOAD_BLOCK_SIZE,

--- a/atomic_reactor/plugins/pre_add_image_content_manifest.py
+++ b/atomic_reactor/plugins/pre_add_image_content_manifest.py
@@ -20,7 +20,7 @@ from atomic_reactor.constants import (IMAGE_BUILD_INFO_DIR, INSPECT_ROOTFS,
 from atomic_reactor.config import get_cachito_session
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (base_image_is_scratch, df_parser, read_yaml,
-                                 read_content_sets
+                                 read_content_sets, map_to_user_params
                                  )
 from atomic_reactor.utils import imageutil
 from atomic_reactor.utils.pnc import PNCUtil
@@ -84,6 +84,8 @@ class AddImageContentManifestPlugin(PreBuildPlugin):
         'content_sets': [],
         'image_contents': [],
     }
+
+    args_from_user_params = map_to_user_params("remote_sources")
 
     def __init__(self, workflow, remote_sources=None, destdir=IMAGE_BUILD_INFO_DIR):
         """

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -71,6 +71,12 @@ class AddLabelsPlugin(PreBuildPlugin):
     key = "add_labels_in_dockerfile"
     is_allowed_to_fail = False
 
+    @staticmethod
+    def args_from_user_params(user_params: dict) -> dict:
+        if release := user_params.get("release"):
+            return {"labels": {"release": release}}
+        return {}
+
     def __init__(self, workflow, labels=None, dont_overwrite=None,
                  auto_labels=("build-date",
                               "architecture",

--- a/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
+++ b/atomic_reactor/plugins/pre_add_yum_repo_by_url.py
@@ -24,7 +24,7 @@ Example configuration to add content of repo file at URL:
 
 """
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import is_scratch_build
+from atomic_reactor.util import is_scratch_build, map_to_user_params
 from atomic_reactor.utils.yum import YumRepo
 from urllib.parse import urlparse
 
@@ -32,6 +32,8 @@ from urllib.parse import urlparse
 class AddYumRepoByUrlPlugin(PreBuildPlugin):
     key = "add_yum_repo_by_url"
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("repourls:yum_repourls")
 
     def __init__(self, workflow, repourls=None, inject_proxy=None):
         """

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -14,7 +14,7 @@ from atomic_reactor.plugins.pre_fetch_sources import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY, PROG, KOJI_RESERVE_MAX_RETRIES,
                                       KOJI_RESERVE_RETRY_DELAY)
 from atomic_reactor.config import get_koji_session
-from atomic_reactor.util import get_build_json, is_scratch_build
+from atomic_reactor.util import get_build_json, is_scratch_build, map_to_user_params
 from koji import GenericError
 import koji
 
@@ -27,6 +27,8 @@ class BumpReleasePlugin(PreBuildPlugin):
 
     key = PLUGIN_BUMP_RELEASE_KEY
     is_allowed_to_fail = False  # We really want to stop the process
+
+    args_from_user_params = map_to_user_params("append:flatpak")
 
     # The target parameter is no longer used by this plugin. It's
     # left as an optional parameter to allow a graceful transition

--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -16,7 +16,7 @@ when koji build tags change.
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (get_platforms_in_limits, is_scratch_build, is_isolated_build,
-                                 get_orchestrator_platforms)
+                                 get_orchestrator_platforms, map_to_user_params)
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 from atomic_reactor.config import get_koji_session
 
@@ -24,6 +24,8 @@ from atomic_reactor.config import get_koji_session
 class CheckAndSetPlatformsPlugin(PreBuildPlugin):
     key = PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("koji_target")
 
     def __init__(self, workflow, koji_target=None):
 

--- a/atomic_reactor/plugins/pre_check_user_settings.py
+++ b/atomic_reactor/plugins/pre_check_user_settings.py
@@ -16,7 +16,8 @@ from atomic_reactor.util import (
     read_content_sets,
     read_fetch_artifacts_koji,
     read_fetch_artifacts_pnc,
-    read_fetch_artifacts_url
+    read_fetch_artifacts_url,
+    map_to_user_params,
 )
 
 from osbs.utils import Labels
@@ -35,6 +36,8 @@ class CheckUserSettingsPlugin(PreBuildPlugin):
     """
     key = PLUGIN_CHECK_USER_SETTINGS
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("flatpak")
 
     def __init__(self, workflow, flatpak=False):
         """

--- a/atomic_reactor/plugins/pre_download_remote_source.py
+++ b/atomic_reactor/plugins/pre_download_remote_source.py
@@ -16,7 +16,7 @@ from shlex import quote
 from atomic_reactor.constants import REMOTE_SOURCE_DIR, CACHITO_ENV_FILENAME, CACHITO_ENV_ARG_ALIAS
 from atomic_reactor.download import download_url
 from atomic_reactor.plugin import PreBuildPlugin
-from atomic_reactor.util import get_retrying_requests_session
+from atomic_reactor.util import get_retrying_requests_session, map_to_user_params
 from atomic_reactor.utils.cachito import CFG_TYPE_B64
 from urllib.parse import urlparse
 
@@ -25,6 +25,8 @@ class DownloadRemoteSourcePlugin(PreBuildPlugin):
     key = 'download_remote_source'
     is_allowed_to_fail = False
     REMOTE_SOURCE = 'unpacked_remote_sources'
+
+    args_from_user_params = map_to_user_params("remote_sources")
 
     def __init__(self, workflow, remote_sources=None):
         """

--- a/atomic_reactor/plugins/pre_fetch_sources.py
+++ b/atomic_reactor/plugins/pre_fetch_sources.py
@@ -19,7 +19,7 @@ from atomic_reactor.constants import (PLUGIN_FETCH_SOURCES_KEY, PNC_SYSTEM_USER,
 from atomic_reactor.config import get_koji_session
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.source import GitSource
-from atomic_reactor.util import get_retrying_requests_session
+from atomic_reactor.util import get_retrying_requests_session, map_to_user_params
 from atomic_reactor.download import download_url
 from atomic_reactor.metadata import label_map
 from atomic_reactor.utils.pnc import PNCUtil
@@ -33,6 +33,12 @@ class FetchSourcesPlugin(PreBuildPlugin):
     SRPMS_DOWNLOAD_DIR = 'image_sources'
     REMOTE_SOURCES_DOWNLOAD_DIR = 'remote_sources'
     MAVEN_SOURCES_DOWNLOAD_DIR = 'maven_sources'
+
+    args_from_user_params = map_to_user_params(
+        "koji_build_id:sources_for_koji_build_id",
+        "koji_build_nvr:sources_for_koji_build_nvr",
+        "signing_intent",
+    )
 
     def __init__(
         self, workflow, koji_build_id=None, koji_build_nvr=None, signing_intent=None,

--- a/atomic_reactor/plugins/pre_flatpak_update_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_update_dockerfile.py
@@ -34,7 +34,7 @@ from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.pre_flatpak_create_dockerfile import (FLATPAK_INCLUDEPKGS_FILENAME,
                                                                   FLATPAK_CLEANUPSCRIPT_FILENAME,
                                                                   get_flatpak_source_spec)
-from atomic_reactor.util import df_parser, is_flatpak_build
+from atomic_reactor.util import df_parser, is_flatpak_build, map_to_user_params
 
 
 # ODCS API constant
@@ -95,6 +95,8 @@ def set_flatpak_compose_info(workflow, source):
 class FlatpakUpdateDockerfilePlugin(PreBuildPlugin):
     key = "flatpak_update_dockerfile"
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("compose_ids")
 
     def __init__(self, workflow, compose_ids=tuple()):
         """

--- a/atomic_reactor/plugins/pre_inject_parent_image.py
+++ b/atomic_reactor/plugins/pre_inject_parent_image.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
+from atomic_reactor.util import map_to_user_params
 from osbs.utils import graceful_chain_get, ImageName
 from atomic_reactor.constants import PLUGIN_INJECT_PARENT_IMAGE_KEY
 from atomic_reactor.config import get_koji_session
@@ -35,6 +36,8 @@ class InjectParentImage(PreBuildPlugin):
 
     key = PLUGIN_INJECT_PARENT_IMAGE_KEY
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("koji_parent_build")
 
     def __init__(self, workflow, koji_parent_build=None):
         """

--- a/atomic_reactor/plugins/pre_koji.py
+++ b/atomic_reactor/plugins/pre_koji.py
@@ -12,13 +12,15 @@ import os
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import YUM_REPOS_DIR
 from atomic_reactor.utils.yum import YumRepo
-from atomic_reactor.util import render_yum_repo
+from atomic_reactor.util import render_yum_repo, map_to_user_params
 from atomic_reactor.config import get_koji_session
 
 
 class KojiPlugin(PreBuildPlugin):
     key = "koji"
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("target:koji_target")
 
     def __init__(self, workflow, target=None):
         """

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -20,7 +20,8 @@ from atomic_reactor.util import (RegistrySession,
                                  RegistryClient,
                                  has_operator_bundle_manifest,
                                  read_yaml_from_url, df_parser,
-                                 terminal_key_paths,)
+                                 terminal_key_paths,
+                                 map_to_user_params)
 from osbs.utils.yaml import (
     load_schema,
     validate_with_schema,
@@ -54,6 +55,11 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
 
     key = PLUGIN_PIN_OPERATOR_DIGESTS_KEY
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params(
+        "replacement_pullspecs:operator_bundle_replacement_pullspecs",
+        "operator_csv_modifications_url",
+    )
 
     def __init__(self, workflow, replacement_pullspecs=None,
                  operator_csv_modifications_url=None):

--- a/atomic_reactor/plugins/pre_pull_base_image.py
+++ b/atomic_reactor/plugins/pre_pull_base_image.py
@@ -19,7 +19,7 @@ import docker
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (get_build_json, get_platforms, base_image_is_custom,
                                  get_checksums, get_manifest_media_type,
-                                 RegistrySession, RegistryClient)
+                                 RegistrySession, RegistryClient, map_to_user_params)
 from atomic_reactor.utils import imageutil
 from io import BytesIO
 from requests.exceptions import HTTPError, RetryError, Timeout
@@ -29,6 +29,8 @@ from osbs.utils import ImageName
 class PullBaseImagePlugin(PreBuildPlugin):
     key = "pull_base_image"
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("parent_images_digests")
 
     def __init__(self, workflow, check_platforms=False, inspect_only=False,
                  parent_images_digests=None):

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -39,6 +39,13 @@ class ResolveComposesPlugin(PreBuildPlugin):
     key = PLUGIN_RESOLVE_COMPOSES_KEY
     is_allowed_to_fail = False
 
+    args_from_user_params = util.map_to_user_params(
+        "koji_target",
+        "signing_intent",
+        "compose_ids",
+        "repourls:yum_repourls",
+    )
+
     def __init__(self, workflow, koji_target=None, signing_intent=None, compose_ids=tuple(),
                  repourls=None, minimum_time_to_expire=MINIMUM_TIME_TO_EXPIRE):
         """

--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -18,7 +18,7 @@ from atomic_reactor.config import get_koji_session, get_cachito_session
 from atomic_reactor.utils.koji import get_koji_task_owner
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
-from atomic_reactor.util import get_build_json, is_scratch_build
+from atomic_reactor.util import get_build_json, is_scratch_build, map_to_user_params
 
 
 class ResolveRemoteSourcePlugin(PreBuildPlugin):
@@ -31,6 +31,8 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
 
     key = PLUGIN_RESOLVE_REMOTE_SOURCE
     is_allowed_to_fail = False
+
+    args_from_user_params = map_to_user_params("dependency_replacements")
 
     def __init__(self, workflow, dependency_replacements=None):
         """

--- a/atomic_reactor/tasks/orchestrator.py
+++ b/atomic_reactor/tasks/orchestrator.py
@@ -43,7 +43,7 @@ class OrchestratorTask(plugin_based.PluginBasedTask):
         postbuild=[
             {"name": "fetch_worker_metadata"},
             {"name": "compare_components"},
-            {"name": "tag_from_config", "args": {"tag_suffixes": "{{TAG_SUFFIXES}}"}},
+            {"name": "tag_from_config"},
             {"name": "group_manifests"},
             {"name": "generate_maven_metadata"},
         ],

--- a/atomic_reactor/tasks/worker.py
+++ b/atomic_reactor/tasks/worker.py
@@ -50,7 +50,7 @@ class WorkerTask(plugin_based.PluginBasedTask):
         ],
         postbuild=[
             {"name": "all_rpm_packages", "args": {"image_id": "BUILT_IMAGE_ID"}},
-            {"name": "tag_from_config", "args": {"tag_suffixes": "{{TAG_SUFFIXES}}"}},
+            {"name": "tag_from_config"},
             {"name": "tag_and_push"},
             {"name": "export_operator_manifests"},
             {"name": "compress", "args": {"load_exported_image": True, "method": "gzip"}},

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -482,13 +482,10 @@ def base_image_is_custom(base_image_name):
 
 
 def get_orchestrator_platforms(workflow):
-    try:
-        orchestrate_build_plugin = workflow.get_orchestrate_build_plugin()
-    except ValueError:
-        # Not an orchestrator build
-        return None
+    if workflow.is_orchestrator_build():
+        return workflow.user_params.get("platforms")
     else:
-        return orchestrate_build_plugin['args']['platforms']
+        return None
 
 
 def get_platforms(workflow):

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -853,3 +853,12 @@ def test_release_label(tmpdir, workflow, caplog, base_new, df_new, plugin_new,
 
     if expected_log:
         assert expected_log in caplog.text
+
+
+def test_labels_from_user_params(workflow):
+    workflow.user_params["release"] = "42"
+
+    runner = PreBuildPluginsRunner(workflow, [])
+    plugin = runner.create_instance_from_plugin(AddLabelsPlugin, {})
+
+    assert plugin.labels == {"release": "42"}

--- a/tests/plugins/test_check_and_set_platforms.py
+++ b/tests/plugins/test_check_and_set_platforms.py
@@ -95,8 +95,8 @@ def write_container_yaml(tmpdir, platform_exclude='', platform_only=''):
 
 
 def set_orchestrator_platforms(workflow, orchestrator_platforms):
-    workflow.buildstep_plugins_conf = [{'name': PLUGIN_BUILD_ORCHESTRATE_KEY,
-                                        'args': {'platforms': orchestrator_platforms}}]
+    workflow.buildstep_plugins_conf = [{'name': PLUGIN_BUILD_ORCHESTRATE_KEY}]
+    workflow.user_params['platforms'] = orchestrator_platforms
 
 
 def prepare(tmpdir, labels=None):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -61,6 +61,7 @@ from atomic_reactor.util import (LazyGit, figure_out_build_file,
                                  has_operator_appregistry_manifest,
                                  has_operator_bundle_manifest, DockerfileImages,
                                  terminal_key_paths,
+                                 map_to_user_params,
                                  )
 from tests.constants import (DOCKERFILE_GIT, MOCK, REACTOR_CONFIG_MAP)
 import atomic_reactor.util
@@ -1951,3 +1952,18 @@ def test_dockerfile_images(source_registry, organization, dockerfile_images, bas
 def test_terminal_key_paths(data, expected):
     """Unittest for terminal_key_paths data"""
     assert set(terminal_key_paths(data)) == expected
+
+
+def test_map_to_user_params():
+    get_args = map_to_user_params(
+        "arg1",
+        "arg2:param2",
+        "arg_none",
+        "arg_missing",
+    )
+    user_params = {
+        "arg1": 1,
+        "param2": 2,
+        "arg_none": None,
+    }
+    assert get_args(user_params) == {"arg1": 1, "arg2": 2}

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -986,21 +986,18 @@ def test_is_flatpak_build(workflow, extra_user_params, flatpak, user_params):
     assert is_flatpak_build(workflow) == flatpak
 
 
-@pytest.mark.parametrize(('inputs', 'results'), [
-    (None, None),
-    ([], None),
-    ([{'name': 'Bogus', 'args': {'platforms': ['spam']}}], None),
-    ([{'name': 'Bogus', 'args': {'platforms': ['spam']}},
-      {'name': PLUGIN_BUILD_ORCHESTRATE_KEY, 'args': {'platforms': ['ppce64le', 'arm64']}}],
-     ['arm64', 'ppce64le'])
-])
-def test_get_orchestrator_platforms(inputs, results, user_params):
-    workflow = DockerBuildWorkflow(source=None,
-                                   buildstep_plugins=inputs)
-    if results:
-        assert sorted(get_orchestrator_platforms(workflow)) == sorted(results)
+@pytest.mark.parametrize("is_orchestrator", [True, False])
+def test_get_orchestrator_platforms(is_orchestrator, user_params):
+    workflow = DockerBuildWorkflow(source=None)
+    if is_orchestrator:
+        workflow.buildstep_plugins_conf = [{"name": PLUGIN_BUILD_ORCHESTRATE_KEY}]
+
+    workflow.user_params["platforms"] = ["x86_64", "ppc64le"]
+
+    if is_orchestrator:
+        assert get_orchestrator_platforms(workflow) == ["x86_64", "ppc64le"]
     else:
-        assert get_orchestrator_platforms(workflow) == results
+        assert get_orchestrator_platforms(workflow) is None
 
 
 def test_df_parser(tmpdir):


### PR DESCRIPTION
CLOUDBLD-6300

The argument rendering logic that was previously handled by osbs-client
is now handled by atomic-reactor plugins themselves.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
