### PR TITLE
Fetch logs from pipeline run for source container builds

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -122,6 +122,7 @@ class KojiImportBase(ExitPlugin):
         self.koji_task_id = None
         self.session = None
         self.reserve_build = self.workflow.conf.koji.get('reserve_build', False)
+        self.pipeline_run_name = None
 
     def get_output(self, *args):
         # Must be implemented by subclasses
@@ -412,7 +413,7 @@ class KojiImportBase(ExitPlugin):
             return Output(file=logfile, metadata=metadata)
 
         try:
-            self.build_id = self.workflow.user_params['pipeline_run_name']
+            self.pipeline_run_name = self.workflow.user_params['pipeline_run_name']
         except KeyError:
             self.log.error("No pipeline_run_name found")
             raise
@@ -428,7 +429,7 @@ class KojiImportBase(ExitPlugin):
         output, output_file = self.get_output(worker_metadatas, buildroot_id)
         osbs_logs = OSBSLogs(self.log)
         output_files = [add_log_type(add_buildroot_id(md, buildroot_id))
-                        for md in osbs_logs.get_log_files(self.osbs, self.build_id)]
+                        for md in osbs_logs.get_log_files(self.osbs, self.pipeline_run_name)]
 
         output.extend([of.metadata for of in output_files])
         if output_file:

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -323,6 +323,8 @@ def get_buildroot():
             'type': 'none',
             'arch': os.uname()[4],
         },
+        'components': [],
+        'tools': [],
     }
 
     return buildroot

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -58,6 +58,8 @@ IMPORTED_IMAGE_ID = 'eee28534d167d7b3297eace1fc32c46aabedc40696e48ae04c7654f9747
 
 IMAGE_RAISE_RETRYGENERATOREXCEPTION = 'registry.example.com/non-existing-parent-image'
 
+OSBS_BUILD_LOG_FILENAME = 'osbs_build.log'
+
 REACTOR_CONFIG_MAP = dedent("""\
 version: 1
 koji:

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -409,7 +409,9 @@ def mock_environment(tmpdir, session=None, name=None,
                         'os': 'Red Hat Enterprise Linux Server 7.3 (Maipo)',
                         'arch': 'x86_64'
                     },
-                    'id': 1
+                    'id': 1,
+                    'components': [],
+                    'tools': [],
                 }
             ],
             'metadata_version': 0,
@@ -887,6 +889,8 @@ class TestKojiImport(object):
             'host',
             'content_generator',
             'container',
+            'components',
+            'tools',
         }
 
         host = buildroot['host']


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
