### PR TITLE
Add/enable mypy

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -55,6 +55,19 @@ jobs:
       - name: Run markdownlint
         uses: containerbuildsystem/actions/markdownlint@master
 
+  mypy:
+    name: mypy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Run mypy
+        uses: containerbuildsystem/actions/mypy@master
+        with:
+          package: 'atomic_reactor'
+
   pylint:
     name: Pylint analyzer for Python ${{ matrix.os.python }}
     runs-on: ubuntu-latest

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+python_version = 3.8
+exclude = .*plugins\/.*
+
+; The following is REQUIRED - `exclude` DOES NOT do what you think it does. It
+; ONLY ignores files encountered while recursively discovering files to check.
+; Without this option, mypy will ALWAYS include 'atomic_reactor/plugins/post_rpmqa.py'
+; Yes it did take me ~1.5 hrs to figure this out.
+[mypy-atomic_reactor.plugins.*]
+ignore_errors = True
+
+[mypy-*.dirs]
+ignore_errors = True
+
+[mypy-*.plugin]
+ignore_errors = True
+
+[mypy-*.inner]
+ignore_errors = True


### PR DESCRIPTION
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
