### PR TITLE
Update add_dockerfile plugin for Tekton

### DIFF
--- a/tests/plugins/test_add_dockerfile.py
+++ b/tests/plugins/test_add_dockerfile.py
@@ -6,16 +6,41 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from flexmock import flexmock
-from atomic_reactor.plugin import PreBuildPluginsRunner
+from pathlib import Path
+from typing import Dict, Optional, NamedTuple
+
+from atomic_reactor.plugin import PluginsRunner
 from atomic_reactor.plugins.pre_add_dockerfile import AddDockerfilePlugin
-from atomic_reactor.util import df_parser
-from tests.stubs import StubSource
+
+from tests.mock_env import MockEnv
 
 
-def prepare(workflow, df_path):
-    workflow.source = StubSource()
-    flexmock(workflow, df_path=df_path)
+def mock_env(
+    workflow, df_content: str, args: Optional[Dict[str, str]] = None
+) -> PluginsRunner:
+    env = MockEnv(workflow).for_plugin("prebuild", AddDockerfilePlugin.key, args)
+
+    (Path(workflow.source.path) / "Dockerfile").write_text(df_content)
+    workflow.build_dir.init_build_dirs(["aarch64", "x86_64"], workflow.source)
+
+    return env.create_runner()
+
+
+class DockerfileCopy(NamedTuple):
+    name: str
+    content: str
+
+
+def check_outputs(expected_df_content: str, expected_df_copy: Optional[DockerfileCopy] = None):
+    def check_in_build_dir(build_dir):
+        df_content = build_dir.dockerfile_path.read_text()
+        assert df_content == expected_df_content
+
+        if expected_df_copy:
+            df_copy_path = build_dir.path / expected_df_copy.name
+            assert df_copy_path.read_text() == expected_df_copy.content
+
+    return check_in_build_dir
 
 
 def test_adddockerfile_plugin(tmpdir, workflow):  # noqa
@@ -23,27 +48,21 @@ def test_adddockerfile_plugin(tmpdir, workflow):  # noqa
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-    df = df_parser(str(tmpdir))
-    df.content = df_content
 
-    prepare(workflow, df.dockerfile_path)
-
-    runner = PreBuildPluginsRunner(
-        workflow,
-        [{
-            'name': AddDockerfilePlugin.key,
-            'args': {'nvr': 'rhel-server-docker-7.1-20'}
-        }]
-    )
+    runner = mock_env(workflow, df_content, {'nvr': 'rhel-server-docker-7.1-20'})
     runner.run()
+
     assert AddDockerfilePlugin.key is not None
 
-    expected_output = """
+    expected_df_content = """
 FROM fedora
 RUN yum install -y python-django
 ADD Dockerfile-rhel-server-docker-7.1-20 /root/buildinfo/Dockerfile-rhel-server-docker-7.1-20
 CMD blabla"""
-    assert df.content == expected_output
+    # the copied Dockerfile should have the *original* content
+    expected_df_copy = DockerfileCopy("Dockerfile-rhel-server-docker-7.1-20", df_content)
+
+    workflow.build_dir.for_each_platform(check_outputs(expected_df_content, expected_df_copy))
 
 
 def test_adddockerfile_todest(tmpdir, workflow):  # noqa
@@ -51,28 +70,22 @@ def test_adddockerfile_todest(tmpdir, workflow):  # noqa
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-    df = df_parser(str(tmpdir))
-    df.content = df_content
 
-    prepare(workflow, df.dockerfile_path)
-
-    runner = PreBuildPluginsRunner(
-        workflow,
-        [{
-            'name': AddDockerfilePlugin.key,
-            'args': {'nvr': 'jboss-eap-6-docker-6.4-77',
-                     'destdir': '/usr/share/doc/'}
-        }]
+    runner = mock_env(
+        workflow, df_content, {'nvr': 'jboss-eap-6-docker-6.4-77', 'destdir': '/usr/share/doc/'}
     )
     runner.run()
+
     assert AddDockerfilePlugin.key is not None
 
-    expected_output = """
+    expected_df_content = """
 FROM fedora
 RUN yum install -y python-django
 ADD Dockerfile-jboss-eap-6-docker-6.4-77 /usr/share/doc/Dockerfile-jboss-eap-6-docker-6.4-77
 CMD blabla"""
-    assert df.content == expected_output
+    expected_df_copy = DockerfileCopy("Dockerfile-jboss-eap-6-docker-6.4-77", df_content)
+
+    workflow.build_dir.for_each_platform(check_outputs(expected_df_content, expected_df_copy))
 
 
 def test_adddockerfile_nvr_from_labels(tmpdir, workflow):  # noqa
@@ -81,21 +94,21 @@ FROM fedora
 RUN yum install -y python-django
 LABEL Name="jboss-eap-6-docker" "Version"="6.4" "Release"=77
 CMD blabla"""
-    df = df_parser(str(tmpdir))
-    df.content = df_content
 
-    prepare(workflow, df.dockerfile_path)
-
-    runner = PreBuildPluginsRunner(
-        workflow,
-        [{
-            'name': AddDockerfilePlugin.key
-        }]
-    )
+    runner = mock_env(workflow, df_content)
     runner.run()
+
     assert AddDockerfilePlugin.key is not None
 
-    assert "ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77" in df.content  # noqa
+    expected_df_content = """
+FROM fedora
+RUN yum install -y python-django
+LABEL Name="jboss-eap-6-docker" "Version"="6.4" "Release"=77
+ADD Dockerfile-jboss-eap-6-docker-6.4-77 /root/buildinfo/Dockerfile-jboss-eap-6-docker-6.4-77
+CMD blabla"""
+    expected_df_copy = DockerfileCopy("Dockerfile-jboss-eap-6-docker-6.4-77", df_content)
+
+    workflow.build_dir.for_each_platform(check_outputs(expected_df_content, expected_df_copy))
 
 
 def test_adddockerfile_fails(tmpdir, caplog, workflow):  # noqa
@@ -103,17 +116,7 @@ def test_adddockerfile_fails(tmpdir, caplog, workflow):  # noqa
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-    df = df_parser(str(tmpdir))
-    df.content = df_content
-
-    prepare(workflow, df.dockerfile_path)
-
-    runner = PreBuildPluginsRunner(
-        workflow,
-        [{
-            'name': AddDockerfilePlugin.key
-        }]
-    )
+    runner = mock_env(workflow, df_content)
     runner.run()
     assert "plugin 'add_dockerfile' raised an exception: ValueError" in caplog.text
 
@@ -123,24 +126,17 @@ def test_adddockerfile_final(tmpdir, workflow):  # noqa
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-    df = df_parser(str(tmpdir))
-    df.content = df_content
 
-    prepare(workflow, df.dockerfile_path)
-
-    runner = PreBuildPluginsRunner(
-        workflow,
-        [{
-             'name': AddDockerfilePlugin.key,
-             'args': {'nvr': 'rhel-server-docker-7.1-20', "use_final_dockerfile": True}
-        }]
+    runner = mock_env(
+        workflow, df_content, {'nvr': 'rhel-server-docker-7.1-20', "use_final_dockerfile": True}
     )
     runner.run()
+
     assert AddDockerfilePlugin.key is not None
 
-    expected_output = """
+    expected_df_content = """
 FROM fedora
 RUN yum install -y python-django
 ADD Dockerfile /root/buildinfo/Dockerfile-rhel-server-docker-7.1-20
 CMD blabla"""
-    assert df.content == expected_output
+    workflow.build_dir.for_each_platform(check_outputs(expected_df_content))


### PR DESCRIPTION
CLOUDBLD-8123

For each platform, add the platform-specific Dockerfile to the build.

Improve tests to also check the content of the copied Dockerfile when
use_final_dockerfile is set to False.

Note that there is a slight behavior change when not using the final
Dockerfile. Previously, the plugin would copy the current snapshot
during initialization. Now, it will do so in the run() method instead.
In practice, this makes no difference because of how PluginRunners work.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
