### PR TITLE
mypy: fix "key" attribute

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,15 +2,5 @@
 python_version = 3.8
 exclude = .*plugins\/.*
 
-; The following is REQUIRED - `exclude` DOES NOT do what you think it does. It
-; ONLY ignores files encountered while recursively discovering files to check.
-; Without this option, mypy will ALWAYS include 'atomic_reactor/plugins/post_rpmqa.py'
-; Yes it did take me ~1.5 hrs to figure this out.
-[mypy-atomic_reactor.plugins.*]
-ignore_errors = True
-
-[mypy-*.plugin]
-ignore_errors = True
-
 [mypy-*.inner]
 ignore_errors = True

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -10,6 +10,7 @@ definition of plugin system
 
 plugins are supposed to be run when image is built and we need to extract some information
 """
+from abc import ABC, abstractmethod
 import copy
 import logging
 import os
@@ -41,13 +42,9 @@ class InappropriateBuildStepError(Exception):
     """Requested build step is not appropriate"""
 
 
-class Plugin(object):
+class Plugin(ABC):
     """ abstract plugin class """
 
-    # unique plugin identification
-    # output of this plugin can be found in results specified with this key,
-    # same thing goes for input: use this key for providing input for this plugin
-    key = None
     # by default, if plugin fails (raises exc), execution continues
     is_allowed_to_fail = True
 
@@ -58,6 +55,28 @@ class Plugin(object):
         self.log = logging.getLogger("atomic_reactor.plugins." + self.key)
         self.args = args
         self.kwargs = kwargs
+
+    @property
+    @abstractmethod
+    def key(self) -> str:
+        """Unique plugin identification
+
+        Output of this plugin can be found in results specified with this key,
+        same thing goes for input: use this key for providing input for this plugin
+
+        In subclass it can be specified just as "key" attribute
+        """
+
+        # Implementation notes: because this must be defined in each plugin it's abstract
+        # property. For easy implementation it's just instance property not a class
+        # property (with py<=3.8 it requires metaprogramming).
+        # For py>3.8:
+        #  ```
+        #  @classmethod
+        #  @property
+        #  def key(cls) -> str
+        #  ```
+        return "plugin"
 
     def __str__(self):
         return "%s" % self.key

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -295,6 +295,9 @@ class TestBuildPluginsRunner(object):
         workflow.user_params = {'shrubbery': 'yrebburhs'}
 
         class MyPlugin(BuildPlugin):
+
+            key = 'my_plugin'
+
             @staticmethod
             def args_from_user_params(user_params):
                 return {'shrubbery': user_params['shrubbery']}
@@ -325,6 +328,9 @@ class TestBuildPluginsRunner(object):
         workflow.user_params = {}
 
         class MyPlugin(BuildPlugin):
+
+            key = 'my_plugin'
+
             def __init__(self, workflow, spam=None, **kwargs):
                 self.spam = spam
                 for key, value in kwargs.items():


### PR DESCRIPTION
It cannot be `None` and with this patch definition of key in
subclasses/plugins is enforced by python itself

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
