### PR TITLE
pin down flexmock 0.11.0 and fix tests

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -39,7 +39,7 @@ flake8==4.0.1
     # via -r tests/requirements.in
 flatpak-module-tools==0.12 ; python_version < "3.9"
     # via -r requirements.in
-flexmock==0.10.10
+flexmock==0.11.1
     # via -r tests/requirements.in
 gssapi==1.7.2
     # via

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 
 import logging
 
-import flexmock
+from flexmock import flexmock
 import osbs
 import pytest
 

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-import flexmock
+from flexmock import flexmock
 
 from atomic_reactor.cli import task
 from atomic_reactor.tasks import orchestrator, worker, sources, common, binary

--- a/tests/plugins/test_pull_base_image.py
+++ b/tests/plugins/test_pull_base_image.py
@@ -7,7 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import docker
-import flexmock
+from flexmock import flexmock
 import json
 import sys
 import pytest

--- a/tests/plugins/test_remove_built_image.py
+++ b/tests/plugins/test_remove_built_image.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from atomic_reactor.inner import DockerBuildWorkflow

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -147,9 +147,8 @@ class TestSquashPlugin(object):
 
             return new_id
 
-        squash = flexmock()
-        squash.should_receive('run').replace_with(mock_run)
-        flexmock(Squash).new_instances(squash).with_args(Squash, **kwargs)
+        flexmock(Squash).should_receive('run').replace_with(mock_run)
+        flexmock(Squash).should_receive('__init__').with_args(**kwargs)
 
         flexmock(exit_remove_built_image).should_receive('defer_removal')
 

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -1,4 +1,4 @@
-flexmock>=0.10.6
+flexmock>=0.11.0
 responses>=0.9.0,<0.10.8
 pypng
 # 5.0 is the minimum version required by latest version of pytest-html. As of

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -68,8 +68,9 @@ flake8==4.0.1 \
     --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
     --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
     # via -r tests/requirements.in
-flexmock==0.10.10 \
-    --hash=sha256:8bb073f4b7b590672e8c312e73d6a14f88ae624a867b691462f9e8c24b9f19d1
+flexmock==0.11.1 \
+    --hash=sha256:1c51371767f968e1d2f505138de72b07704ecebc9b34e0b52ffdeeb510685c3f \
+    --hash=sha256:8cdd911f48d0696efd41231dbbd63fb1eb8290b34b0bb691019739d6cd94eadd
     # via -r tests/requirements.in
 idna==3.3 \
     --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \

--- a/tests/tasks/test_common.py
+++ b/tests/tasks/test_common.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from dataclasses import dataclass
 from typing import Optional, ClassVar
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from atomic_reactor import source

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -6,7 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-import flexmock
+from flexmock import flexmock
 import pytest
 
 from osbs.exceptions import OsbsValidationException

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -10,7 +10,7 @@ from atomic_reactor.utils.cachito import (
     CachitoAPI, CachitoAPIInvalidRequest, CachitoAPIRequestTimeout, CachitoAPIUnsuccessfulRequest)
 
 from requests.exceptions import HTTPError
-import flexmock
+from flexmock import flexmock
 import pytest
 import responses
 import json

--- a/tests/utils/test_koji.py
+++ b/tests/utils/test_koji.py
@@ -16,7 +16,7 @@ from atomic_reactor.utils.koji import (koji_login, create_koji_session,
 from atomic_reactor.plugin import BuildCanceledException
 from atomic_reactor.constants import (KOJI_MAX_RETRIES, KOJI_RETRY_INTERVAL,
                                       KOJI_OFFLINE_RETRY_INTERVAL)
-import flexmock
+from flexmock import flexmock
 import pytest
 
 

--- a/tests/utils/test_odcs.py
+++ b/tests/utils/test_odcs.py
@@ -10,7 +10,7 @@ from atomic_reactor.utils.odcs import (ODCSClient, MULTILIB_METHOD_DEFAULT,
                                        WaitComposeToFinishTimeout)
 from tests.retry_mock import mock_get_retry_session
 
-import flexmock
+from flexmock import flexmock
 import pytest
 import responses
 import json


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
