### PR TITLE
Make tests not rely on a real remote git repo

### DIFF
--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -19,7 +19,7 @@ from atomic_reactor.plugin import (PreBuildPlugin, PrePublishPlugin, PostBuildPl
                                    BuildStepPlugin, InappropriateBuildStepError)
 from flexmock import flexmock
 import pytest
-from tests.util import requires_internet, is_string_type
+from tests.util import is_string_type
 from tests.constants import DOCKERFILE_MULTISTAGE_CUSTOM_BAD_PATH
 import inspect
 import signal
@@ -719,7 +719,6 @@ class ExitUsesSource(ExitWatched):
         WatchedMixIn.run(self)
 
 
-@requires_internet
 def test_source_not_removed_for_exit_plugins(build_dir):
     flexmock(DockerfileParser, content='df_content')
     mock_inspect()

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -14,8 +14,7 @@ from atomic_reactor.source import (
 )
 from osbs.exceptions import OsbsValidationException
 
-from tests.constants import DOCKERFILE_GIT, SOURCE_CONFIG_ERROR_PATH
-from tests.util import requires_internet
+from tests.constants import SOURCE_CONFIG_ERROR_PATH
 
 
 class TestSource(object):
@@ -24,13 +23,18 @@ class TestSource(object):
         assert os.path.exists(s.workdir)
 
 
-@requires_internet
 class TestGitSource(object):
-    def test_checks_out_repo(self):
-        gs = GitSource('git', DOCKERFILE_GIT)
+    @pytest.mark.parametrize("add_git_suffix", [True, False])
+    def test_checks_out_repo(self, local_fake_repo, add_git_suffix):
+        if add_git_suffix:
+            repo_url = local_fake_repo + ".git"
+            os.rename(local_fake_repo, repo_url)
+        else:
+            repo_url = local_fake_repo
+        gs = GitSource('git', repo_url)
         gs.get()
         assert os.path.exists(os.path.join(gs.path, '.git'))
-        assert os.path.basename(gs.path) == 'docker-hello-world'
+        assert os.path.basename(gs.path) == 'app-operator'
         assert gs.commit_id is not None
         assert len(gs.commit_id) == 40  # current git hashes are this long
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -63,7 +63,7 @@ from atomic_reactor.util import (LazyGit, figure_out_build_file,
                                  terminal_key_paths,
                                  map_to_user_params,
                                  )
-from tests.constants import (DOCKERFILE_GIT, MOCK, REACTOR_CONFIG_MAP)
+from tests.constants import MOCK, REACTOR_CONFIG_MAP
 import atomic_reactor.util
 from atomic_reactor.utils import imageutil
 from atomic_reactor.constants import INSPECT_CONFIG
@@ -71,7 +71,6 @@ from atomic_reactor.source import SourceConfig
 from osbs.utils import ImageName
 from osbs.exceptions import OsbsValidationException
 from tests.mock_env import MockEnv
-from tests.util import requires_internet
 from tests.stubs import StubSource
 from tests.constants import OSBS_BUILD_LOG_FILENAME
 
@@ -142,9 +141,8 @@ def test_figure_out_build_file(tmpdir, contents, local_path, expected_path, expe
         assert expected_exception in str(e.value)
 
 
-@requires_internet
-def test_lazy_git():
-    lazy_git = LazyGit(git_url=DOCKERFILE_GIT)
+def test_lazy_git(local_fake_repo):
+    lazy_git = LazyGit(git_url=local_fake_repo)
     lazy_git.clone()
     with lazy_git:
         assert lazy_git.git_path is not None
@@ -158,10 +156,9 @@ def test_lazy_git():
         assert len(lazy_git.commit_id) == 40  # current git hashes are this long
 
 
-@requires_internet
-def test_lazy_git_with_tmpdir(tmpdir):
-    t = str(tmpdir.realpath())
-    lazy_git = LazyGit(git_url=DOCKERFILE_GIT, tmpdir=t)
+def test_lazy_git_with_tmpdir(local_fake_repo, tmpdir):
+    t = str(tmpdir.join("lazy-git-tmp-dir").realpath())
+    lazy_git = LazyGit(git_url=local_fake_repo, tmpdir=t)
     lazy_git.clone()
     assert lazy_git._tmpdir == t
     assert lazy_git.git_path is not None

--- a/tests/util.py
+++ b/tests/util.py
@@ -7,7 +7,6 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-import pytest
 import requests
 import uuid
 
@@ -72,9 +71,6 @@ def has_connection():
     except requests.ConnectionError:
         return False
 
-
-# In case we run tests in an environment without internet connection.
-requires_internet = pytest.mark.skipif(not has_connection(), reason="requires internet connection")
 
 FAKE_CSV = '''\
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Signed-off-by: Chenxiong Qi <cqi@redhat.com>

I often encounter problem with the tests which clone a real remote git repository from GitHub, the tests hangs and wait for the git-clone to finish. This patch proposes an additional way to test the GitSource and LazyGit by creating a local git repo.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
