### PR TITLE
bump osbs-client ref

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -59,7 +59,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3c028f79d2ce38524449509a5abfe08073d3135f
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@5d930f226093c2710c2e0c3e38eee50f3ded7304
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ flatpak-module-tools >= 0.11;python_version>="3.9"
 jsonschema
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@3c028f79d2ce38524449509a5abfe08073d3135f#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@5d930f226093c2710c2e0c3e38eee50f3ded7304#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3c028f79d2ce38524449509a5abfe08073d3135f
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@5d930f226093c2710c2e0c3e38eee50f3ded7304
     # via -r requirements.in
 pycairo==1.20.1
     # via pygobject


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
