### PR TITLE
pin_operator_digest: update plugin to work in tekton

### DIFF
--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -91,19 +91,6 @@ class Source(object):
     def workdir(self):
         return self._workdir
 
-    @property
-    def manifests_dir(self):
-        if self.config.operator_manifests is None:
-            raise RuntimeError("operator_manifests configuration missing in container.yaml")
-        repo_dir = os.path.realpath(self.path)
-        manifests_dir = os.path.realpath(os.path.join(
-            repo_dir,
-            self.config.operator_manifests["manifests_dir"]
-        ))
-        if not manifests_dir.startswith(repo_dir):
-            raise RuntimeError("manifests_dir points outside of cloned repository")
-        return manifests_dir
-
     def get(self):
         """Run this to get source and save it to `workdir` or a newly created workdir."""
         raise NotImplementedError('Must override in subclasses!')

--- a/atomic_reactor/utils/operator.py
+++ b/atomic_reactor/utils/operator.py
@@ -9,7 +9,9 @@ import os
 import re
 import logging
 from collections import OrderedDict
+from pathlib import Path
 
+from atomic_reactor.dirs import BuildDir
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 
@@ -570,7 +572,7 @@ class OperatorCSV(object):
     # Annotation keys that are expected to contain pullspecs
     _known_annotation_keys = ("containerImage",)
 
-    def __init__(self, path, data, pullspec_heuristic=default_pullspec_heuristic):
+    def __init__(self, path, data, pullspec_heuristic=default_pullspec_heuristic, **kwargs):
         """
         Initialize an OperatorCSV
 
@@ -585,6 +587,7 @@ class OperatorCSV(object):
         self.path = path
         self.data = data
         self._pullspec_heuristic = pullspec_heuristic
+        self.repo_dir = kwargs.get('repo_dir', None)
 
     @property
     def checksum(self):
@@ -603,11 +606,15 @@ class OperatorCSV(object):
             data = yaml.load(f)
             return cls(path, data, **kwargs)
 
-    def dump(self):
+    def dump(self, build_dir: BuildDir = None):
         """
         Write data to file (preserves comments)
         """
-        with open(self.path, "w") as f:
+        if build_dir:
+            path = Path(str(self.path).replace(str(self.repo_dir), str(build_dir.path)))
+        else:
+            path = self.path
+        with open(path, "w") as f:
             yaml.dump(self.data, f)
 
     def has_related_images(self):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -25,8 +25,6 @@ from atomic_reactor.constants import (
     PLUGIN_PIN_OPERATOR_DIGESTS_KEY,
 )
 from atomic_reactor.plugin import PluginFailedException
-from atomic_reactor.plugins.build_orchestrate_build import (OrchestrateBuildPlugin,
-                                                            WORKSPACE_KEY_OVERRIDE_KWARGS)
 from atomic_reactor.plugins.pre_pin_operator_digest import (
     PinOperatorDigestsPlugin,
     PullspecReplacer,
@@ -237,17 +235,6 @@ def mock_inspect_query(pullspec, labels, times=1):
         .with_args(image)
         .and_return(inspect)
         .times(times))
-
-
-def get_build_kwarg(workflow, k, platform=None):
-    """
-    Get build-kwarg override
-    """
-    key = OrchestrateBuildPlugin.key
-
-    workspace = workflow.plugin_workspace.get(key, {})
-    override_kwargs = workspace.get(WORKSPACE_KEY_OVERRIDE_KWARGS, {})
-    return override_kwargs.get(platform, {}).get(k)
 
 
 def get_site_config(allowed_registries=None, registry_post_replace=None, repo_replacements=None,

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -713,18 +713,16 @@ class TestPinOperatorDigest(object):
         # plugin must always retun pullspecs
         assert result['pin_operator_digest']['related_images']['pullspecs']
 
-    @pytest.mark.parametrize('has_envs', [True, False])
-    def test_exclude_csvs(self, workflow, source_dir, caplog, has_envs):
-        # Worker does not care if there is a conflict between relatedImages
-        # and RELATED_IMAGE_* env vars, orchestrator should have caught this already
+    def test_exclude_csvs(self, workflow, source_dir, caplog):
         manifests_dir = source_dir.joinpath(OPERATOR_MANIFESTS_DIR)
         manifests_dir.mkdir()
         csv = mock_operator_csv(manifests_dir, 'csv.yaml', ['foo'],
                                 with_related_images=True,
-                                with_related_image_envs=has_envs)
+                                with_related_image_envs=False)
         original_content = csv.read_text("utf-8")
 
         user_config = get_user_config(OPERATOR_MANIFESTS_DIR)
+
         runner = mock_env(workflow, source_dir, site_config=get_site_config(),
                           user_config=user_config)
         runner.run()

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -1060,25 +1060,44 @@ class TestOperatorCSVModifications:
 
         assert exc_msg in str(exc_info.value)
 
-    @pytest.mark.parametrize('pull_specs,exc_msg', [
+    @pytest.mark.parametrize('pull_specs, modification_specs, exc_msg', [
         # case: missing definitions
         (
             ["missing:v5.6"],
+            [
+                {
+                    "original": "myimage:v1.2.2",
+                    "new": "myimage:v1.2.700",
+                    "pinned": False,
+                },
+            ],
             "Provided operator CSV modifications misses following pullspecs: missing:v5.6"
         ),
         # case: extra definitions
         (
-            ["myimage:v1.2.2", "yet-another-image:123"],
-            ("Provided operator CSV modifications misses following pullspecs: "
-             "yet-another-image:123")
+            ["myimage:v1.2.2"],
+            [
+                {
+                    "original": "myimage:v1.2.2",
+                    "new": "myimage:v1.2.700",
+                    "pinned": False,
+                },
+                {
+                    "original": "yet-another-image:123",
+                    "new": "myimage:v1.2.700",
+                    "pinned": False,
+                },
+            ],
+            "Provided operator CSV modifications defines extra pullspecs: yet-another-image:123"
         ),
     ])
     @responses.activate
-    def test_pullspecs_replacements_errors(self, workflow, source_dir, pull_specs, exc_msg):
+    def test_pullspecs_replacements_errors(self, workflow, source_dir, pull_specs,
+                                           modification_specs, exc_msg):
         """Plugin should fail when CSV modifications doesn't meet expectations"""
         test_url = "https://example.com/modifications.json"
         modification_data = {
-            "pullspec_replacements": PULLSPEC_REPLACEMENTS
+            "pullspec_replacements": modification_specs
         }
         responses.add(responses.GET, test_url, json=modification_data)
 

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -1349,7 +1349,7 @@ class TestOperatorCSVModifications:
                                             'spec': {
                                                 'containers': [{
                                                     'name': 'foo-1',
-                                                    'image': 'myimage:v1.2.2'
+                                                    'image': 'myimage:v1.2.700'
                                                 }]
                                             }
                                         }
@@ -1357,7 +1357,7 @@ class TestOperatorCSVModifications:
                                 }]
                             }
                         },
-                        'relatedImages': [{'name': 'foo-1', 'image': 'myimage:v1.2.2'}],
+                        'relatedImages': [{'name': 'foo-1', 'image': 'myimage:v1.2.700'}],
                         'skips': ['1.2.3'],
                     }
                 },
@@ -1384,7 +1384,7 @@ class TestOperatorCSVModifications:
                                             'spec': {
                                                 'containers': [{
                                                     'name': 'foo-1',
-                                                    'image': 'myimage:v1.2.2'
+                                                    'image': 'myimage:v1.2.700'
                                                 }]
                                             }
                                         }
@@ -1392,7 +1392,7 @@ class TestOperatorCSVModifications:
                                 }]
                             }
                         },
-                        'relatedImages': [{'name': 'foo-1', 'image': 'myimage:v1.2.2'}],
+                        'relatedImages': [{'name': 'foo-1', 'image': 'myimage:v1.2.700'}],
                     }
                 },
                 id='update_only'

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -309,28 +309,6 @@ class TestPinOperatorDigest(object):
         msg = "operator_manifests configuration missing in container.yaml"
         assert msg in str(exc_info.value)
 
-    @pytest.mark.parametrize('manifests_dir, symlinks', [
-        ('foo', {'foo': '/tmp/foo'}),
-    ])
-    def test_manifests_dir_not_subdir_of_repo(self, manifests_dir, symlinks,
-                                              workflow, build_dir):
-        # make sure plugin is not skipped because of missing site config
-        site_config = get_site_config()
-        user_config = get_user_config(manifests_dir)
-        runner = mock_env(workflow, build_dir,
-                          site_config=site_config, user_config=user_config)
-
-        # make symlinks
-        for rel_dest, src in (symlinks or {}).items():
-            dest = os.path.join(runner.workflow.source.path, rel_dest)
-            pathlib.Path(src).mkdir(exist_ok=True)
-            os.symlink(src, str(dest))
-
-        with pytest.raises(PluginFailedException) as exc_info:
-            runner.run()
-
-        assert "manifests_dir points outside of cloned repo" in str(exc_info.value)
-
     @pytest.mark.parametrize('filepaths', [
         ['csv1.yaml'],
         ['csv2.yaml'],


### PR DESCRIPTION
Remove worker and orchestrator differences completely,
and unify the login in the run() method of the plugin.
In OSBS 2 there will not be any worker orchestrator
abstraction.

* CLOUDBLD-8112

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
