### PR TITLE
Add paramiko to requirements

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -153,7 +153,7 @@ setuptools-rust==1.1.2 \
     --hash=sha256:72288a34cbb2efc436227f61548a453e91b2b3de1ca5846ab5d6bbcb859595c7 \
     --hash=sha256:a0adb9b503c0ffc4e8fe80b7c617898cefa78049983aaaea7f747e153a3e65d1
     # via -r requirements-build.in
-setuptools_scm[toml]==6.4.2 \
+setuptools-scm[toml]==6.4.2 \
     --hash=sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30 \
     --hash=sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4
     # via -r requirements-build.in

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -10,10 +10,15 @@ attrs==21.2.0
     #   pytest
 backoff==1.11.1
     # via -r requirements.in
+bcrypt==3.2.0
+    # via paramiko
 certifi==2021.10.8
     # via requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.7
     # via requests
 coverage[toml]==6.1.1
@@ -21,6 +26,7 @@ coverage[toml]==6.1.1
 cryptography==3.4.8
     # via
     #   -r requirements.in
+    #   paramiko
     #   pyspnego
     #   requests-kerberos
 decorator==5.1.0
@@ -63,6 +69,8 @@ osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5
     # via -r requirements.in
 packaging==21.2
     # via pytest
+paramiko==2.9.2
+    # via -r requirements.in
 pep8==1.7.1
     # via -r requirements-devel.in
 pluggy==1.0.0
@@ -81,6 +89,8 @@ pyflakes==2.4.0
     #   flake8
 pygobject==3.42.0
     # via -r requirements.in
+pynacl==1.5.0
+    # via paramiko
 pyparsing==2.4.7
     # via packaging
 pypng==0.0.21
@@ -133,6 +143,7 @@ ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
 six==1.16.0
     # via
+    #   bcrypt
     #   docker
     #   docker-squash
     #   dockerfile-parse

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11,<0.13;python_version<"3.9"
 flatpak-module-tools >= 0.11;python_version>="3.9"
 jsonschema
+paramiko
 PyYAML
 ruamel.yaml
 git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7#egg=osbs-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,15 +8,21 @@ attrs==21.2.0
     # via jsonschema
 backoff==1.11.1
     # via -r requirements.in
+bcrypt==3.2.0
+    # via paramiko
 certifi==2021.10.8
     # via requests
 cffi==1.15.0
-    # via cryptography
+    # via
+    #   bcrypt
+    #   cryptography
+    #   pynacl
 charset-normalizer==2.0.7
     # via requests
 cryptography==3.4.8
     # via
     #   -r requirements.in
+    #   paramiko
     #   pyspnego
     #   requests-kerberos
 decorator==5.1.0
@@ -49,12 +55,16 @@ krb5==0.2.0
     # via pyspnego
 osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7
     # via -r requirements.in
+paramiko==2.9.2
+    # via -r requirements.in
 pycairo==1.20.1
     # via pygobject
 pycparser==2.20
     # via cffi
 pygobject==3.42.0
     # via -r requirements.in
+pynacl==1.5.0
+    # via paramiko
 pyrsistent==0.18.0
     # via jsonschema
 pyspnego[kerberos]==0.3.1
@@ -85,6 +95,7 @@ ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
 six==1.16.0
     # via
+    #   bcrypt
     #   docker
     #   docker-squash
     #   dockerfile-parse


### PR DESCRIPTION
paramiko is required to work with remote hosts

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
