### PR TITLE
Fix wrong inject_yum_repo plugin name in prebuild task definition

### DIFF
--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -33,7 +33,7 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
             {"name": "add_image_content_manifest"},
             {"name": "add_dockerfile"},
             {"name": "distgit_fetch_artefacts"},
-            {"name": "inject_yum_repos"},
+            {"name": "inject_yum_repo"},
             {"name": "hide_files"},
             {"name": "distribution_scope"},
             {"name": "add_buildargs_in_dockerfile"},


### PR DESCRIPTION
* CLOUDBLD-8243

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
