### PR TITLE
Add missing plugin to stub task definition

### DIFF
--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -76,6 +76,7 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
         exit=[
             {"name": "verify_media", "required": False},
             {"name": "koji_import"},
+            {"name": "push_floating_tags"},
             {"name": "koji_tag_build"},
             {"name": "store_metadata"},
             {"name": "sendmail"},


### PR DESCRIPTION
The push_floating_tags plugin was accidentally omitted, adding it now
to prevent future confusion.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
