### PR TITLE
Update change_from_in_df plugin for Tekton

### DIFF
--- a/tests/plugins/test_change_from_in_df.py
+++ b/tests/plugins/test_change_from_in_df.py
@@ -6,74 +6,67 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
-from flexmock import flexmock
 from osbs.utils import ImageName
 
-from atomic_reactor.plugin import PreBuildPluginsRunner, PluginFailedException
+from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.pre_change_from_in_df import ChangeFromPlugin
-from atomic_reactor.util import df_parser, DockerfileImages
-from tests.stubs import StubSource
+
+from tests.mock_env import MockEnv
 
 pytestmark = pytest.mark.usefixtures('user_params')
 
 
-def mock_workflow(workflow, df_path=None, df_images=None):
-    """
-    Provide just enough structure that workflow can be used to run the plugin.
-    Defaults below are solely to enable that purpose; tests where those values
-    matter should provide their own.
-    """
-    if df_images is None:
-        df_images = []
-    workflow.source = StubSource()
-    flexmock(workflow, df_path=df_path)
-    if df_images:
-        workflow.data.dockerfile_images = DockerfileImages(df_images)
+def mock_workflow(workflow, df_content, override_df_images=None):
+    """"" Provide just enough structure that workflow can be used to run the plugin."""
+    (Path(workflow.source.path) / "Dockerfile").write_text(df_content)
+    workflow.build_dir.init_build_dirs(["aarch64", "x86_64"], workflow.source)
+
+    if override_df_images:
+        df_images = override_df_images
     else:
-        workflow.data.dockerfile_images = DockerfileImages(['mock:base'])
-        workflow.data.dockerfile_images['mock:base'] = ImageName.parse("mock:tag")
+        df_images = workflow.build_dir.any_platform.dockerfile.parent_images
+
+    MockEnv(workflow).set_dockerfile_images(df_images)
 
     return workflow
 
 
 def run_plugin(workflow):
-    result = PreBuildPluginsRunner(
-        workflow,
-        [{
-            'name': ChangeFromPlugin.key,
-            'args': {},
-        }]
-    ).run()
-
+    result = MockEnv(workflow).for_plugin("prebuild", ChangeFromPlugin.key).create_runner().run()
     return result[ChangeFromPlugin.key]
+
+
+def check_df_content(expected_content, workflow):
+    def check_df(build_dir):
+        assert build_dir.dockerfile_path.read_text() == expected_content
+
+    workflow.build_dir.for_each_platform(check_df)
 
 
 @pytest.mark.parametrize('base_image', [
     "base:image",
     "different_registry.com/base:image",
 ])
-def test_update_base_image(tmpdir, workflow, base_image):
+def test_update_base_image(workflow, base_image):
     df_content = dedent("""\
         FROM {}
         LABEL horses=coconuts
         CMD whoah
     """)
-    dfp = df_parser(str(tmpdir))
-    dfp.content = df_content.format(base_image)
     base_str = "base@sha256:1234"
     local_tag = ImageName.parse("base@sha256:1234")
 
-    workflow = mock_workflow(workflow,
-                             df_path=dfp.dockerfile_path,
-                             df_images=dfp.parent_images)
+    workflow = mock_workflow(workflow, df_content=df_content.format(base_image))
     workflow.data.dockerfile_images[base_image] = local_tag
 
     run_plugin(workflow)
     expected_df = df_content.format(base_str)
-    assert dfp.content == expected_df
+
+    check_df_content(expected_df, workflow)
 
 
 @pytest.mark.parametrize('df_content, expected_df_content', [
@@ -232,11 +225,8 @@ def test_update_base_image(tmpdir, workflow, base_image):
         """),
     ),
 ])
-def test_update_parent_images(df_content, expected_df_content, tmpdir, workflow):
+def test_update_parent_images(df_content, expected_df_content, workflow):
     """test the happy path for updating multiple parents"""
-    dfp = df_parser(str(tmpdir))
-    dfp.content = df_content
-
     # maps from dockerfile image to image with manifest digest
     first = ImageName.parse("first:parent")
     second = ImageName.parse("second:parent")
@@ -255,10 +245,9 @@ def test_update_parent_images(df_content, expected_df_content, tmpdir, workflow)
         custom: build3,
     }
 
-    workflow = mock_workflow(workflow,
-                             df_path=dfp.dockerfile_path,
-                             df_images=dfp.parent_images)
+    workflow = mock_workflow(workflow, df_content)
 
+    dfp = workflow.build_dir.any_platform.dockerfile
     for parent in dfp.parent_images:
         if parent == 'scratch':
             continue
@@ -267,22 +256,21 @@ def test_update_parent_images(df_content, expected_df_content, tmpdir, workflow)
 
     original_base = workflow.data.dockerfile_images.base_image
     run_plugin(workflow)
-    assert dfp.content == expected_df_content
+
+    check_df_content(expected_df_content, workflow)
+
     if workflow.data.dockerfile_images.base_from_scratch:
         assert original_base == workflow.data.dockerfile_images.base_image
 
 
-def test_parent_images_unresolved(tmpdir, workflow):
+def test_parent_images_unresolved(workflow):
     """test when parent_images hasn't been filled in with unique tags."""
-    dfp = df_parser(str(tmpdir))
-    dfp.content = dedent("""\
+    df_content = dedent("""\
         FROM extra_image
         FROM base_image
     """)
 
-    workflow = mock_workflow(workflow,
-                             df_path=dfp.dockerfile_path,
-                             df_images=['extra_image', 'base_image'])
+    workflow = mock_workflow(workflow, df_content)
     workflow.data.dockerfile_images['base_image'] = 'base_local'
 
     with pytest.raises(PluginFailedException) as exc:
@@ -290,18 +278,15 @@ def test_parent_images_unresolved(tmpdir, workflow):
     assert "raised an exception: ParentImageUnresolved" in str(exc.value)
 
 
-def test_parent_images_missing(tmpdir, workflow):
+def test_parent_images_missing(workflow):
     """test when parent_images has been mangled and lacks parents compared to dockerfile."""
-    dfp = df_parser(str(tmpdir))
-    dfp.content = dedent("""\
+    df_content = dedent("""\
         FROM first:parent AS builder1
         FROM second:parent AS builder2
         FROM monty
     """)
 
-    workflow = mock_workflow(workflow,
-                             df_path=dfp.dockerfile_path,
-                             df_images=['monty'])
+    workflow = mock_workflow(workflow, df_content, override_df_images=['monty'])
     workflow.data.dockerfile_images['monty'] = 'monty_local'
 
     with pytest.raises(PluginFailedException) as exc:
@@ -309,13 +294,15 @@ def test_parent_images_missing(tmpdir, workflow):
     assert "raised an exception: ParentImageMissing" in str(exc.value)
 
 
-def test_parent_images_mismatch_base_image(tmpdir, workflow):
+def test_parent_images_mismatch_base_image(workflow):
     """test when base_image has been updated differently from parent_images."""
-    dfp = df_parser(str(tmpdir))
-    dfp.content = "FROM base:image"
+    df_content = "FROM base:image"
     workflow = mock_workflow(workflow,
-                             df_path=dfp.dockerfile_path,
-                             df_images=['base:image', 'parent_different:latest'])
+                             df_content,
+                             override_df_images=['base:image', 'parent_different:latest'])
+
+    workflow.data.dockerfile_images['base:image'] = 'base:resolved'
+    workflow.data.dockerfile_images['parent_different:latest'] = 'parent_different:resolved'
 
     with pytest.raises(PluginFailedException) as exc:
         run_plugin(workflow)


### PR DESCRIPTION
Change the FROM lines in each per-platform Dockerfile.

Slight change in behavior: the plugin now checks for unresolved parents
before checking for mismatched base image. Both of those would be code
bugs, it shouldn't matter which we check first.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
