### PR TITLE
Update add_buildargs_in_df plugin for Tekton

### DIFF
--- a/tests/plugins/test_add_buildargs.py
+++ b/tests/plugins/test_add_buildargs.py
@@ -7,19 +7,24 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from pathlib import Path
 from textwrap import dedent
+from typing import Dict
+
 import pytest
-from flexmock import flexmock
-from atomic_reactor.plugin import PreBuildPluginsRunner
-from atomic_reactor.plugins.pre_add_buildargs_in_df import (
-    AddBuildargsPlugin)
-from atomic_reactor.util import df_parser
-from tests.stubs import StubSource
+
+from atomic_reactor.plugin import PluginsRunner
+from atomic_reactor.plugins.pre_add_buildargs_in_df import AddBuildargsPlugin
+
+from tests.mock_env import MockEnv
 
 
-def prepare(workflow, df_path: str):
-    workflow.source = StubSource()
-    flexmock(workflow, df_path=df_path)
+def mock_env(workflow, df_content: str, buildargs: Dict[str, str]) -> PluginsRunner:
+    env = MockEnv(workflow).for_plugin("prebuild", AddBuildargsPlugin.key)
+    (Path(workflow.source.path) / "Dockerfile").write_text(df_content)
+    workflow.build_dir.init_build_dirs(["aarch64", "x86_64"], workflow.source)
+    workflow.data.buildargs = buildargs
+    return env.create_runner()
 
 
 @pytest.mark.parametrize('buildargs, df_content, df_expected', [
@@ -130,22 +135,14 @@ def prepare(workflow, df_path: str):
         """)
     ),
 ])
-def test_add_buildargs_plugin(
-    workflow, source_dir, caplog, buildargs, df_content, df_expected
-):
-    df = df_parser(str(source_dir))
-    df.content = df_content
-
-    prepare(workflow, df.dockerfile_path)
-    workflow.data.buildargs = buildargs
-
-    runner = PreBuildPluginsRunner(workflow, [{
-        'name': AddBuildargsPlugin.key,
-        'args': {}
-    }])
+def test_add_buildargs_plugin(workflow, caplog, buildargs, df_content, df_expected):
+    runner = mock_env(workflow, df_content, buildargs)
     runner.run()
 
-    assert df_expected == df.content
+    def check_df(build_dir):
+        assert build_dir.dockerfile_path.read_text() == df_expected
+
+    workflow.build_dir.for_each_platform(check_df)
 
     if not buildargs:
         assert 'No buildargs specified, skipping plugin' in caplog.text


### PR DESCRIPTION
CLOUDBLD-8123

Add the buildargs to each per-platform Dockerfile.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
