### PR TITLE
Fetch sources earlier

### DIFF
--- a/atomic_reactor/plugins/pre_pyrpkg_fetch_artefacts.py
+++ b/atomic_reactor/plugins/pre_pyrpkg_fetch_artefacts.py
@@ -10,18 +10,14 @@ To have everything for a build in dist-git you need to fetch artefacts using 'fe
 
 This plugin should do it.
 """
-import os
-import re
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Final, List
+from typing import List
 
 from atomic_reactor.dirs import BuildDir
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.constants import PLUGIN_DISTGIT_FETCH_KEY
-
-EXPLODED_SOURCES_FILE: Final[str] = 'source-repos'
 
 
 class DistgitFetchArtefactsPlugin(PreBuildPlugin):
@@ -38,43 +34,6 @@ class DistgitFetchArtefactsPlugin(PreBuildPlugin):
         # call parent constructor
         super(DistgitFetchArtefactsPlugin, self).__init__(workflow)
         self.command = self.workflow.conf.sources_command
-
-    def _collect_exploded_sources_files(self, build_dir_path: Path) -> List[Path]:
-        """Collect the fetched exploded sources.
-
-        :param build_dir_path: from which directory to find the exploded sources file.
-        :type build_dir_path: pathlib.Path
-        :return: a list of file names got from the source-repos file. An empty
-            list will be returned if no source-repos exist, that means the
-            container repo does not have any exploded sources.
-        :rtype: list[pathlib.Path]
-        :raises ValueError: if any line of source-repos cannot be parsed or the
-            file cannot be found from the build_dir. Note that, generally,
-            neither of these issues should be captured by this method, since
-            it runs after rhpkg generates the tarballs from the repos listed
-            within source-repos and any potential issue should be handled by
-            rhpkg.
-        """
-        source_repos = build_dir_path / EXPLODED_SOURCES_FILE
-        filenames = []
-        if not source_repos.exists():
-            return filenames
-        regex = re.compile(r'^([\S]+)\s+([\S]+)$')
-        with source_repos.open('r', encoding='utf-8') as f:
-            for line in f:
-                if match := regex.match(line.strip()):
-                    repo_url, git_ref = match.groups()
-                    repo_name = os.path.basename(repo_url).replace('.git', '')
-                    filename = f'{repo_name}-{git_ref}.tar.gz'
-                    if build_dir_path.joinpath(filename).exists():
-                        filenames.append(Path(filename))
-                    else:
-                        raise ValueError(
-                            f'Cannot find the sources file {filename} from {build_dir_path}'
-                        )
-                else:
-                    raise ValueError(f'Invalid line in {EXPLODED_SOURCES_FILE}: {line.rstrip()}.')
-        return filenames
 
     def _fetch_sources(self, build_dir: BuildDir) -> List[Path]:
         """Fetch sources files.
@@ -101,10 +60,6 @@ class DistgitFetchArtefactsPlugin(PreBuildPlugin):
             shutil.move(str(file_name), str(build_dir_path))
             fetched_sources.append(file_name.relative_to(sources_outdir))
         sources_outdir.rmdir()
-
-        # Collect the exploded sources if there is
-        fetched_sources += self._collect_exploded_sources_files(build_dir_path)
-
         return fetched_sources
 
     def run(self):

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -15,6 +15,7 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
     plugins_def = plugin_based.PluginsDef(
         prebuild=[
             {"name": "check_user_settings"},
+            {"name": "distgit_fetch_artefacts"},
             {"name": "check_and_set_platforms"},
             {"name": "flatpak_create_dockerfile"},
             {"name": "inject_parent_image"},
@@ -32,7 +33,6 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
             {"name": "fetch_maven_artifacts"},
             {"name": "add_image_content_manifest"},
             {"name": "add_dockerfile"},
-            {"name": "distgit_fetch_artefacts"},
             {"name": "inject_yum_repos"},
             {"name": "hide_files"},
             {"name": "distribution_scope"},

--- a/tests/plugins/test_pyrpkg_fetch_artefacts.py
+++ b/tests/plugins/test_pyrpkg_fetch_artefacts.py
@@ -6,15 +6,12 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 import subprocess
-from pathlib import Path
 
 import pytest
 
 from atomic_reactor.dirs import BuildDir
 from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
-from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import (
-    DistgitFetchArtefactsPlugin, EXPLODED_SOURCES_FILE,
-)
+from atomic_reactor.plugins.pre_pyrpkg_fetch_artefacts import DistgitFetchArtefactsPlugin
 from osbs.utils import ImageName
 from tests.stubs import StubSource
 from flexmock import flexmock
@@ -34,27 +31,11 @@ class X(object):
 
 @pytest.fixture
 def workflow(workflow):
-    Path(workflow.source.path, EXPLODED_SOURCES_FILE).write_text(
-        "https://git.host/ns/api.git 123456\n"
-        "https://git.host/ns/operator  789012\n",
-        encoding="utf-8",
-    )
     workflow.build_dir.init_build_dirs(["x86_64", "ppc64le"], workflow.source)
     return workflow
 
 
-@pytest.mark.parametrize(
-    'has_exploded_sources,has_invalid_source_repo_line,missing_exploded_source_file',
-    [
-        [True, False, False],
-        [True, True, False],
-        [True, False, True],
-        [False, None, None],
-    ],
-)
-def test_distgit_fetch_artefacts_plugin(
-    has_exploded_sources, has_invalid_source_repo_line, missing_exploded_source_file, workflow
-):  # noqa
+def test_distgit_fetch_artefacts_plugin(workflow):  # noqa
     sources_cmd = 'fedpkg sources'
     workflow.conf.conf['sources_command'] = sources_cmd
 
@@ -65,13 +46,6 @@ def test_distgit_fetch_artefacts_plugin(
     expected_check_call_cmd = sources_cmd.split()
     expected_check_call_cmd.append('--outdir')
     expected_check_call_cmd.append(str(expected_sources_outdir))
-
-    if has_exploded_sources:
-        if has_invalid_source_repo_line:
-            with working_build_dir.joinpath(EXPLODED_SOURCES_FILE).open('a') as f:
-                f.write('https://git.host/ns/webapp.git sha256 123456')
-    else:
-        working_build_dir.joinpath(EXPLODED_SOURCES_FILE).unlink()
 
     expected_sources_files = (
         ("logo.png", b"image"),
@@ -84,10 +58,6 @@ def test_distgit_fetch_artefacts_plugin(
         # These sources files must be downloaded
         for filename, data in expected_sources_files:
             expected_sources_outdir.joinpath(filename).write_bytes(data)
-        if has_exploded_sources:
-            working_build_dir.joinpath('api-123456.tar.gz').write_bytes(b'')
-            if not missing_exploded_source_file:
-                working_build_dir.joinpath('operator-789012.tar.gz').write_bytes(b'')
 
     (flexmock(subprocess)
      .should_receive('check_call')
@@ -100,20 +70,6 @@ def test_distgit_fetch_artefacts_plugin(
             'name': DistgitFetchArtefactsPlugin.key,
         }]
     )
-
-    if has_exploded_sources:
-        if has_invalid_source_repo_line:
-            with pytest.raises(
-                PluginFailedException, match=f'Invalid line in {EXPLODED_SOURCES_FILE}'
-            ):
-                runner.run()
-            return
-
-        if missing_exploded_source_file:
-            with pytest.raises(PluginFailedException, match='Cannot find the sources file'):
-                runner.run()
-            return
-
     runner.run()
 
     def _assert(build_dir: BuildDir):


### PR DESCRIPTION
# Maintainers will complete the following section

- [X] Commit messages are descriptive enough
- [X] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
