### PR TITLE
stop exporting buildroot metadata

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -750,21 +750,8 @@ class KojiImportSourceContainerPlugin(KojiImportBase):
         """
         buildroots = []
 
-        buildroot = koji_get_buildroot(build_id=self.build_id, osbs=self.osbs, rpms=False)
+        buildroot = koji_get_buildroot()
         buildroot['id'] = '{}-{}'.format(buildroot['container']['arch'], buildroot['id'])
-
-        registry = self.workflow.push_conf.docker_registries[0]
-        build_name = get_unique_images(self.workflow)[0].to_str()
-
-        manifest_digest = registry.digests[build_name]
-        digest_version = get_manifest_media_version(manifest_digest)
-        media_type = get_manifest_media_type(digest_version)
-
-        buildroot['extra']['osbs']['koji'] = {
-            'build_name': build_name,
-            'builder_image_id': {media_type: manifest_digest.default}
-        }
-
         buildroots.append(buildroot)
         return buildroots
 

--- a/tests/files/example-koji-metadata-ppc64le.json
+++ b/tests/files/example-koji-metadata-ppc64le.json
@@ -2,7 +2,7 @@
   "buildroots": [
     {
       "container": {
-        "type": "docker",
+        "type": "none",
         "arch": "ppc64le"
       },
       "content_generator": {
@@ -13,90 +13,6 @@
         "os": "Red Hat Enterprise Linux Server 7.3 (Maipo)",
         "arch": "ppc64le"
       },
-      "components": [
-        {
-          "name": "python-ethtool",
-          "sigmd5": "af8ee0374e8160dc19b2598da2b22162",
-          "arch": "ppc64le",
-          "epoch": null,
-          "version": "0.8",
-          "signature": "199e2f91fd431d51",
-          "release": "5.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "python-kitchen",
-          "sigmd5": "25c2edc551a562b6d0f53444b439a895",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "1.1.1",
-          "signature": "199e2f91fd431d51",
-          "release": "5.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "rootfiles",
-          "sigmd5": "44409ce44e76605dacfa2aaece2daf31",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "8.1",
-          "signature": "199e2f91fd431d51",
-          "release": "11.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "bash",
-          "sigmd5": "f972a9919443a8f08420c99d8ad44b9d",
-          "arch": "ppc64le",
-          "epoch": null,
-          "version": "4.2.46",
-          "signature": "199e2f91fd431d51",
-          "release": "28.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "perl-URI",
-          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
-          "arch": "noarch",
-          "epoch": 4,
-          "version": "1.71",
-          "signature": null,
-          "release": "1.el7eng",
-          "type": "rpm"
-        },
-        {
-          "name": "perl-HTTP-Date",
-          "sigmd5": "13f25441e44fb9f67a62144ac51772a6",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "6.02",
-          "signature": "199e2f91fd431d51",
-          "release": "8.el7",
-          "type": "rpm"
-        }
-      ],
-      "tools": [
-        {
-          "version": "1.10.6",
-          "name": "docker-py"
-        },
-        {
-          "version": "1.0.5",
-          "name": "docker_squash"
-        },
-        {
-          "version": "1.6.24.1",
-          "name": "atomic_reactor"
-        },
-        {
-          "version": "0.40.1",
-          "name": "osbs-client"
-        },
-        {
-          "version": "1.12.6",
-          "name": "docker"
-        }
-      ],
       "id": 1
     }
   ],

--- a/tests/files/example-koji-metadata-x86_64.json
+++ b/tests/files/example-koji-metadata-x86_64.json
@@ -2,7 +2,7 @@
   "buildroots": [
     {
       "container": {
-        "type": "docker",
+        "type": "none",
         "arch": "x86_64"
       },
       "content_generator": {
@@ -13,90 +13,6 @@
         "os": "Red Hat Enterprise Linux Server 7.3 (Maipo)",
         "arch": "x86_64"
       },
-      "components": [
-        {
-          "name": "python-ethtool",
-          "sigmd5": "af8ee0374e8160dc19b2598da2b22162",
-          "arch": "x86_64",
-          "epoch": null,
-          "version": "0.8",
-          "signature": "199e2f91fd431d51",
-          "release": "5.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "python-kitchen",
-          "sigmd5": "25c2edc551a562b6d0f53444b439a895",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "1.1.1",
-          "signature": "199e2f91fd431d51",
-          "release": "5.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "rootfiles",
-          "sigmd5": "44409ce44e76605dacfa2aaece2daf31",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "8.1",
-          "signature": "199e2f91fd431d51",
-          "release": "11.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "bash",
-          "sigmd5": "f972a9919443a8f08420c99d8ad44b9d",
-          "arch": "x86_64",
-          "epoch": null,
-          "version": "4.2.46",
-          "signature": "199e2f91fd431d51",
-          "release": "28.el7",
-          "type": "rpm"
-        },
-        {
-          "name": "perl-URI",
-          "sigmd5": "4bf2ed4cb63b3c2fbbf77664460d292b",
-          "arch": "noarch",
-          "epoch": 4,
-          "version": "1.71",
-          "signature": null,
-          "release": "1.el7eng",
-          "type": "rpm"
-        },
-        {
-          "name": "perl-HTTP-Date",
-          "sigmd5": "13f25441e44fb9f67a62144ac51772a6",
-          "arch": "noarch",
-          "epoch": null,
-          "version": "6.02",
-          "signature": "199e2f91fd431d51",
-          "release": "8.el7",
-          "type": "rpm"
-        }
-      ],
-      "tools": [
-        {
-          "version": "1.10.6",
-          "name": "docker-py"
-        },
-        {
-          "version": "1.0.5",
-          "name": "docker_squash"
-        },
-        {
-          "version": "1.6.24.1",
-          "name": "atomic_reactor"
-        },
-        {
-          "version": "0.40.1",
-          "name": "osbs-client"
-        },
-        {
-          "version": "1.12.6",
-          "name": "docker"
-        }
-      ],
       "id": 1
     }
   ],

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -394,15 +394,8 @@ def mock_environment(tmpdir, session=None, name=None,
             'buildroots': [
                 {
                     'container': {
-                        'type': 'docker',
+                        'type': 'none',
                         'arch': 'x86_64'
-                    },
-                    'extra': {
-                        'osbs': {
-                            'build_id': '12345',
-                            'builder_image_id': '67890',
-                            'koji': {'build_name': 'myproject/hello-world:unique-tag'}
-                        }
                     },
                     'content_generator': {
                         'version': '1.6.23',
@@ -412,34 +405,6 @@ def mock_environment(tmpdir, session=None, name=None,
                         'os': 'Red Hat Enterprise Linux Server 7.3 (Maipo)',
                         'arch': 'x86_64'
                     },
-                    'components': [
-                        {
-                            'name': 'perl-Net-LibIDN',
-                            'sigmd5': '1dba38d073ea8f3e6c99cfe32785c81e',
-                            'arch': 'x86_64',
-                            'epoch': None,
-                            'version': '0.12',
-                            'signature': '199e2f91fd431d51',
-                            'release': '15.el7',
-                            'type': 'rpm'
-                        },
-                        {
-                            'name': 'tzdata',
-                            'sigmd5': '2255a5807ca7e4d7274995db18e52bea',
-                            'arch': 'noarch',
-                            'epoch': None,
-                            'version': '2017b',
-                            'signature': '199e2f91fd431d51',
-                            'release': '1.el7',
-                            'type': 'rpm'
-                        },
-                    ],
-                    'tools': [
-                        {
-                            'version': '1.12.6',
-                            'name': 'docker'
-                        }
-                    ],
                     'id': 1
                 }
             ],
@@ -918,9 +883,6 @@ class TestKojiImport(object):
             'host',
             'content_generator',
             'container',
-            'tools',
-            'components',
-            'extra',
         }
 
         host = buildroot['host']
@@ -946,37 +908,9 @@ class TestKojiImport(object):
         assert isinstance(container, dict)
         assert set(container.keys()) == {'type', 'arch'}
 
-        assert container['type'] == 'docker'
+        assert container['type'] == 'none'
         assert container['arch']
         assert is_string_type(container['arch'])
-
-        assert isinstance(buildroot['tools'], list)
-        assert len(buildroot['tools']) > 0
-        for tool in buildroot['tools']:
-            assert isinstance(tool, dict)
-            assert set(tool.keys()) == {'name', 'version'}
-
-            assert tool['name']
-            assert is_string_type(tool['name'])
-#            assert tool['version']
-#            assert is_string_type(tool['version'])
-
-        if not source:
-            self.check_components(buildroot['components'])
-        else:
-            assert buildroot['components'] == []
-
-        extra = buildroot['extra']
-        assert isinstance(extra, dict)
-        assert set(extra.keys()) == {'osbs'}
-
-        assert 'osbs' in extra
-        osbs = extra['osbs']
-        assert isinstance(osbs, dict)
-        assert set(osbs.keys()) == {'build_id', 'builder_image_id', 'koji'}
-
-        assert is_string_type(osbs['build_id'])
-        assert is_string_type(osbs['builder_image_id'])
 
     def validate_output(self, output, has_config, source=False):
         assert isinstance(output, dict)


### PR DESCRIPTION
Since we're moving to OpenShift Pipelines
OSBS will not be a buildroot anymore, making
the buildroot metadata related to OSBS
unnecessary

* CLOUDBLD-7747

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
