### PR TITLE
Remove two unused DockerBuildWorkflow attributes

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -486,7 +486,6 @@ class DockerBuildWorkflow(object):
         # info about pre-declared build, build-id and token
         self.reserved_build_id = None
         self.reserved_token = None
-        self.cancel_isolated_autorebuild = False
         self.koji_source_nvr = {}
         self.koji_source_source_url = None
         self.koji_source_manifest = None
@@ -504,7 +503,6 @@ class DockerBuildWorkflow(object):
 
         self.df_dir = build_file_dir
         self._df_path = None
-        self.original_df = None
         self.buildargs = {}  # --buildargs for container build
         self.dockerfile_images = DockerfileImages([])
         # OSBS2 TBD

--- a/atomic_reactor/plugins/pre_change_from_in_df.py
+++ b/atomic_reactor/plugins/pre_change_from_in_df.py
@@ -54,7 +54,6 @@ class ChangeFromPlugin(PreBuildPlugin):
 
     def run(self):
         dfp = df_parser(self.workflow.df_path)
-        self.workflow.original_df = dfp.content
 
         df_base = dfp.baseimage
         build_base = self.workflow.dockerfile_images.base_image

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -266,7 +266,6 @@ def test_update_parent_images(df_content, expected_df_content, tmpdir):
     original_base = workflow.dockerfile_images.base_image
     run_plugin(workflow)
     assert dfp.content == expected_df_content
-    assert workflow.original_df == df_content
     if workflow.dockerfile_images.base_from_scratch:
         assert original_base == workflow.dockerfile_images.base_image
 

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -45,7 +45,6 @@ BUILD_RESULTS_ATTRS = ['build_logs',
 DUMMY_BUILD_RESULT = BuildResult(image_id="image_id")
 DUMMY_FAILED_BUILD_RESULT = BuildResult(fail_reason='it happens')
 DUMMY_REMOTE_BUILD_RESULT = BuildResult.make_remote_image_result()
-DUMMY_ORIGINAL_DF = "FROM test_base_image"
 
 pytestmark = pytest.mark.usefixtures('user_params')
 


### PR DESCRIPTION
Also remove relative code from test and change_from_in_dockerfile
plugin.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
