### PR TITLE
allow isolated flatpaks

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -14,7 +14,7 @@ from atomic_reactor.plugins.pre_fetch_sources import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.constants import (PLUGIN_BUMP_RELEASE_KEY, PROG, KOJI_RESERVE_MAX_RETRIES,
                                       KOJI_RESERVE_RETRY_DELAY)
 from atomic_reactor.config import get_koji_session
-from atomic_reactor.util import is_scratch_build, map_to_user_params
+from atomic_reactor.util import is_scratch_build
 from koji import GenericError
 import koji
 
@@ -28,7 +28,13 @@ class BumpReleasePlugin(PreBuildPlugin):
     key = PLUGIN_BUMP_RELEASE_KEY
     is_allowed_to_fail = False  # We really want to stop the process
 
-    args_from_user_params = map_to_user_params("append:flatpak")
+    @staticmethod
+    def args_from_user_params(user_params: dict) -> dict:
+        flatpak = user_params.get("flatpak")
+        isolated = user_params.get("isolated")
+        if flatpak and not isolated:
+            return {"append": True}
+        return {}
 
     # The target parameter is no longer used by this plugin. It's
     # left as an optional parameter to allow a graceful transition


### PR DESCRIPTION
set append for bump_release only for flatpaks which aren't isolated

* CLOUDBLD-7764

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
