### PR TITLE
Make resetting dockerfile_images a bit more sane

### DIFF
--- a/atomic_reactor/config.py
+++ b/atomic_reactor/config.py
@@ -9,7 +9,12 @@ of the BSD license. See the LICENSE file for details.
 from copy import deepcopy
 from atomic_reactor.utils.cachito import CachitoAPI
 from atomic_reactor.constants import REACTOR_CONFIG_ENV_NAME
-from atomic_reactor.util import (read_yaml, read_yaml_from_file_path, DefaultKeyDict)
+from atomic_reactor.util import (
+    read_yaml,
+    read_yaml_from_file_path,
+    DefaultKeyDict,
+    DockerfileImages,
+)
 from osbs.utils import RegistryURI
 
 import logging
@@ -263,17 +268,15 @@ class Configuration(object):
 
         logger.info("reading config content %s", self.conf)
 
-    def set_workflow_based_on_config(self, workflow):
+    def update_dockerfile_images_from_config(self, dockerfile_images: DockerfileImages) -> None:
         """
-        Sets attributes in workflow based on config
+        Set source registry and organization in dockerfile images.
         """
-
-        # set source registry and organization
-        if workflow.dockerfile_images:
+        # only update if there are any actual images (not just 'scratch')
+        if dockerfile_images:
             source_registry_docker_uri = self.source_registry['uri'].docker_uri
             organization = self.registries_organization
-            workflow.dockerfile_images.set_source_registry(source_registry_docker_uri,
-                                                           organization)
+            dockerfile_images.set_source_registry(source_registry_docker_uri, organization)
 
     def _get_cluster_configuration(self):
         all_cluster_configs = {}

--- a/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/pre_flatpak_create_dockerfile.py
@@ -153,10 +153,4 @@ class FlatpakCreateDockerfilePlugin(PreBuildPlugin):
         created_files = self.workflow.build_dir.for_all_platforms_copy(_create_dockerfile)
 
         dockerfile_path = created_files[0]
-        self.workflow.set_df_path(str(dockerfile_path))
-
-        # set source registry and organization
-        source_registry_docker_uri = self.workflow.conf.source_registry['uri'].docker_uri
-        organization = self.workflow.conf.registries_organization
-        self.workflow.dockerfile_images.set_source_registry(source_registry_docker_uri,
-                                                            organization)
+        self.workflow.reset_dockerfile_images(str(dockerfile_path))

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -188,6 +188,9 @@ def mock_env(workflow, tmpdir, platform='x86_64', base_layers=0,
     # Ensure to succeed in reading the content_sets.yml
     env.workflow.source.get_build_file_path = lambda: (str(tmpdir), str(tmpdir))
 
+    # TEMP solution until the plugin is updated to read Dockerfiles from build dirs
+    env.workflow._df_path = str(tmpdir)
+
     return env.create_runner()
 
 
@@ -253,7 +256,6 @@ def test_add_image_content_manifest(workflow, requests_mock, tmpdir, caplog,
     if manifest_file_exists:
         tmpdir.join(manifest_file).write("")
     runner = mock_env(workflow, tmpdir, platform, base_layers)
-    runner.workflow.set_df_path(dfp.dockerfile_path)
     runner.workflow.df_dir = str(tmpdir)
     if manifest_file_exists:
         with pytest.raises(PluginFailedException):
@@ -294,7 +296,6 @@ def test_fetch_maven_artifacts_no_pnc_config(workflow, requests_mock, tmpdir, ca
 
     with pytest.raises(PluginFailedException):
         runner = mock_env(workflow, tmpdir, r_c_m_override=r_c_m)
-        runner.workflow.set_df_path(dfp.dockerfile_path)
         runner.run()
 
     msg = 'No PNC configuration found in reactor config map'
@@ -321,7 +322,6 @@ def test_none_remote_source_icm_url(workflow, requests_mock, tmpdir, caplog,
     dfp = util.df_parser(str(tmpdir))
     dfp.content = df_content
     runner = mock_env(workflow, tmpdir, platform, base_layers, remote_sources=None)
-    runner.workflow.set_df_path(dfp.dockerfile_path)
     runner.workflow.df_dir = str(tmpdir)
     expected_output = deepcopy(ICM_MINIMAL_DICT)
     expected_output['image_contents'].append({'purl': PNC_ARTIFACT['purl']})
@@ -356,7 +356,6 @@ def test_no_pnc_artifacts(workflow, requests_mock, tmpdir, caplog, content_sets,
     dfp = util.df_parser(str(tmpdir))
     dfp.content = df_content
     runner = mock_env(workflow, tmpdir, platform, base_layers, pnc_artifacts=False)
-    runner.workflow.set_df_path(dfp.dockerfile_path)
     runner.workflow.df_dir = str(tmpdir)
     expected_output = deepcopy(ICM_DICT)
     expected_output['image_contents'] = expected_output['image_contents'][:-1]

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1052,9 +1052,8 @@ def test_no_base_image(build_dir, source_dir):
     dfp = df_parser(str(source_dir))
     dfp.content = "# no FROM\nADD spam /eggs"
 
-    workflow._df_path = dfp.dockerfile_path
     with pytest.raises(RuntimeError) as exc:
-        workflow.set_df_path(str(source_dir))
+        workflow.reset_dockerfile_images(str(source_dir))
     assert "no base image specified" in str(exc.value)
 
 


### PR DESCRIPTION
Rename the set_df_path method to reset_dockerfile and also give the
method the responsibility of properly setting the registry and
organization from config.

Remove the corresponding logic from the flatpak_create_dockerfile
plugin, which shouldn't have to worry about such details.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
