### PR TITLE
Fix the workflow.source fixture and its mocking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import requests
 import requests.exceptions
 from atomic_reactor.constants import DOCKERFILE_FILENAME
 from atomic_reactor.dirs import RootBuildDir
+from atomic_reactor.source import DummySource
 from tests.constants import LOCALHOST_REGISTRY_HTTP, DOCKER0_REGISTRY_HTTP, TEST_IMAGE
 from tests.util import uuid_value
 
@@ -66,8 +67,11 @@ def user_params(monkeypatch):
 
 
 @pytest.fixture
-def workflow(build_dir, user_params):
-    return DockerBuildWorkflow(RootBuildDir(build_dir), source=None)
+def workflow(build_dir, source_dir, user_params):
+    return DockerBuildWorkflow(
+        build_dir=RootBuildDir(build_dir),
+        source=DummySource(None, None, workdir=source_dir),
+    )
 
 
 @pytest.mark.optionalhook

--- a/tests/mock_env.py
+++ b/tests/mock_env.py
@@ -5,8 +5,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import Iterable, List, Union
 
 from atomic_reactor.constants import (PLUGIN_BUILD_ORCHESTRATE_KEY,
                                       PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
@@ -18,7 +17,6 @@ from atomic_reactor.plugin import (PreBuildPluginsRunner,
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.config import Configuration
 from atomic_reactor.util import DockerfileImages
-from tests.stubs import StubSource
 
 
 class MockEnv(object):
@@ -29,7 +27,7 @@ class MockEnv(object):
     for a specific test scenario.
 
     Example usage:
-    >>> runner = (MockEnv()
+    >>> runner = (MockEnv(workflow)
     >>>           .for_plugin('prebuild', 'my_plugin')
     >>>           .set_scratch(True)
     >>>           .make_orchestrator()
@@ -55,14 +53,8 @@ class MockEnv(object):
         'exit': 'exit_results',
     }
 
-    def __init__(self, workflow=None, build_dir: Optional[Path] = None):
-        if not workflow and build_dir is None:
-            raise ValueError(
-                "Argument build_dir is missed to create a DockerBuildWorkflow instance."
-            )
-        self.workflow = workflow or DockerBuildWorkflow(build_dir)
-        self.workflow.source = StubSource()
-
+    def __init__(self, workflow: DockerBuildWorkflow):
+        self.workflow = workflow
         self._phase = None
         self._plugin_key = None
         self._reactor_config_map = None
@@ -196,7 +188,7 @@ class MockEnv(object):
         Get reactor config map (from the ReactorConfigPlugin's workspace)
 
         If config does not exist, it will be created, i.e. you can do:
-        >>> env = MockEnv()
+        >>> env = MockEnv(workflow)
         >>> env.reactor_config.conf['sources_command'] = 'fedpkg sources'
 
         :return: ReactorConfig instance

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -97,7 +97,7 @@ def generate_archive(tmpdir, empty=False, change_csv_content=False, multiple_csv
     archive_path.remove()
 
 
-def mock_env(tmpdir, has_appregistry_label=False, appregistry_label=False,
+def mock_env(workflow, tmpdir, has_appregistry_label=False, appregistry_label=False,
              has_bundle_label=True, bundle_label=True,
              has_archive=True,
              scratch=False, orchestrator=False, selected_platform=True, empty_archive=False,
@@ -110,7 +110,7 @@ def mock_env(tmpdir, has_appregistry_label=False, appregistry_label=False,
     )
     manifests_dir = mock_manifests_dir(repo_dir)
 
-    env = (MockEnv()
+    env = (MockEnv(workflow)
            .for_plugin('postbuild', ExportOperatorManifestsPlugin.key)
            .set_scratch(scratch))
     if orchestrator:
@@ -141,12 +141,12 @@ class TestExportOperatorManifests(object):
     @pytest.mark.parametrize('bundle_label', [True, False])
     @pytest.mark.parametrize('orchestrator', [True, False])
     @pytest.mark.parametrize('selected_platform', [True, False])
-    def test_skip(self, tmpdir, caplog, has_appregistry_label, appregistry_label,
+    def test_skip(self, workflow, tmpdir, caplog, has_appregistry_label, appregistry_label,
                   has_bundle_label, bundle_label,
                   orchestrator, selected_platform):
 
         runner = mock_env(
-            tmpdir, has_appregistry_label=has_appregistry_label,
+            workflow, tmpdir, has_appregistry_label=has_appregistry_label,
             has_bundle_label=has_bundle_label, bundle_label=bundle_label,
             appregistry_label=appregistry_label,
             orchestrator=orchestrator, selected_platform=selected_platform
@@ -167,8 +167,8 @@ class TestExportOperatorManifests(object):
 
     @pytest.mark.skip(reason="plugin needs rework to get image content")
     @pytest.mark.parametrize('scratch', [True, False])
-    def test_export_archive(self, tmpdir, scratch):
-        runner = mock_env(tmpdir, scratch=scratch)
+    def test_export_archive(self, workflow, tmpdir, scratch):
+        runner = mock_env(workflow, tmpdir, scratch=scratch)
         result = runner.run()
         archive = result[PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY]
 
@@ -181,23 +181,22 @@ class TestExportOperatorManifests(object):
             assert sorted(z.namelist()) == sorted(expected)
 
     @pytest.mark.skip(reason="plugin needs rework to get image content")
-    def test_csv_is_changed_in_built_image(self, tmpdir):
-        runner = mock_env(tmpdir, change_csv_content=True)
+    def test_csv_is_changed_in_built_image(self, workflow, tmpdir):
+        runner = mock_env(workflow, tmpdir, change_csv_content=True)
         with pytest.raises(PluginFailedException, match='have different content'):
             runner.run()
 
     @pytest.mark.skip(reason="plugin needs rework to get image content")
-    def test_multiple_csv_files_inside_built_image(self, tmpdir):
-        runner = mock_env(tmpdir, multiple_csv=True)
+    def test_multiple_csv_files_inside_built_image(self, workflow, tmpdir):
+        runner = mock_env(workflow, tmpdir, multiple_csv=True)
         with pytest.raises(PluginFailedException, match='but contains more'):
             runner.run()
 
     @pytest.mark.skip(reason="plugin needs rework to get image content")
     @pytest.mark.parametrize('remove_fails', [True, False])
     @pytest.mark.parametrize('has_archive', [True, False, None])
-    def test_no_archive(self, tmpdir, caplog, remove_fails, has_archive):
-        runner = mock_env(tmpdir, has_archive=has_archive,
-                          remove_fails=remove_fails)
+    def test_no_archive(self, workflow, tmpdir, caplog, remove_fails, has_archive):
+        runner = mock_env(workflow, tmpdir, has_archive=has_archive, remove_fails=remove_fails)
         if has_archive:
             runner.run()
             if remove_fails:
@@ -213,8 +212,8 @@ class TestExportOperatorManifests(object):
 
     @pytest.mark.skip(reason="plugin needs rework to get image content")
     @pytest.mark.parametrize('empty_archive', [True, False])
-    def test_empty_manifests_dir(self, tmpdir, caplog, empty_archive):
-        runner = mock_env(tmpdir, empty_archive=empty_archive)
+    def test_empty_manifests_dir(self, workflow, tmpdir, caplog, empty_archive):
+        runner = mock_env(workflow, tmpdir, empty_archive=empty_archive)
         if empty_archive:
             with pytest.raises(PluginFailedException) as exc:
                 runner.run()


### PR DESCRIPTION
The workflow fixture will now have a usable `source` and MockEnv will not overwrite it anymore.

Should make for easier mocking in unit tests.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
