### PR TITLE
fix remove_workdir in source.py

### DIFF
--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -118,7 +118,12 @@ class Source(object):
         return self._config
 
     def remove_workdir(self):
-        shutil.rmtree(self.workdir)
+        for entry_name in os.listdir(self.workdir):
+            entry_path = os.path.join(self.workdir, entry_name)
+            if os.path.isfile(entry_path):
+                os.unlink(entry_path)
+            else:
+                shutil.rmtree(entry_path)
 
     def get_vcs_info(self):
         """Returns VcsInfo namedtuple or None if not applicable."""


### PR DESCRIPTION
we can't delete the whole directory because it might
be mounted so we have to remove its contents

* CLOUDBLD-7741

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
