### PR TITLE
Minor refactor of resolve_remote_source plugin

### DIFF
--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2019 Red Hat, Inc
+Copyright (c) 2019-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -8,17 +8,17 @@ of the BSD license. See the LICENSE file for details.
 import os.path
 from collections import Counter
 
+from atomic_reactor.config import get_koji_session, get_cachito_session
 from atomic_reactor.constants import (
     PLUGIN_RESOLVE_REMOTE_SOURCE,
     REMOTE_SOURCE_DIR,
     REMOTE_SOURCE_JSON_FILENAME,
     REMOTE_SOURCE_TARBALL_FILENAME,
 )
-from atomic_reactor.config import get_koji_session, get_cachito_session
-from atomic_reactor.utils.koji import get_koji_task_owner
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.plugins.build_orchestrate_build import override_build_kwarg
 from atomic_reactor.util import is_scratch_build, map_to_user_params
+from atomic_reactor.utils.koji import get_koji_task_owner
 
 
 class ResolveRemoteSourcePlugin(PreBuildPlugin):

--- a/atomic_reactor/plugins/pre_resolve_remote_source.py
+++ b/atomic_reactor/plugins/pre_resolve_remote_source.py
@@ -209,7 +209,7 @@ class ResolveRemoteSourcePlugin(PreBuildPlugin):
             self.log.exception(msg)
             raise ValueError(msg) from exc
 
-        data.update({k: source_request.get(k, []) for k in optional})
+        data.update({k: source_request[k] for k in optional if k in source_request})
 
         return data
 

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -425,6 +425,18 @@ def teardown_function(*args):
     sys.modules.pop('pre_resolve_remote_source', None)
 
 
+def test_source_request_to_json_missing_optional_keys(workflow):
+    p = ResolveRemoteSourcePlugin(workflow)
+
+    source_request = {
+        "repo": REMOTE_SOURCE_REPO,
+        "ref": REMOTE_SOURCE_REF,
+        "packages": [],
+    }
+    # test that missing optional keys are ignored as expected
+    assert p.source_request_to_json(source_request) == source_request
+
+
 @pytest.mark.parametrize('scratch', (True, False))
 @pytest.mark.parametrize('dr_strs, dependency_replacements',
                          ((None, None),


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
