### PR TITLE
Add tox with mypy and pytype checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = mypy,pytype
+
+[testenv]
+deps =
+    -rrequirements.txt
+
+[testenv:mypy]
+skip_install = true
+commands =
+    pip install mypy  # cannot be in deps due requirement of hashes
+    mypy -p atomic_reactor --install-types --non-interactive --ignore-missing-imports
+
+[testenv:pytype]
+skip_install = true
+commands =
+    pip install pytype  # cannot be in deps due requirement of hashes
+    pytype atomic_reactor
+


### PR DESCRIPTION
mypy - checks annotations
pytype - mypy on stereoids

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
