### PR TITLE
Move tag_from_config plugin to prebuild

### DIFF
--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -45,6 +45,7 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
             {"name": "hide_files"},
             {"name": "distribution_scope"},
             {"name": "add_buildargs_in_dockerfile"},
+            {"name": "tag_from_config"},
         ],
     )
 
@@ -66,7 +67,6 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
         postbuild=[
             {"name": "flatpak_create_oci"},
             {"name": "all_rpm_packages"},
-            {"name": "tag_from_config"},
             {"name": "export_operator_manifests"},
             {"name": "compress"},
             {"name": "fetch_worker_metadata"},

--- a/atomic_reactor/tasks/orchestrator.py
+++ b/atomic_reactor/tasks/orchestrator.py
@@ -36,6 +36,7 @@ class OrchestratorTask(plugin_based.PluginBasedTask):
             {"name": "add_labels_in_dockerfile"},
             {"name": "resolve_remote_source"},
             {"name": "pin_operator_digest"},
+            {"name": "tag_from_config"},
         ],
         buildstep=[
             {"name": "orchestrate_build"},
@@ -43,7 +44,6 @@ class OrchestratorTask(plugin_based.PluginBasedTask):
         postbuild=[
             {"name": "fetch_worker_metadata"},
             {"name": "compare_components"},
-            {"name": "tag_from_config"},
             {"name": "group_manifests"},
             {"name": "generate_maven_metadata"},
         ],

--- a/atomic_reactor/tasks/worker.py
+++ b/atomic_reactor/tasks/worker.py
@@ -43,6 +43,7 @@ class WorkerTask(plugin_based.PluginBasedTask):
             {"name": "download_remote_source"},
             {"name": "add_buildargs_in_dockerfile"},
             {"name": "pin_operator_digest"},
+            {"name": "tag_from_config"},
         ],
         prepublish=[
             {"name": "squash"},
@@ -50,7 +51,6 @@ class WorkerTask(plugin_based.PluginBasedTask):
         ],
         postbuild=[
             {"name": "all_rpm_packages", "args": {"image_id": "BUILT_IMAGE_ID"}},
-            {"name": "tag_from_config"},
             {"name": "tag_and_push"},
             {"name": "export_operator_manifests"},
             {"name": "compress", "args": {"load_exported_image": True, "method": "gzip"}},


### PR DESCRIPTION
Also update it so it will compute the whole image pullspec
and store it in the TagConf class

CLOUDBLD-8244

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
