### PR TITLE
Rename any_build_dir to any_platform

### DIFF
--- a/atomic_reactor/dirs.py
+++ b/atomic_reactor/dirs.py
@@ -182,7 +182,7 @@ class RootBuildDir(object):
         self._copy_sources(source)
 
     @property
-    def any_build_dir(self) -> BuildDir:
+    def any_platform(self) -> BuildDir:
         """Get a platform-specific build directory.
 
         This is typically used by code that does not care about platform. The

--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -30,7 +30,7 @@ class SourceContainerPlugin(BuildStepPlugin):
     key = PLUGIN_SOURCE_CONTAINER_KEY
 
     def export_image(self, image_output_dir: Path) -> str:
-        output_path = self.workflow.build_dir.any_build_dir.exported_squashed_image
+        output_path = self.workflow.build_dir.any_platform.exported_squashed_image
 
         cmd = ['skopeo', 'copy']
         source_img = 'oci:{}'.format(image_output_dir)

--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -307,9 +307,9 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
             raise RuntimeError("operator_manifests configuration missing in container.yaml")
         self.log.info("Looking for operator CSV files in %s", self.workflow.build_dir.path)
         manifests_dir = self.workflow.source.config.operator_manifests["manifests_dir"]
-        kwargs = {'repo_dir': self.workflow.build_dir.any_build_dir.path}
+        kwargs = {'repo_dir': self.workflow.build_dir.any_platform.path}
         operator_manifest = OperatorManifest.from_directory(
-            os.path.join(self.workflow.build_dir.any_build_dir.path, manifests_dir), **kwargs)
+            os.path.join(self.workflow.build_dir.any_platform.path, manifests_dir), **kwargs)
         self.log.info("Found operator CSV file: %s", operator_manifest.csv.path)
 
         return operator_manifest

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -79,7 +79,7 @@ def test_running_build(workflow, caplog,
     )
 
     temp_image_output_dir = workflow.build_dir.source_container_output_dir
-    exported_image_file = workflow.build_dir.any_build_dir.exported_squashed_image
+    exported_image_file = workflow.build_dir.any_platform.exported_squashed_image
     temp_image_export_dir = exported_image_file.parent
     tempfile_chain = (flexmock(tempfile)
                       .should_receive("mkdtemp")
@@ -161,7 +161,7 @@ def test_running_build(workflow, caplog,
     )
 
     if not export_failed:
-        export_tar = workflow.build_dir.any_build_dir.exported_squashed_image
+        export_tar = workflow.build_dir.any_platform.exported_squashed_image
         with open(export_tar, "wb") as f:
             with tarfile.TarFile(mode="w", fileobj=f) as tf:
                 for f in os.listdir(temp_image_output_dir):

--- a/tests/plugins/test_pin_operator_digests.py
+++ b/tests/plugins/test_pin_operator_digests.py
@@ -409,7 +409,7 @@ class TestPinOperatorDigest(object):
         with pytest.raises(PluginFailedException) as exc_info:
             runner.run()
 
-        csv = os.path.join(runner.workflow.build_dir.any_build_dir.path,
+        csv = os.path.join(runner.workflow.build_dir.any_platform.path,
                            runner.workflow.source.config.operator_manifests['manifests_dir'],
                            csv.name)
         expected = (
@@ -603,7 +603,7 @@ class TestPinOperatorDigest(object):
         }
 
         assert result['pin_operator_digest'] == expected_result
-        replaced_csv = os.path.join(runner.workflow.build_dir.any_build_dir.path,
+        replaced_csv = os.path.join(runner.workflow.build_dir.any_platform.path,
                                     runner.workflow.source.config.operator_manifests[
                                         "manifests_dir"],
                                     'csv.yaml')
@@ -1420,7 +1420,7 @@ class TestOperatorCSVModifications:
             operator_csv_modifications_url=test_url
         )
 
-        pytest_tmp_dir = runner.workflow.build_dir.any_build_dir.path
+        pytest_tmp_dir = runner.workflow.build_dir.any_platform.path
 
         runner.run()
 

--- a/tests/test_dirs.py
+++ b/tests/test_dirs.py
@@ -140,28 +140,28 @@ def test_rootbuilddir_has_sources(build_dir):
     assert root.has_sources
 
 
-def test_rootbuilddir_get_any_build_dir(build_dir, mock_source):
+def test_rootbuilddir_get_any_platform(build_dir, mock_source):
     root = RootBuildDir(build_dir)
     root.init_build_dirs(["x86_64", "s390x"], mock_source)
-    build_dir_1 = root.any_build_dir
-    build_dir_2 = root.any_build_dir
+    build_dir_1 = root.any_platform
+    build_dir_2 = root.any_platform
     assert build_dir_1.path == build_dir_2.path
     assert build_dir_1.platform == build_dir_2.platform
 
 
-def test_rootbuilddir_get_any_build_dir_fails_if_build_dirs_not_inited(build_dir):
+def test_rootbuilddir_get_any_platform_fails_if_build_dirs_not_inited(build_dir):
     with pytest.raises(BuildDirIsNotInitialized, match="not initialized yet"):
-        print(RootBuildDir(build_dir).any_build_dir)
+        print(RootBuildDir(build_dir).any_platform)
 
 
-def test_rootbuilddir_get_any_build_dir_by_different_platforms_order(build_dir, mock_source):
+def test_rootbuilddir_get_any_platform_by_different_platforms_order(build_dir, mock_source):
     root = RootBuildDir(build_dir)
     root.init_build_dirs(["x86_64", "s390x"], mock_source)
-    build_dir_1 = root.any_build_dir
+    build_dir_1 = root.any_platform
 
     root = RootBuildDir(build_dir)
     root.init_build_dirs(["s390x", "x86_64"], mock_source)
-    build_dir_2 = root.any_build_dir
+    build_dir_2 = root.any_platform
 
     assert build_dir_1.path == build_dir_2.path
     assert build_dir_1.platform == build_dir_2.platform


### PR DESCRIPTION
Considering the workflow attribute is called "build_dir", the usual
access pattern is currently "build_dir.any_build_dir". That looks odd.
The name "any_platform" should adequately express what the property
represents, and matches the naming of other methods that handle build
directories (such as "for_each_platform").

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
