### PR TITLE
remove support for multiple registries

### DIFF
--- a/atomic_reactor/config.py
+++ b/atomic_reactor/config.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2021 Red Hat, Inc
+Copyright (c) 2021-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -407,22 +407,19 @@ class Configuration(object):
         return self._get_value(ReactorConfigKeys.REGISTRIES_ORGANIZATION_KEY, fallback=None)
 
     @property
-    def registries(self):
+    def registry(self):
         all_registries = self._get_value(ReactorConfigKeys.REGISTRIES_KEY)
 
-        registries_cm = {}
-        for registry in all_registries:
-            reguri = RegistryURI(registry.get('url'))
-            regdict = {}
-            regdict['version'] = reguri.version
-            if registry.get('auth'):
-                regdict['secret'] = registry['auth']['cfg_path']
-            regdict['insecure'] = registry.get('insecure', False)
-            regdict['expected_media_types'] = registry.get('expected_media_types', [])
+        registry = all_registries[0]
 
-            registries_cm[reguri.docker_uri] = regdict
+        reguri = RegistryURI(registry.get('url'))
+        regdict = {'uri': reguri.docker_uri, 'version': reguri.version}
+        if registry.get('auth'):
+            regdict['secret'] = registry['auth']['cfg_path']
+        regdict['insecure'] = registry.get('insecure', False)
+        regdict['expected_media_types'] = registry.get('expected_media_types', [])
 
-        return registries_cm
+        return regdict
 
     @property
     def docker_registry(self):

--- a/atomic_reactor/plugins/pre_tag_from_config.py
+++ b/atomic_reactor/plugins/pre_tag_from_config.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2016, 2017, 2018 Red Hat, Inc
+Copyright (c) 2016-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -93,7 +93,7 @@ class TagFromConfigPlugin(PreBuildPlugin):
 
     def add_registry_to_images(self):
         for image in self.workflow.data.tag_conf.images:
-            image.registry = next(iter(self.workflow.conf.registries))
+            image.registry = self.workflow.conf.registry['uri']
 
     def get_component_name(self):
         try:

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -453,6 +453,8 @@
                 "expected_media_types": {"$ref": "#/definitions/media_types"}
             },
             "additionalProperties": false,
+            "maxItems": 1,
+            "minItems": 1,
             "required": ["url"]
         }
     },

--- a/atomic_reactor/schemas/workflow_data.json
+++ b/atomic_reactor/schemas/workflow_data.json
@@ -5,7 +5,6 @@
   "properties": {
     "dockerfile_images": {"$ref": "#/definitions/dockerfile_images"},
     "tag_conf": {"$ref": "#/definitions/tag_conf"},
-    "push_conf": {"$ref": "#/definitions/push_conf"},
 
     "prebuild_results": {"type": "object"},
     "buildstep_result": {"type": "object"},
@@ -64,7 +63,7 @@
     "build_result": {"$ref": "#/definitions/build_result"}
   },
   "required": [
-    "dockerfile_images", "tag_conf", "push_conf",
+    "dockerfile_images", "tag_conf",
     "prebuild_results", "buildstep_result", "postbuild_results", "prepub_results", "exit_results",
     "plugin_workspace",
     "plugins_timestamps", "plugins_durations", "plugins_errors", "build_canceled", "plugin_failed",
@@ -143,19 +142,6 @@
         }
       },
       "required": ["primary_images", "unique_images", "floating_images"],
-      "additionalProperties": false
-    },
-    "push_conf": {
-      "type": "object",
-      "properties": {
-        "docker": {
-          "type": "object",
-          "patternProperties": {
-            "^[^ ]+$": {"$ref": "#/definitions/docker_registry"}
-          }
-        }
-      },
-      "required": ["docker"],
       "additionalProperties": false
     },
     "build_result": {

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -550,20 +550,20 @@ class Dockercfg(object):
             logger.error(msg, exc_info=True)
             raise RuntimeError(msg) from exc
 
-    def get_credentials(self, docker_registry):
+    def get_credentials(self, registry):
         # For maximal robustness we check the host:port of the passed in
         # registry against the host:port of the items in the secret. This is
         # somewhat similar to what the Docker CLI does.
         #
-        docker_registry = registry_hostname(docker_registry)
+        registry = registry_hostname(registry)
         try:
-            return self.json_secret[docker_registry]
+            return self.json_secret[registry]
         except KeyError:
             for reg, creds in self.json_secret.items():
-                if registry_hostname(reg) == docker_registry:
+                if registry_hostname(reg) == registry:
                     return creds
 
-            logger.warning('%s not found in .dockercfg', docker_registry)
+            logger.warning('%s not found in .dockercfg', registry)
             return {}
 
     def unpack_auth_b64(self, docker_registry):
@@ -1182,7 +1182,7 @@ def get_manifest_digests(image, registry, insecure=False, dockercfg_path=None,
     """
     registry_session = RegistrySession(registry, insecure=insecure, dockercfg_path=dockercfg_path)
     registry_client = RegistryClient(registry_session)
-    return registry_client.get_manifest_digests(image,
+    return registry_client.get_manifest_digests(image=image,
                                                 versions=versions,
                                                 require_digest=require_digest)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -457,7 +457,7 @@ This class defines a workflow for building images
 1. Obtain source
 1. Build image
 1. Tag it
-1. Push it to registries
+1. Push it to the registry
 
 ##### DockerBuildWorkflow instance variables
 
@@ -487,7 +487,6 @@ This class defines a workflow for building images
 - prepub_results
 - prepublish_plugins_conf
 - pulled_base_images
-- push_conf
 - source
 - tag_conf
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (c) 2015 Red Hat, Inc
+Copyright (c) 2015-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -132,11 +132,6 @@ registries:
 - url: https://container-registry.example.com/v2
   auth:
       cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
-- url: https://another-container-registry.example.com
-  insecure: True
-- url: https://better-container-registry.example.com/v2
-  expected_media_types:
-  - application/json
 
 source_registry:
     url: https://registry.private.example.com

--- a/tests/plugins/test_push_floating_tags.py
+++ b/tests/plugins/test_push_floating_tags.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2019 Red Hat, Inc
+Copyright (c) 2019-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -179,7 +179,6 @@ def mock_environment(workflow,
 
 
 REGISTRY_V2 = 'registry_v2.example.com'
-OTHER_V2 = 'registry.example.com:5001'
 
 
 GROUPED_V2_RESULTS = {
@@ -281,44 +280,38 @@ NOGROUP_OCI_RESULTS = {
                           'floating_tags',
                           'workers', 'expected_exception'), [
     ("simple_grouped_v2",
-     [REGISTRY_V2, OTHER_V2], GROUPED_V2_RESULTS, 'v2',
+     [REGISTRY_V2], GROUPED_V2_RESULTS, 'v2',
      ['namespace/httpd:2.4-1'],
      {
          'ppc64le': {
              REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
          },
          'x86_64': {
              REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
          }
      },
      None),
     ("simple_grouped_oci",
-     [REGISTRY_V2, OTHER_V2], GROUPED_OCI_RESULTS, 'oci',
+     [REGISTRY_V2], GROUPED_OCI_RESULTS, 'oci',
      ['namespace/httpd:2.4-1'],
      {
          'ppc64le': {
              REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
          },
          'x86_64': {
              REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
          }
      },
      None),
     ("multi_v2",
-     [REGISTRY_V2, OTHER_V2], GROUPED_V2_RESULTS, 'v2',
+     [REGISTRY_V2], GROUPED_V2_RESULTS, 'v2',
      ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
      {
          'ppc64le': {
              REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
          },
          'x86_64': {
              REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
          }
      },
      None),
@@ -359,35 +352,31 @@ NOGROUP_OCI_RESULTS = {
      },
      None),
     ("No tags",
-     [REGISTRY_V2, OTHER_V2], GROUPED_V2_RESULTS, 'v2',
+     [REGISTRY_V2], GROUPED_V2_RESULTS, 'v2',
      None,
      {
          'ppc64le': {
              REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
          },
          'x86_64': {
              REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
          }
      },
      'No floating images to tag, skipping push_floating_tags'),
     ("called_from_worker",
-     [REGISTRY_V2, OTHER_V2], GROUPED_V2_RESULTS, 'v2',
+     [REGISTRY_V2], GROUPED_V2_RESULTS, 'v2',
      ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
      {},
      'push_floating_tags cannot be used by a worker builder'),
     ("No_results",
-     [REGISTRY_V2, OTHER_V2], None, 'oci',
+     [REGISTRY_V2], None, 'oci',
      ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
      {
          'ppc64le': {
              REGISTRY_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-ppc64le-latest'],
          },
          'x86_64': {
              REGISTRY_V2: ['namespace/httpd:worker-build-x86_64-latest'],
-             OTHER_V2: ['namespace/httpd:worker-build-x86_64-latest'],
          }
      },
      'No manifest digest available, skipping push_floating_tags'),
@@ -405,7 +394,6 @@ def test_floating_tags_push(workflow, tmpdir, test_name, registries, manifest_re
 
     all_registry_conf = {
         REGISTRY_V2: {'version': 'v2', 'insecure': True},
-        OTHER_V2: {'version': 'v2', 'insecure': False},
     }
 
     temp_dir = mkdtemp(dir=str(tmpdir))
@@ -432,12 +420,6 @@ def test_floating_tags_push(workflow, tmpdir, test_name, registries, manifest_re
                            floating_images=floating_tags,
                            manifest_results=manifest_results,
                            annotations=annotations)
-
-    for registry, opts in registry_conf.items():
-        kwargs = {}
-        if 'insecure' in opts:
-            kwargs['insecure'] = opts['insecure']
-        env.workflow.data.push_conf.add_docker_registry(registry, **kwargs)
 
     if workers:
         env.make_orchestrator()

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2016 Red Hat, Inc
+Copyright (c) 2016-2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.usefixtures('user_params')
 
 @pytest.fixture
 def workflow(workflow, source_dir):
-    flexmock(workflow.conf, registries={REGISTRY: {}})
+    flexmock(workflow.conf, registry={'uri': REGISTRY})
 
     workflow.build_dir.init_build_dirs(["x86_64"], workflow.source)
     workflow.build_dir.any_platform.dockerfile.content = DF_CONTENT_LABELS


### PR DESCRIPTION
For backword compatibility we'll let the config
be `registries` but `maxItems` is set to `1` and
we're not using `PushConf()` anymore that let us
manipulate registry metadata.

* CLOUDBLD-8654

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
