### PR TITLE
don't remove repo at the end of workflow, as pvc will be cleaned up

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -761,7 +761,6 @@ class DockerBuildWorkflow(object):
                 if not exception_being_handled:
                     raise ex
             finally:
-                self.source.remove_workdir()  # OSBS2 TBD: Don't remove here, remove in exit task?
                 self.fs_watcher.finish()
 
             signal.signal(signal.SIGTERM, signal.SIG_DFL)


### PR DESCRIPTION
anyway

* CLOUDBLD-8331

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
