### PR TITLE
[OCP3] pre_resolve_compose: add a new compose: module_resolve_tags key

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -433,12 +433,18 @@ class ComposeConfig(object):
         self.multilib_arches = []
         self.multilib_method = None
         self.modular_tags = data.get('modular_koji_tags')
+        self.module_resolve_tags = data.get('module_resolve_tags')
         self.koji_tag = koji_tag
 
         if self.modular_tags is True:
             if not self.koji_tag:
                 raise ValueError('koji_tag is required when modular_koji_tags is True')
             self.modular_tags = [self.koji_tag]
+
+        if self.module_resolve_tags is True:
+            if not self.koji_tag:
+                raise ValueError('koji_tag is required when module_resolve_tags is True')
+            self.module_resolve_tags = [self.koji_tag]
 
         if data.get('pulp_repos'):
             for arch in pulp_data or {}:
@@ -528,6 +534,10 @@ class ComposeConfig(object):
             'source': ' '.join(noprofile_modules),
             'sigkeys': self.signing_intent['keys'],
         }
+        if self.module_resolve_tags:
+            # For ODCS, modular_koji_tags has a different meaning for source_type=module
+            # and for other source types. We use different keys for the two types.
+            request['modular_koji_tags'] = self.module_resolve_tags
         if self.arches:
             request['arches'] = self.arches
         return request

--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -97,7 +97,8 @@ class ODCSClient(object):
                         not empty and no mulitlib_method value is provided.
         :param modular_koji_tags: list<str>, the koji tags which are tagged to builds from the
                         modular Koji Content Generator.  Builds with matching tags will be
-                        included in the compose.
+                        included in the compose. For source_type "module" compose, these tags
+                        are used to resolve partially specified modules.
 
         :return: dict, status of compose being created by request.
         """


### PR DESCRIPTION
The module_resolve_tags key specifies that modules that are incompletely
specified (name:stream, not name:stream:version:context) are looked up
in the given set of Koji tags, rather than using the latest built
version in MBS.

This is mapped to koji_modular_tags in the ODCS request, since ODCS
uses koji_modular_tags for both the existing koji_modular_tags meaning
in container.yaml, and also for this meaning. See
https://pagure.io/odcs/pull-request/496

* CLOUDBLD-4225

Signed-off-by: Owen W. Taylor <otaylor@fishsoup.net>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
