### PR TITLE
Implement part of ImageUtil

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata.py
+++ b/atomic_reactor/plugins/exit_store_metadata.py
@@ -17,7 +17,6 @@ from atomic_reactor.constants import (PLUGIN_KOJI_UPLOAD_PLUGIN_KEY,
                                       SCRATCH_FROM)
 from atomic_reactor.config import get_openshift_session
 from atomic_reactor.plugin import ExitPlugin
-from atomic_reactor.utils import imageutil
 
 
 class StoreMetadataPlugin(ExitPlugin):
@@ -220,8 +219,8 @@ class StoreMetadataPlugin(ExitPlugin):
                     not self.workflow.dockerfile_images.base_from_scratch):
                 base_image_name = base_image
                 try:
-                    # OSBS2 TBD
-                    base_image_id = imageutil.base_image_inspect().get('Id', "")
+                    # OSBS2 TBD: we probably don't need this and many other annotations anymore
+                    base_image_id = self.workflow.imageutil.base_image_inspect().get('Id', "")
                 except KeyError:
                     base_image_id = ""
             else:

--- a/atomic_reactor/plugins/pre_add_image_content_manifest.py
+++ b/atomic_reactor/plugins/pre_add_image_content_manifest.py
@@ -22,7 +22,6 @@ from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (base_image_is_scratch, df_parser, read_yaml,
                                  read_content_sets, map_to_user_params
                                  )
-from atomic_reactor.utils import imageutil
 from atomic_reactor.utils.pnc import PNCUtil
 
 
@@ -126,8 +125,8 @@ class AddImageContentManifestPlugin(PreBuildPlugin):
             #     *always* have 2 layers
             self._layer_index = 1
         if not base_image_is_scratch(self.dfp.baseimage):
-            # OSBS2 TBD
-            inspect = imageutil.base_image_inspect()
+            # OSBS2 TBD: decide if we need to inspect a specific arch
+            inspect = self.workflow.imageutil.base_image_inspect()
             self._layer_index = len(inspect[INSPECT_ROOTFS][INSPECT_ROOTFS_LAYERS])
         return self._layer_index
 

--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -60,7 +60,6 @@ from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.util import (df_parser,
                                  label_to_string,
                                  LabelFormatter)
-from atomic_reactor.utils import imageutil
 from osbs.utils import Labels
 import json
 import datetime
@@ -278,8 +277,8 @@ class AddLabelsPlugin(PreBuildPlugin):
             base_image_labels = {}
         else:
             try:
-                # OSBS2 TBD
-                config = imageutil.base_image_inspect()[INSPECT_CONFIG]
+                # OSBS2 TBD: inspect the correct architecture
+                config = self.workflow.imageutil.base_image_inspect()[INSPECT_CONFIG]
             except KeyError as exc:
                 message = "base image was not inspected"
                 self.log.error(message)

--- a/atomic_reactor/plugins/pre_change_from_in_df.py
+++ b/atomic_reactor/plugins/pre_change_from_in_df.py
@@ -11,7 +11,6 @@ to the more specific names given by the builder.
 """
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import df_parser, base_image_is_scratch
-from atomic_reactor.utils import imageutil
 
 
 class BaseImageMismatch(RuntimeError):
@@ -92,8 +91,9 @@ class ChangeFromPlugin(PreBuildPlugin):
                 new_parents.append(df_img)
                 continue
             local_image = self.workflow.dockerfile_images[df_img]
-            # OSBS2 TBD
-            inspection = imageutil.get_inspect_for_image(local_image)
+            # OSBS2 TBD: we don't want to map images to Ids anymore,
+            #   but to manifest list digests instead
+            inspection = self.workflow.imageutil.get_inspect_for_image(local_image)
 
             try:
                 parent_image_ids[df_img] = inspection['Id']

--- a/atomic_reactor/plugins/pre_distribution_scope.py
+++ b/atomic_reactor/plugins/pre_distribution_scope.py
@@ -8,7 +8,6 @@ of the BSD license. See the LICENSE file for details.
 from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import df_parser
-from atomic_reactor.utils import imageutil
 
 
 class NothingToCheck(Exception):
@@ -89,11 +88,11 @@ class DistributionScopePlugin(PreBuildPlugin):
             scope = self.get_scope('current', labels)
 
             # Find out the parent's intended scope
-            # OSBS2 TBD
-            inspect = imageutil.base_image_inspect()
+            # OSBS2 TBD: decide if we need to inspect a specific arch
+            inspect = self.workflow.imageutil.base_image_inspect()
             parent_labels = {}
             if not self.workflow.dockerfile_images.base_from_scratch:
-                parent_labels = inspect[INSPECT_CONFIG]['Labels']
+                parent_labels = inspect.get(INSPECT_CONFIG, {}).get('Labels', {})
             parent_scope = self.get_scope('parent', parent_labels)
         except NothingToCheck:
             self.log.debug("no checks performed")

--- a/atomic_reactor/plugins/pre_hide_files.py
+++ b/atomic_reactor/plugins/pre_hide_files.py
@@ -9,7 +9,6 @@ import os
 
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import df_parser
-from atomic_reactor.utils import imageutil
 from atomic_reactor.constants import INSPECT_CONFIG, SCRATCH_FROM
 
 
@@ -91,9 +90,9 @@ class HideFilesPlugin(PreBuildPlugin):
         if parent_image_id == SCRATCH_FROM:
             return
 
-        # OSBS2 TBD
-        inspect = imageutil.get_inspect_for_image(parent_image_id)
-        inherited_user = inspect.get(INSPECT_CONFIG).get('User', '')
+        # OSBS2 TBD: decide if we need to inspect a specific arch
+        inspect = self.workflow.imageutil.get_inspect_for_image(parent_image_id)
+        inherited_user = inspect.get(INSPECT_CONFIG, {}).get('User', '')
 
         if inherited_user:
             add_start_lines.append('USER root')

--- a/atomic_reactor/plugins/pre_inject_yum_repo.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repo.py
@@ -16,7 +16,6 @@ from atomic_reactor.constants import YUM_REPOS_DIR, RELATIVE_REPOS_PATH, INSPECT
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import df_parser
 from atomic_reactor.utils.yum import YumRepo
-from atomic_reactor.utils import imageutil
 
 
 class InjectYumRepoPlugin(PreBuildPlugin):
@@ -29,9 +28,9 @@ class InjectYumRepoPlugin(PreBuildPlugin):
             return user
 
         if not self.workflow.dockerfile_images.base_from_scratch:
-            # OSBS2 TBD
-            inspect = imageutil.base_image_inspect()
-            user = inspect.get(INSPECT_CONFIG).get('User')
+            # OSBS2 TBD: decide if we need to inspect a specific arch
+            inspect = self.workflow.imageutil.base_image_inspect()
+            user = inspect.get(INSPECT_CONFIG, {}).get('User')
             if user:
                 return f'USER {user}'
 

--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -15,7 +15,6 @@ from atomic_reactor.util import (
     base_image_is_custom, get_manifest_media_type, is_scratch_build,
     get_platforms, RegistrySession, RegistryClient
 )
-from atomic_reactor.utils import imageutil
 from copy import copy
 from osbs.utils import Labels
 
@@ -83,8 +82,8 @@ class KojiParentPlugin(PreBuildPlugin):
                 self.workflow.dockerfile_images.custom_base_image):
             self._base_image_nvr = self.detect_parent_image_nvr(
                 self.workflow.dockerfile_images.base_image,
-                # OSBS2 TBD
-                inspect_data=imageutil.base_image_inspect(),
+                # OSBS2 TBD: decide if we need to inspect a specific arch
+                inspect_data=self.workflow.imageutil.base_image_inspect(),
             )
 
         manifest_mismatches = []
@@ -253,8 +252,8 @@ class KojiParentPlugin(PreBuildPlugin):
         """
 
         if inspect_data is None:
-            # OSBS2 TBD
-            inspect_data = imageutil.get_inspect_for_image(image_name)
+            # OSBS2 TBD: decide if we need to inspect a specific arch
+            inspect_data = self.workflow.imageutil.get_inspect_for_image(image_name)
         labels = Labels(inspect_data[INSPECT_CONFIG].get('Labels', {}))
 
         label_names = [Labels.LABEL_TYPE_COMPONENT, Labels.LABEL_TYPE_VERSION,

--- a/atomic_reactor/plugins/prepub_squash.py
+++ b/atomic_reactor/plugins/prepub_squash.py
@@ -14,7 +14,6 @@ from atomic_reactor.constants import EXPORTED_SQUASHED_IMAGE_NAME, IMAGE_TYPE_DO
 from atomic_reactor.plugin import PrePublishPlugin
 from atomic_reactor.plugins.exit_remove_built_image import defer_removal
 from atomic_reactor.util import get_exported_image_metadata, is_flatpak_build
-from atomic_reactor.utils import imageutil
 from docker_squash.squash import Squash
 
 __all__ = ('PrePublishSquashPlugin', )
@@ -74,10 +73,13 @@ class PrePublishSquashPlugin(PrePublishPlugin):
         if from_base and from_layer is None:
             if not self.workflow.dockerfile_images.base_from_scratch:
                 try:
-                    # OSBS2 TBD
-                    base_image_id = imageutil.base_image_inspect()['Id']
+                    # OSBS2 TBD: this entire plugin will be deleted
+                    base_image_id = self.workflow.imageutil.base_image_inspect()['Id']
                 except KeyError:
-                    self.log.error("Missing Id in inspection: '%s'", imageutil.base_image_inspect())
+                    self.log.error(
+                        "Missing Id in inspection: '%s'",
+                        self.workflow.imageutil.base_image_inspect(),
+                    )
                     raise
                 self.log.info("will squash from base-image: '%s'", base_image_id)
                 self.from_layer = base_image_id

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -49,7 +49,6 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       USER_CONFIG_FILES, REPO_FETCH_ARTIFACTS_KOJI)
 
 from atomic_reactor.auth import HTTPRegistryAuth
-from atomic_reactor.utils import imageutil
 
 from dockerfile_parse import DockerfileParser
 
@@ -1278,8 +1277,9 @@ def df_parser(df_path, workflow=None, cache_content=False, env_replace=True, par
         # the workflow for the parent_env
 
         try:
-            # OSBS2 TBD
-            parent_config = imageutil.base_image_inspect()[INSPECT_CONFIG]
+            # OSBS2 TBD: this entire function should eventually be removed and all of its uses
+            #   replaced with BuildDir.dockerfile_with_parent_env()
+            parent_config = workflow.imageutil.base_image_inspect()[INSPECT_CONFIG]
         except (AttributeError, TypeError, KeyError):
             logger.debug("base image unable to be inspected")
         else:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -49,6 +49,7 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       USER_CONFIG_FILES, REPO_FETCH_ARTIFACTS_KOJI)
 
 from atomic_reactor.auth import HTTPRegistryAuth
+from atomic_reactor.types import ImageInspectionData
 
 from dockerfile_parse import DockerfileParser
 
@@ -843,7 +844,9 @@ class RegistryClient(object):
 
         return digests
 
-    def get_inspect_for_image(self, image: ImageName, arch: Optional[str] = None) -> dict:
+    def get_inspect_for_image(
+        self, image: ImageName, arch: Optional[str] = None
+    ) -> ImageInspectionData:
         """Return inspect for image.
 
         :param image: The remote image to inspect

--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -93,17 +93,6 @@ class ImageUtil:
 # OSBS2 TBD
 
 
-def get_inspect_for_image(image):
-    # util.get_inspect_for_image(image, registry, insecure=False, dockercfg_path=None)
-    # or use skopeo
-    # insecure = self.pull_registries[base_image.registry]['insecure']
-    # dockercfg_path = self.pull_registries[base_image.registry]['dockercfg_path']
-    # self._base_image_inspect =\
-    #     atomic_reactor.util.get_inspect_for_image(base_image, base_image.registry, insecure,
-    # dockercfg_path)
-    return {}
-
-
 def get_image_history(image):
     # get image history with skopeo / registry api
     return []
@@ -111,12 +100,6 @@ def get_image_history(image):
 
 def inspect_built_image():
     # get output image final/arch specific from somewhere
-    # and call get_inspect_for_image
-    return {}
-
-
-def base_image_inspect():
-    # get base image from workflow.dockerfile_images
     # and call get_inspect_for_image
     return {}
 

--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -13,6 +13,7 @@ from osbs.utils import ImageName
 
 from atomic_reactor import config
 from atomic_reactor import util
+from atomic_reactor.types import ImageInspectionData
 
 
 def image_is_inspectable(image: Union[str, ImageName]) -> bool:
@@ -42,7 +43,7 @@ class ImageUtil:
 
     def get_inspect_for_image(
         self, image: Union[str, ImageName], platform: Optional[str] = None
-    ) -> dict:
+    ) -> ImageInspectionData:
         """Inspect an image. Should mainly be used to inspect parent images.
 
         The image must be inspectable, passing a non-inspectable image is an error.
@@ -60,7 +61,7 @@ class ImageUtil:
         goarch = self._conf.platform_to_goarch_mapping[platform]
         return self._cached_inspect_image(str(image), goarch)
 
-    def base_image_inspect(self, platform: Optional[str] = None) -> dict:
+    def base_image_inspect(self, platform: Optional[str] = None) -> ImageInspectionData:
         """Inspect the base image (the parent image for the final build stage).
 
         If the base image is scratch or custom, return an empty dict.
@@ -75,7 +76,9 @@ class ImageUtil:
         return self.get_inspect_for_image(base_image, platform)
 
     @functools.lru_cache(maxsize=None)
-    def _cached_inspect_image(self, image: str, goarch: Optional[str] = None) -> dict:
+    def _cached_inspect_image(
+        self, image: str, goarch: Optional[str] = None
+    ) -> ImageInspectionData:
         # Important: this method must take the image name as a string, not an ImageName.
         #   The functools cache decorator maps inputs to outputs in a dict. While the
         #   ImageName object *is* hashable, it is also mutable, which can lead to very

--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -5,6 +5,91 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
+
+import functools
+from typing import Optional, Union
+
+from osbs.utils import ImageName
+
+from atomic_reactor import config
+from atomic_reactor import util
+
+
+def image_is_inspectable(image: Union[str, ImageName]) -> bool:
+    """Check if we should expect the image to be inspectable."""
+    im = str(image)
+    return not (util.base_image_is_scratch(im) or util.base_image_is_custom(im))
+
+
+class ImageUtil:
+    """Convenience class for working with images relevant to the build process.
+
+    Supports e.g. inspecting the base image and other parent images.
+    """
+
+    def __init__(self, dockerfile_images: util.DockerfileImages, conf: config.Configuration):
+        """Init an ImageUtil.
+
+        :param dockerfile_images: information about the image references in the Dockerfile
+        :param conf: atomic-reactor configuration
+        """
+        self._dockerfile_images = dockerfile_images
+        self._conf = conf
+
+    def set_dockerfile_images(self, dockerfile_images: util.DockerfileImages) -> None:
+        """Set a new dockerfile_images instance."""
+        self._dockerfile_images = dockerfile_images
+
+    def get_inspect_for_image(
+        self, image: Union[str, ImageName], platform: Optional[str] = None
+    ) -> dict:
+        """Inspect an image. Should mainly be used to inspect parent images.
+
+        The image must be inspectable, passing a non-inspectable image is an error.
+
+        The result is cached, this method will not query the registry more than once
+        (if successful) for the same image reference (within one Python process).
+
+        :param image: The image to inspect
+        :param platform: Optionally, inspect the base image for a specific platform.
+            This can be either the platform name (e.g. x86_64) or the GOARCH name (amd64).
+        """
+        if not image_is_inspectable(image):
+            raise ValueError(f"{image!r} is not inspectable")
+
+        goarch = self._conf.platform_to_goarch_mapping[platform]
+        return self._cached_inspect_image(str(image), goarch)
+
+    def base_image_inspect(self, platform: Optional[str] = None) -> dict:
+        """Inspect the base image (the parent image for the final build stage).
+
+        If the base image is scratch or custom, return an empty dict.
+
+        :param platform: Optionally, inspect the base image for a specific platform.
+            This can be either the platform name (e.g. x86_64) or the GOARCH name (amd64).
+        """
+        base_image: Union[str, ImageName] = self._dockerfile_images.base_image
+        if not image_is_inspectable(base_image):
+            return {}
+
+        return self.get_inspect_for_image(base_image, platform)
+
+    @functools.lru_cache(maxsize=None)
+    def _cached_inspect_image(self, image: str, goarch: Optional[str] = None) -> dict:
+        # Important: this method must take the image name as a string, not an ImageName.
+        #   The functools cache decorator maps inputs to outputs in a dict. While the
+        #   ImageName object *is* hashable, it is also mutable, which can lead to very
+        #   unpleasant bugs.
+        parsed_image = ImageName.parse(image)
+        client = self._get_registry_client(parsed_image.registry)
+        return client.get_inspect_for_image(parsed_image, goarch)
+
+    @functools.lru_cache(maxsize=None)
+    def _get_registry_client(self, registry: str) -> util.RegistryClient:
+        session = util.RegistrySession.create_from_config(self._conf, registry)
+        return util.RegistryClient(session)
+
+
 # OSBS2 TBD
 
 

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -29,7 +29,6 @@ from atomic_reactor.constants import (DEFAULT_DOWNLOAD_BLOCK_SIZE, PROG,
                                       KOJI_RETRY_INTERVAL, KOJI_OFFLINE_RETRY_INTERVAL)
 from atomic_reactor.util import (Output, get_image_upload_filename,
                                  get_checksums, get_manifest_media_type)
-from atomic_reactor.utils import imageutil
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 
 logger = logging.getLogger(__name__)
@@ -461,8 +460,8 @@ def get_output(workflow, buildroot_id, pullspec, platform, source_build=False, l
         image_id = workflow.image_id
         parent_id = None
         if not workflow.dockerfile_images.base_from_scratch:
-            # OSBS2 TBD
-            parent_id = imageutil.base_image_inspect()['Id']
+            # OSBS2 TBD: inspect the correct architecture
+            parent_id = workflow.imageutil.base_image_inspect()['Id']
 
         layer_sizes = workflow.layer_sizes
 

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -21,7 +21,6 @@ from tests.mock_env import MockEnv
 from tests.utils.test_cachito import CACHITO_URL, CACHITO_REQUEST_ID
 
 from atomic_reactor import util
-from atomic_reactor.utils import imageutil
 from atomic_reactor.constants import INSPECT_ROOTFS, INSPECT_ROOTFS_LAYERS, PLUGIN_FETCH_MAVEN_KEY
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_add_image_content_manifest import AddImageContentManifestPlugin
@@ -182,7 +181,7 @@ def mock_env(workflow, tmpdir, platform='x86_64', base_layers=0,
             'prebuild', PLUGIN_FETCH_MAVEN_KEY, {'pnc_artifact_ids': [PNC_ARTIFACT['id']]}
         )
     tmpdir.join('cert').write('')
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(inspection_data)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(inspection_data)
     env.workflow.user_params['platform'] = platform
 
     # Ensure to succeed in reading the content_sets.yml

--- a/tests/plugins/test_add_image_content_manifest.py
+++ b/tests/plugins/test_add_image_content_manifest.py
@@ -148,11 +148,16 @@ def mock_get_icm(requests_mock):
 def mock_env(workflow, tmpdir, platform='x86_64', base_layers=0,
              remote_sources=REMOTE_SOURCES, r_c_m_override=None, pnc_artifacts=True,
              ):  # pylint: disable=W0102
-    inspection_data = {
-        INSPECT_ROOTFS: {
-            INSPECT_ROOTFS_LAYERS: list(range(base_layers))
+
+    if base_layers > 0:
+        inspection_data = {
+            INSPECT_ROOTFS: {
+                INSPECT_ROOTFS_LAYERS: list(range(base_layers))
+            }
         }
-    }
+    else:
+        inspection_data = {}
+
     if r_c_m_override is None:
         r_c_m = {
             'version': 1,
@@ -265,7 +270,7 @@ def test_add_image_content_manifest(workflow, requests_mock, tmpdir, caplog,
     expected_output = deepcopy(ICM_DICT)
     if content_sets:
         expected_output['content_sets'] = CONTENT_SETS[platform]
-    expected_output['metadata']['image_layer_index'] = base_layers if base_layers else 1
+    expected_output['metadata']['image_layer_index'] = base_layers if base_layers else 0
     runner.run()
     assert dfp.content == expected_df
     output_file = os.path.join(str(tmpdir), manifest_file)

--- a/tests/plugins/test_add_labels.py
+++ b/tests/plugins/test_add_labels.py
@@ -13,7 +13,6 @@ from atomic_reactor.util import df_parser, DockerfileImages
 from atomic_reactor.source import VcsInfo
 from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor import start_time as atomic_reactor_start_time
-from atomic_reactor.utils import imageutil
 import datetime
 import re
 import json
@@ -174,7 +173,7 @@ def test_add_labels_plugin(tmpdir, workflow, df_content, labels_conf_base, label
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(labels_conf_base)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(labels_conf_base)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -219,7 +218,7 @@ def test_add_labels(tmpdir, workflow, release, use_reactor):
     df = df_parser(str(tmpdir))
     df.content = DF_CONTENT
 
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(LABELS_CONF_BASE)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(LABELS_CONF_BASE)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, df_path=df.dockerfile_path)
     flexmock(workflow, source=MockSource())
@@ -274,7 +273,7 @@ def test_add_labels_plugin_generated(tmpdir, workflow, auto_label, value_re_part
     df.content = DF_CONTENT
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(LABELS_CONF_BASE)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(LABELS_CONF_BASE)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -381,7 +380,7 @@ def test_add_labels_aliases(tmpdir, workflow, caplog, df_old_as_plugin_arg, df_n
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_labels)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_labels)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -454,7 +453,7 @@ def test_add_labels_equal_aliases(tmpdir, workflow, caplog, base_l, df_l, expect
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_labels)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_labels)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -529,7 +528,7 @@ def test_add_labels_equal_aliases2(tmpdir, workflow, caplog, base_l, df_l, expec
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_labels)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_labels)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -608,7 +607,7 @@ def test_dont_overwrite_if_in_dockerfile(tmpdir, workflow, label_names, dont_ove
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(labels_conf_base)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(labels_conf_base)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -658,7 +657,7 @@ def test_url_label(tmpdir, workflow, url_format, info_url):
     df.content = DF_CONTENT_LABELS
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_labels)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_labels)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -713,7 +712,7 @@ def test_add_labels_plugin_explicit(tmpdir, workflow, auto_label, labels_docker,
     df.content = labels_docker
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(labels_base)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(labels_base)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -747,7 +746,7 @@ def test_add_labels_base_image(tmpdir, workflow, parent, should_fail, caplog, re
     df.content = "FROM {}\n".format(parent)
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return({})
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return({})
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource())
 
@@ -822,7 +821,7 @@ def test_release_label(tmpdir, workflow, caplog, base_new, df_new, plugin_new,
     df.content = df_content
 
     flexmock(workflow, df_path=df.dockerfile_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_labels)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_labels)
     workflow.dockerfile_images = DockerfileImages(df.parent_images)
     flexmock(workflow, source=MockSource(release_env))
 

--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -12,7 +12,6 @@ from flexmock import flexmock
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_change_from_in_df import ChangeFromPlugin
 from atomic_reactor.util import df_parser, DockerfileImages
-from atomic_reactor.utils import imageutil
 from osbs.utils import ImageName
 from tests.stubs import StubSource
 from textwrap import dedent
@@ -70,7 +69,7 @@ def test_update_base_image(tmpdir, workflow, base_image):
                              df_path=dfp.dockerfile_path,
                              df_images=dfp.parent_images)
     workflow.dockerfile_images[base_image] = local_tag
-    (flexmock(imageutil)
+    (flexmock(workflow.imageutil)
      .should_receive('get_inspect_for_image')
      .with_args(local_tag)
      .and_return(dict(Id=base_str)))
@@ -91,7 +90,7 @@ def test_update_base_image_inspect_broken(tmpdir, workflow, caplog):
                              df_path=dfp.dockerfile_path,
                              df_images=dfp.parent_images)
     workflow.dockerfile_images['base:image'] = local_tag
-    (flexmock(imageutil)
+    (flexmock(workflow.imageutil)
      .should_receive('get_inspect_for_image')
      .with_args(local_tag)
      .and_return(dict(no_id="here")))
@@ -262,7 +261,7 @@ def test_update_parent_images(df_content, expected_df_content, tmpdir, workflow)
 
     for image_name, image_id in img_ids.items():
         print(image_name)
-        (flexmock(imageutil)
+        (flexmock(workflow.imageutil)
          .should_receive('get_inspect_for_image')
          .with_args(ImageName.parse(image_name))
          .and_return(dict(Id=image_id)))

--- a/tests/plugins/test_check_user_settings.py
+++ b/tests/plugins/test_check_user_settings.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+from flexmock import flexmock
 
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_check_user_settings import CheckUserSettingsPlugin
@@ -112,6 +113,8 @@ def mock_env(workflow, source_dir: Path, labels=None, flatpak=False, dockerfile_
     dfp = df_parser(str(source_dir))
     env.workflow._df_path = str(source_dir)
     env.workflow.dockerfile_images = DockerfileImages([] if flatpak else dfp.parent_images)
+
+    flexmock(env.workflow.imageutil).should_receive("base_image_inspect").and_return({})
 
     return env.create_runner()
 

--- a/tests/plugins/test_hide_files.py
+++ b/tests/plugins/test_hide_files.py
@@ -16,7 +16,6 @@ from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.plugin import PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_hide_files import HideFilesPlugin
 from atomic_reactor.util import df_parser
-from atomic_reactor.utils import imageutil
 
 
 @pytest.mark.usefixtures('user_params')
@@ -247,7 +246,7 @@ class TestHideFilesPlugin(object):
         flexmock(workflow, df_path=df_path)
 
         for parent in parent_images or []:
-            (flexmock(imageutil)
+            (flexmock(workflow.imageutil)
              .should_receive('get_inspect_for_image')
              .with_args(parent)
              .and_return({INSPECT_CONFIG: {'User': inherited_user}}))

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -29,7 +29,6 @@ from atomic_reactor.inner import TagConf, PushConf, BuildResult
 from atomic_reactor.util import (ManifestDigest, DockerfileImages,
                                  get_manifest_media_version, get_manifest_media_type,
                                  graceful_chain_get)
-from atomic_reactor.utils import imageutil
 from atomic_reactor.source import GitSource, PathSource
 from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE, IMAGE_TYPE_OCI_TAR,
                                       PLUGIN_GENERATE_MAVEN_METADATA_KEY,
@@ -275,7 +274,6 @@ def mock_environment(workflow, source_dir: Path, session=None, name=None,
 
     mock_reactor_config(workflow)
     workflow.user_params['scratch'] = scratch
-    base_image_id = '123456parent-id'
 
     workflow.source = StubSource()
     if yum_repourls:
@@ -283,7 +281,7 @@ def mock_environment(workflow, source_dir: Path, session=None, name=None,
     workflow.image_id = '123456imageid'
     workflow.dockerfile_images = DockerfileImages(['Fedora:22'])
 
-    flexmock(imageutil).should_receive('base_image_inspect').and_return({'ParentId': base_image_id})
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return({})
     setattr(workflow, 'tag_conf', TagConf())
     setattr(workflow, 'reserved_build_id ', None)
     setattr(workflow, 'reserved_token', None)

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -18,7 +18,6 @@ from atomic_reactor.plugin import PrePublishPluginsRunner, PluginFailedException
 from atomic_reactor.plugins import exit_remove_built_image
 from atomic_reactor.plugins.prepub_squash import PrePublishSquashPlugin
 from atomic_reactor.util import DockerfileImages
-from atomic_reactor.utils import imageutil
 from docker_squash.squash import Squash
 
 
@@ -37,7 +36,7 @@ def workflow(workflow):
     workflow.dockerfile_images = DockerfileImages(['Fedora:22'])
     workflow.image_id = 'image_id'
     flexmock(workflow, image='image')
-    (flexmock(imageutil)
+    (flexmock(workflow.imageutil)
         .should_receive('base_image_inspect')
         .and_return({'Id': BASE_IMAGE_ID}))
     return workflow

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -24,7 +24,6 @@ from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.plugins.exit_store_metadata import StoreMetadataPlugin
 from atomic_reactor.util import LazyGit, ManifestDigest, df_parser, DockerfileImages
-from atomic_reactor.utils import imageutil
 import pytest
 from tests.constants import (LOCALHOST_REGISTRY, DOCKER0_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME,
                              INPUT_IMAGE)
@@ -84,7 +83,7 @@ def prepare(workflow, docker_registries=None):
         r.digests["namespace/image:asd123"] = ManifestDigest(v1=DIGEST_NOT_USED,
                                                              v2=DIGEST2)
 
-    flexmock(imageutil).should_receive('base_image_inspect').and_return({'Id': '01234567'})
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return({'Id': '01234567'})
     workflow.build_logs = [
         "a", "b",
     ]

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -16,7 +16,6 @@ from atomic_reactor.inner import BuildResult
 from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.post_tag_from_config import TagFromConfigPlugin
 from atomic_reactor.util import df_parser
-from atomic_reactor.utils import imageutil
 from atomic_reactor.constants import INSPECT_CONFIG
 from tests.constants import IMPORTED_IMAGE_ID
 
@@ -116,7 +115,7 @@ def test_tag_parse(workflow, floating_tags, unique_tags, primary_tags, expected)
             'Env': {'parentrelease': '7.4.1'},
         }
     }
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(base_inspect)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(base_inspect)
 
     if unique_tags is not None and primary_tags is not None and floating_tags is not None:
         input_tags = {

--- a/tests/plugins/test_yum_inject.py
+++ b/tests/plugins/test_yum_inject.py
@@ -18,7 +18,6 @@ from atomic_reactor.plugins.pre_add_yum_repo_by_url import AddYumRepoByUrlPlugin
 from atomic_reactor.plugins.pre_inject_yum_repo import InjectYumRepoPlugin
 from atomic_reactor.util import df_parser, sha256sum, DockerfileImages
 from atomic_reactor.utils.yum import YumRepo
-from atomic_reactor.utils import imageutil
 from flexmock import flexmock
 from tests.stubs import StubSource
 
@@ -33,7 +32,7 @@ def prepare(workflow, df_path, df_dir, inherited_user=''):
     workflow.source = StubSource()
     inspect_data = {INSPECT_CONFIG: {'User': inherited_user}}
     flexmock(workflow, df_path=df_path)
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(inspect_data)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(inspect_data)
     workflow.df_dir = df_dir
     workflow.dockerfile_images = DockerfileImages(df_parser(df_path).parent_images)
     return workflow

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -65,7 +65,6 @@ from atomic_reactor.util import (LazyGit, figure_out_build_file,
                                  )
 from tests.constants import MOCK, REACTOR_CONFIG_MAP
 import atomic_reactor.util
-from atomic_reactor.utils import imageutil
 from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.source import SourceConfig
 from osbs.utils import ImageName
@@ -1029,7 +1028,7 @@ def test_df_parser_parent_env_wf(tmpdir, workflow, caplog, env_arg):
         """)
     env_conf = {INSPECT_CONFIG: {"Env": env_arg}}
     workflow.source = StubSource()
-    flexmock(imageutil).should_receive('base_image_inspect').and_return(env_conf)
+    flexmock(workflow.imageutil).should_receive('base_image_inspect').and_return(env_conf)
     df = df_parser(str(tmpdir), workflow=workflow)
     df.content = df_content
 

--- a/tests/utils/test_imageutil.py
+++ b/tests/utils/test_imageutil.py
@@ -1,0 +1,152 @@
+"""
+Copyright (c) 2021 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import pytest
+from flexmock import flexmock
+from osbs.utils import ImageName
+
+from atomic_reactor import config
+from atomic_reactor import util
+from atomic_reactor.utils import imageutil
+
+
+@pytest.fixture
+def df_images():
+    """DockerfileImages instance for testing."""
+    return util.DockerfileImages(["registry.com/fedora:35"])
+
+
+@pytest.mark.parametrize(
+    "image, is_inspectable",
+    [
+        ("scratch", False),
+        ("koji/image-build", False),
+        ("registry.com/foo/bar", True),
+        # does not work, nobody should ever try to use scratch as an ImageName
+        # (ImageName.parse("scratch"), False),
+        (ImageName.parse("koji/image-build"), False),
+        (ImageName.parse("registry.com/foo/bar"), True),
+    ],
+)
+def test_inspectable(image, is_inspectable):
+    assert imageutil.image_is_inspectable(image) == is_inspectable
+
+
+class TestImageUtil:
+    """Tests for the ImageUtil class."""
+
+    config = config.Configuration(
+        raw_config={
+            "version": 1,
+            # "registries": [],  # relevant to RegistrySession, not directly relevant to ImageUtil
+            "platform_descriptors": [{"platform": "x86_64", "architecture": "amd64"}],
+        },
+    )
+
+    inspect_data = {"some": "inspect data as returned by RegistryClient.get_inspect_for_image"}
+
+    def mock_get_registry_client(self, expect_image, expect_arch):
+        """Make the _get_registry_client method return a fake RegistryClient."""
+        registry_client = flexmock()
+        (
+            registry_client
+            .should_receive("get_inspect_for_image")
+            .with_args(expect_image, expect_arch)
+            .once()
+            .and_return(self.inspect_data)
+        )
+        (
+            flexmock(imageutil.ImageUtil)
+            .should_receive("_get_registry_client")
+            .with_args(expect_image.registry)
+            .once()
+            .and_return(registry_client)
+        )
+        return registry_client
+
+    def test_get_inspect_for_image(self, df_images):
+        """Test get_inspect_for_image and its caching behavior."""
+        image_util = imageutil.ImageUtil(df_images, self.config)
+        image = ImageName.parse("registry.com/some-image:1")
+
+        self.mock_get_registry_client(image, expect_arch=None)
+
+        assert image_util.get_inspect_for_image(image) == self.inspect_data
+        # check caching (the registry client mock expects its method to be called exactly once,
+        #   if imageutil didn't cache the result, it would get called twice)
+        assert image_util.get_inspect_for_image(image) == self.inspect_data
+
+        image_as_str = image.to_str()
+        # should hit cache regardless of whether you pass a string or an ImageName
+        assert image_util.get_inspect_for_image(image_as_str) == self.inspect_data
+
+    @pytest.mark.parametrize(
+        "platform, expect_goarch",
+        [
+            ("x86_64", "amd64"),  # platform is mapped to goarch
+            ("s390x", "s390x"),  # platform is not mapped (goarch name is the same)
+            ("amd64", "amd64"),  # pass goarch directly
+         ],
+    )
+    def test_get_inspect_for_image_specific_platform(self, platform, expect_goarch, df_images):
+        """Test that get_inspect_for_image handles the platform to goarch mapping properly."""
+        image_util = imageutil.ImageUtil(df_images, self.config)
+        image = ImageName.parse("registry.com/some-image:1")
+
+        # main check: expect_arch
+        self.mock_get_registry_client(image, expect_arch=expect_goarch)
+        assert image_util.get_inspect_for_image(image, platform) == self.inspect_data
+
+        # should hit cache regardless of whether you pass a platform or a goarch
+        assert image_util.get_inspect_for_image(image, expect_goarch) == self.inspect_data
+
+    def test_get_inspect_for_image_not_inspectable(self, df_images):
+        """Test that passing a non-inspectable image raises an error."""
+        image_util = imageutil.ImageUtil(df_images, self.config)
+        custom_image = ImageName.parse("koji/image-build")
+
+        with pytest.raises(ValueError, match=r"ImageName\(.*\) is not inspectable"):
+            image_util.get_inspect_for_image(custom_image)
+
+    @pytest.mark.parametrize("platform", [None, "x86_64"])
+    def test_base_image_inspect(self, platform, df_images):
+        """Test that base_image_inspect just calls get_inspect_for_image with the right args."""
+        image_util = imageutil.ImageUtil(df_images, self.config)
+        (
+            flexmock(image_util)
+            .should_receive("get_inspect_for_image")
+            # base image in df_images
+            .with_args(ImageName.parse("registry.com/fedora:35"), platform)
+            .once()
+            .and_return(self.inspect_data)
+        )
+        assert image_util.base_image_inspect(platform) == self.inspect_data
+
+    @pytest.mark.parametrize("base_image", ["scratch", "koji/image-build"])
+    def test_base_image_inspect_not_inspectable(self, base_image):
+        """Test that inspecting a non-inspectable base image returns an empty dict."""
+        image_util = imageutil.ImageUtil(util.DockerfileImages([base_image]), self.config)
+        assert image_util.base_image_inspect() == {}
+
+    def test_get_registry_client(self):
+        """Test the method that makes a RegistryClient (other tests mock this method)."""
+        image_util = imageutil.ImageUtil(util.DockerfileImages([]), self.config)
+
+        registry_session = flexmock()
+        (
+            flexmock(util.RegistrySession)
+            .should_receive("create_from_config")
+            .with_args(self.config, "registry.com")
+            .once()
+            .and_return(registry_session)
+        )
+        flexmock(util.RegistryClient).should_receive("__init__").with_args(registry_session).once()
+
+        image_util._get_registry_client("registry.com")
+        # test caching (i.e. test that the create_from_config method is called only once)
+        image_util._get_registry_client("registry.com")


### PR DESCRIPTION
CLOUDBLD-8036

Implement the methods that will be needed by prebuild plugins.

Add the workflow.imageutil property that provides an ImageUtil object
for plugins.

Remove stubs of newly implemeted imageutil methods and fix all the
plugins that used those stubs.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
