### PR TITLE
Refactor bump release plugin

### DIFF
--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -71,7 +71,9 @@ class BumpReleasePlugin(PreBuildPlugin):
         return '.'.join([part for part in [release, suffix, rest]
                          if part is not None])
 
-    def next_release_general(self, component: str, version: str, release: Optional[str]) -> str:
+    def next_release_general(
+        self, component: str, version: str, release: Optional[str] = None
+    ) -> str:
         """Get next release for build."""
         if is_scratch_build(self.workflow):
             # no need to append for scratch build
@@ -186,7 +188,7 @@ class BumpReleasePlugin(PreBuildPlugin):
                     self.log.info("retrying CGInitBuild")
                     time.sleep(KOJI_RESERVE_RETRY_DELAY)
                     if not source_build:
-                        next_release = self.next_release_general(component, version, release)
+                        next_release = self.next_release_general(component, version)
                         dockerfile_labels[release_label] = next_release
                     else:
                         base_rel, base_suffix = release.rsplit('.', 1)

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -36,9 +36,6 @@ class BumpReleasePlugin(PreBuildPlugin):
             return {"append": True}
         return {}
 
-    # The target parameter is no longer used by this plugin. It's
-    # left as an optional parameter to allow a graceful transition
-    # in osbs-client.
     def __init__(self, workflow, append=False):
         """
         constructor

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -272,17 +272,14 @@ class BumpReleasePlugin(PreBuildPlugin):
                                            user_provided_release=True)
             return
 
-        if release:
-            if not self.append:
-                self.log.debug("release set explicitly so not incrementing")
+        if release and not self.append:
+            self.log.debug("release set explicitly so not incrementing")
 
-                if not is_scratch_build(self.workflow):
-                    self.check_build_existence_for_explicit_release(component, version, release)
-                    dockerfile_labels[release_label] = release
-                else:
-                    return
-
-        if not release or self.append:
+            if not is_scratch_build(self.workflow):
+                self.check_build_existence_for_explicit_release(component, version, release)
+                dockerfile_labels[release_label] = release
+        else:
+            # release not set or release should be appended
             self.next_release_general(component, version, release, release_label,
                                       dockerfile_labels)
 


### PR DESCRIPTION
Various simplifications in preparation for the Tekton changes (which will not be part of this PR).

This should preserve exactly the same functionality as before.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
