### PR TITLE
Minor pin_operator_digest fix for Tekton

### DIFF
--- a/atomic_reactor/plugins/pre_pin_operator_digest.py
+++ b/atomic_reactor/plugins/pre_pin_operator_digest.py
@@ -20,7 +20,7 @@ from atomic_reactor.constants import (
 from atomic_reactor.util import (RegistrySession,
                                  RegistryClient,
                                  has_operator_bundle_manifest,
-                                 read_yaml_from_url, df_parser,
+                                 read_yaml_from_url,
                                  terminal_key_paths,
                                  map_to_user_params)
 from osbs.utils.yaml import (
@@ -289,7 +289,10 @@ class PinOperatorDigestsPlugin(PreBuildPlugin):
         site_config = self.workflow.conf.operator_manifests
         allowed_packages = site_config.get("skip_all_allow_list", [])
 
-        parser = df_parser(self.workflow.df_path, workflow=self.workflow)
+        # any_platform: the component label should be equal for all platforms
+        parser = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
+            self.workflow.imageutil.base_image_inspect()
+        )
         dockerfile_labels = parser.labels
         labels = Labels(dockerfile_labels)
 


### PR DESCRIPTION
Read the Dockerfile from a build dir, not the source dir.

In the unit tests, do not mix the repo_dir (== source directory) and the
build_dir. Do all the mocking in the repo_dir instead.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
