### PR TITLE
Run CentOS tests on CentOS Stream

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,8 +7,13 @@ OS=${OS:="centos"}
 OS_VERSION=${OS_VERSION:="8"}
 PYTHON_VERSION=${PYTHON_VERSION:="3.8"}
 ACTION=${ACTION:="test"}
-IMAGE="$OS:$OS_VERSION"
 CONTAINER_NAME="atomic-reactor-$OS-$OS_VERSION-py$PYTHON_VERSION"
+
+if [[ "$OS" == centos ]]; then
+    IMAGE="quay.io/centos/centos:stream$OS_VERSION"
+else
+    IMAGE="$OS:$OS_VERSION"
+fi
 
 # Use arrays to prevent globbing and word splitting
 engine_mounts=(-v "$PWD":"$PWD":z)


### PR DESCRIPTION
CentOS 8 went EOL on 2022-01-31. Switch to CentOS Stream 8.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
