### PR TITLE
Preserve permissions when copying to build dirs

### DIFF
--- a/atomic_reactor/dirs.py
+++ b/atomic_reactor/dirs.py
@@ -8,7 +8,7 @@ of the BSD license. See the LICENSE file for details.
 import logging
 
 from pathlib import Path
-from shutil import copyfile, copytree
+from shutil import copy2, copytree
 from typing import Dict, Any, List, Callable, Iterable, Optional
 
 from dockerfile_parse import DockerfileParser
@@ -279,6 +279,6 @@ class RootBuildDir(object):
                     copytree(src_file, dest)
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
-                    copyfile(src_file, dest)
+                    copy2(src_file, dest)
 
         return the_new_files


### PR DESCRIPTION
Replace shutil.copyfile with shutil.copy2. The former only copies file
content, while the latter also copies permissions and metadata.

The shutil.copytree method uses copy2 by default, no changes needed
there.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
