### PR TITLE
Update the check_user_settings plugin for OSBS 2

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -61,7 +61,7 @@ from atomic_reactor.constants import (
     KOJI_SOURCE_ENGINE,
 )
 from atomic_reactor.util import (Output,
-                                 df_parser, get_primary_images,
+                                 get_primary_images,
                                  get_floating_images, get_unique_images,
                                  get_manifest_media_type,
                                  get_digests_map_from_annotations, is_scratch_build,
@@ -699,8 +699,11 @@ class KojiImportPlugin(KojiImportBase):
             extra['custom_user_metadata'] = self.userdata
 
     def _update_build(self, build):
-        labels = Labels(df_parser(self.workflow.df_path,
-                                  workflow=self.workflow).labels)
+        # any_platform: the N-V-R labels should be equal for all platforms
+        dockerfile = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
+            self.workflow.imageutil.base_image_inspect()
+        )
+        labels = Labels(dockerfile.labels)
         _, component = labels.get_name_and_value(Labels.LABEL_TYPE_COMPONENT)
         _, version = labels.get_name_and_value(Labels.LABEL_TYPE_VERSION)
         _, release = labels.get_name_and_value(Labels.LABEL_TYPE_RELEASE)

--- a/atomic_reactor/plugins/pre_check_user_settings.py
+++ b/atomic_reactor/plugins/pre_check_user_settings.py
@@ -9,7 +9,6 @@ of the BSD license. See the LICENSE file for details.
 from atomic_reactor.constants import PLUGIN_CHECK_USER_SETTINGS
 from atomic_reactor.plugin import PreBuildPlugin
 from atomic_reactor.util import (
-    df_parser,
     has_operator_appregistry_manifest,
     has_operator_bundle_manifest,
     is_isolated_build,
@@ -65,7 +64,10 @@ class CheckUserSettingsPlugin(PreBuildPlugin):
         msg = "Dockerfile version label can't contain '/' character"
         self.log.debug("Running check: %s", msg)
 
-        parser = df_parser(self.workflow.df_path, workflow=self.workflow)
+        # any_platform: the version label should be equal for all platforms
+        parser = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
+            self.workflow.imageutil.base_image_inspect()
+        )
         dockerfile_labels = parser.labels
         labels = Labels(parser.labels)
 

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -22,9 +22,9 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
 
     plugins_def = plugin_based.PluginsDef(
         prebuild=[
-            {"name": "check_user_settings"},
             {"name": "distgit_fetch_artefacts"},
             {"name": "check_and_set_platforms"},
+            {"name": "check_user_settings"},
             {"name": "flatpak_create_dockerfile"},
             {"name": "inject_parent_image"},
             {"name": "check_base_image"},

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1575,8 +1575,18 @@ def exception_message(exc):
     return '{exc.__class__.__name__}: {exc}'.format(exc=exc)
 
 
-def _has_label_flag(workflow, label):
-    dockerfile = df_parser(workflow.df_path, workflow=workflow)
+def _has_label_flag(workflow, label) -> bool:
+    """Check if the Dockerfile for the build sets the specified label to 'true' (case-insensitive).
+
+    Checks the Dockerfile for just one platform. For the boolean-like labels this method should be
+    used to check, it is generally expected that they will be present in the source repo and not
+    modified by OSBS (therefore their values will be equal for all platforms).
+
+    Takes into account parent environment inheritance.
+    """
+    dockerfile = workflow.build_dir.any_platform.dockerfile_with_parent_env(
+        workflow.imageutil.base_image_inspect()
+    )
     labels = Labels(dockerfile.labels)
     try:
         _, value = labels.get_name_and_value(label)
@@ -1585,7 +1595,7 @@ def _has_label_flag(workflow, label):
     return value.lower() == 'true'
 
 
-def has_operator_appregistry_manifest(workflow):
+def has_operator_appregistry_manifest(workflow) -> bool:
     """
     Check if Dockerfile sets the operator manifest appregistry label
 
@@ -1594,7 +1604,7 @@ def has_operator_appregistry_manifest(workflow):
     return _has_label_flag(workflow, Labels.LABEL_TYPE_OPERATOR_MANIFESTS)
 
 
-def has_operator_bundle_manifest(workflow):
+def has_operator_bundle_manifest(workflow) -> bool:
     """
     Check if Dockerfile sets the operator manifest bundle label
 

--- a/tests/plugins/test_check_user_settings.py
+++ b/tests/plugins/test_check_user_settings.py
@@ -14,7 +14,7 @@ from flexmock import flexmock
 
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_check_user_settings import CheckUserSettingsPlugin
-from atomic_reactor.util import df_parser, DockerfileImages
+from atomic_reactor.util import DockerfileImages
 from atomic_reactor.constants import (
     DOCKERFILE_FILENAME,
     REPO_CONTENT_SETS_CONFIG,
@@ -106,12 +106,12 @@ def mock_env(workflow, source_dir: Path, labels=None, flatpak=False, dockerfile_
         'prebuild', CheckUserSettingsPlugin.key, {'flatpak': flatpak}
     )
     env.workflow.source = FakeSource(source_dir)
+    env.workflow.build_dir.init_build_dirs(["aarch64", "x86_64"], env.workflow.source)
 
     if isolated is not None:
         env.set_isolated(isolated)
 
-    dfp = df_parser(str(source_dir))
-    env.workflow._df_path = str(source_dir)
+    dfp = env.workflow.build_dir.any_platform.dockerfile
     env.workflow.dockerfile_images = DockerfileImages([] if flatpak else dfp.parent_images)
 
     flexmock(env.workflow.imageutil).should_receive("base_image_inspect").and_return({})

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -121,9 +121,12 @@ def mock_env(workflow, tmpdir, has_appregistry_label=False, appregistry_label=Fa
         def manifests_dir(self):
             return manifests_dir
 
-    # Set a new source object, only the manifests_dir property is required for tests.
-    setattr(env.workflow, 'source', MockSource())
-    env.workflow._df_path = str(repo_dir)
+        path = str(repo_dir)
+
+    # Set a new source object, only the manifests_dir and path properties are required for tests.
+    source = MockSource()
+    env.workflow.source = source
+    env.workflow.build_dir.init_build_dirs(["aarch64", "x86_64"], source)
 
 #    mock_stream = generate_archive(tmpdir, empty_archive, change_csv_content, multiple_csv)
     if selected_platform:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1854,18 +1854,16 @@ def test_allow_repo_dir_in_dockerignore(tmpdir, dockerignore_exists):
     )
 
 ])
-def test_has_operator_manifest(tmpdir, workflow, labels, f_true, f_false):
+def test_has_operator_manifest(workflow, labels, f_true, f_false):
     df_content = dedent("""\
         FROM fedora
         ENV foo=bar
         """)
     for label in labels:
         df_content += 'LABEL {}\n'.format(label)
-    workflow.source = StubSource()
-    cont_path = os.path.join(str(tmpdir), 'Dockerfile')
-    with open(cont_path, 'w') as f:
-        f.write(df_content)
-    workflow._df_path = cont_path
+
+    workflow.build_dir.init_build_dirs(["x86_64"], workflow.source)
+    workflow.build_dir.any_platform.dockerfile.content = df_content
 
     for func in f_true:
         assert func(workflow), 'Label not properly detected'


### PR DESCRIPTION
- Parse Dockerfile from build dirs, not source dir
- Update util methods the plugin uses to parse the Dockerfile to do the same as ^
- Move the plugin after check_and_set_platforms to make the changes work
- Update other plugins (mostly their unit tests) affected by the util method changes

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
