### PR TITLE
Update distribution_scope plugin for Tekton

### DIFF
--- a/tests/plugins/test_distribution_scope.py
+++ b/tests/plugins/test_distribution_scope.py
@@ -6,26 +6,26 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+import logging
+from pathlib import Path
+
+import pytest
+from flexmock import flexmock
+
 from atomic_reactor.constants import INSPECT_CONFIG
 from atomic_reactor.plugins.pre_distribution_scope import (DistributionScopePlugin,
                                                            DisallowedDistributionScope)
 from atomic_reactor.util import DockerfileImages
-from flexmock import flexmock
-import logging
-import os
-import pytest
 
 
 class TestDistributionScope(object):
     def instantiate_plugin(self, workflow, parent_labels, current_scope, base_from_scratch=False):
-        filename = os.path.join(workflow.source.workdir, 'Dockerfile')
-        with open(filename, 'wt') as df:
+        with open(Path(workflow.source.path) / "Dockerfile", 'wt') as df:
             df.write('FROM scratch\n')
             if current_scope:
                 df.write('LABEL distribution-scope={}\n'.format(current_scope))
 
-        # TEMP solution until the plugin is updated to read Dockerfiles from build dirs
-        workflow._df_path = filename
+        workflow.build_dir.init_build_dirs(["x86_64"], workflow.source)
 
         if not base_from_scratch:
             (flexmock(workflow.imageutil)


### PR DESCRIPTION
CLOUDBLD-8123

Read the Dockerfile from a build dir. We only check the scope labels for
one platform and assume that they cannot differ between platforms.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
