### PR TITLE
Fix dockerfile_with_parent_env method

### DIFF
--- a/atomic_reactor/dirs.py
+++ b/atomic_reactor/dirs.py
@@ -17,6 +17,7 @@ from atomic_reactor.constants import (
     DOCKERFILE_FILENAME,
     EXPORTED_COMPRESSED_IMAGE_NAME_TEMPLATE,
     EXPORTED_SQUASHED_IMAGE_NAME,
+    INSPECT_CONFIG,
 )
 from atomic_reactor.source import Source
 from atomic_reactor.types import ImageInspectionData
@@ -85,7 +86,7 @@ class BuildDir(object):
             will be returned.
         :rtype: None or dict[str, str]
         """
-        envs = data.get("Env")
+        envs = data.get(INSPECT_CONFIG, {}).get("Env")
         if envs is None:
             return None
         if isinstance(envs, dict):

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -72,14 +72,15 @@ def test_builddir_get_parsed_dockerfile(tmpdir):
 
 @pytest.mark.parametrize("inspection_data,expected_envs", [
     [{}, {"HOME": ""}],
-    [{"Env": {}}, {"HOME": ""}],
-    [{"Env": []}, {"HOME": ""}],
+    [{"Config": {}}, {"HOME": ""}],
+    [{"Config": {"Env": {}}}, {"HOME": ""}],
+    [{"Config": {"Env": []}}, {"HOME": ""}],
     [
-        {"Env": ["HOME=/home", "var2=--option=first"]},
+        {"Config": {"Env": ["HOME=/home", "var2=--option=first"]}},
         {"HOME": "/home"},
     ],
     [
-        {"Env": {"HOME": "/home", "var2": "--option=first"}},
+        {"Config": {"Env": {"HOME": "/home", "var2": "--option=first"}}},
         {"HOME": "/home"},
     ],
 ])


### PR DESCRIPTION
The environment variables in the inspection data are at .Config.Env, not
just .Env (top level).

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
