### PR TITLE
mypy: fix dirs implementation

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -9,9 +9,6 @@ exclude = .*plugins\/.*
 [mypy-atomic_reactor.plugins.*]
 ignore_errors = True
 
-[mypy-*.dirs]
-ignore_errors = True
-
 [mypy-*.plugin]
 ignore_errors = True
 

--- a/atomic_reactor/dirs.py
+++ b/atomic_reactor/dirs.py
@@ -93,6 +93,7 @@ class BuildDir(object):
             return envs
         if isinstance(envs, list):
             return dict(item.split("=", 1) for item in envs)
+        raise TypeError(f"Unexpected envs type: {type(envs)}; {envs!r}")
 
     def dockerfile_with_parent_env(self, parent_inspect: ImageInspectionData) -> DockerfileParser:
         """Get the parsed Dockerfile with parent information injected.
@@ -129,7 +130,7 @@ class RootBuildDir(object):
         if not path.exists():
             raise FileNotFoundError(f"Path {path} does not exist.")
         self.path = path
-        self.platforms: Optional[List[str]] = None
+        self.platforms: List[str] = []
 
     @property
     def source_container_sources_dir(self) -> Path:


### PR DESCRIPTION
* `_get_env_from_inspection` must always return something or fail
* None type is not indexable, platforms must be always defined as list

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
