### PR TITLE
split osbs build logs by platform

### DIFF
--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -22,7 +22,7 @@ from atomic_reactor.plugins.build_orchestrate_build import (get_worker_build_inf
                                                             get_koji_upload_dir)
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.util import (OSBSLogs, get_parent_image_koji_data, get_manifest_media_version,
-                                 is_manifest_list, map_to_user_params)
+                                 get_platforms, is_manifest_list, map_to_user_params)
 from atomic_reactor.utils.koji import get_buildroot as koji_get_buildroot
 from atomic_reactor.utils.koji import get_output as koji_get_output
 from atomic_reactor.utils.koji import (
@@ -428,7 +428,7 @@ class KojiImportBase(ExitPlugin):
         buildroot = self.get_buildroot(worker_metadatas)
         buildroot_id = buildroot[0]['id']
         output, output_file = self.get_output(worker_metadatas, buildroot_id)
-        osbs_logs = OSBSLogs(self.log)
+        osbs_logs = OSBSLogs(self.log, get_platforms(self.workflow))
         output_files = [add_log_type(add_buildroot_id(md, buildroot_id))
                         for md in osbs_logs.get_log_files(self.osbs, self.pipeline_run_name)]
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -51,7 +51,7 @@ from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE, IMAGE_TYPE_OCI_
                                       KOJI_SUBTYPE_OP_BUNDLE,
                                       KOJI_SOURCE_ENGINE,
                                       DOCKERFILE_FILENAME,
-                                      REPO_CONTAINER_CONFIG)
+                                      REPO_CONTAINER_CONFIG, PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
 from tests.flatpak import (MODULEMD_AVAILABLE,
                            setup_flatpak_composes,
                            setup_flatpak_source_info)
@@ -267,6 +267,9 @@ def mock_environment(workflow, source_dir: Path, session=None, name=None, oci=Fa
     if source is None:
         source = GitSource('git', 'git://hostname/path')
 
+    platforms = ['x86_64']
+    workflow.data.prebuild_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = platforms
+
     mock_reactor_config(workflow)
     workflow.user_params['scratch'] = scratch
 
@@ -327,7 +330,7 @@ def mock_environment(workflow, source_dir: Path, session=None, name=None, oci=Fa
     setattr(workflow.source.lg, 'commit_id', '123456')
     setattr(workflow.source.lg, 'git_path', str(source_dir))
 
-    workflow.build_dir.init_build_dirs(["x86_64"], workflow.source)
+    workflow.build_dir.init_build_dirs(platforms, workflow.source)
 
     def custom_get(method, url, headers, **kwargs):
         if url == manifest_url:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -75,7 +75,6 @@ from osbs.utils import ImageName
 from osbs.exceptions import OsbsValidationException
 from tests.mock_env import MockEnv
 from tests.stubs import StubSource
-from tests.constants import OSBS_BUILD_LOG_FILENAME
 
 if MOCK:
     from tests.retry_mock import mock_get_retry_session
@@ -1198,22 +1197,47 @@ def test_osbs_logs_get_log_files(tmpdir):
             logs = {
                 "taskRun1": {"containerA": "log message A", "containerB": "log message B"},
                 "taskRun2": {"containerC": "log message C"},
+                "taskRun3-s390x": {"containerD": "log message D"},
+                "taskRun4-ppc64le": {"containerE": "log message E"},
+                "taskRun5-aarch64": {"containerF": "log message F"},
+                "taskRun6-x86-64": {"containerG": "log message G"},
             }
             return logs
 
-    osbs_logfile_metadata = {
-        'checksum': '1b6c0f6e47915b0d0d12cc0fc863750a',
-        'checksum_type': 'md5',
-        'filename': OSBS_BUILD_LOG_FILENAME,
-        'filesize': 42
-    }
+    osbs_logfiles_metadata = [{'checksum': '1b6c0f6e47915b0d0d12cc0fc863750a',
+                               'checksum_type': 'md5',
+                               'filename': 'osbs-build.log',
+                               'filesize': 42
+                               },
+                              {'checksum': '1d1756214255fcd6941a9ddb37d71020',
+                               'checksum_type': 'md5',
+                               'filename': 's390x.log',
+                               'filesize': 14
+                               },
+                              {'checksum': '790b112736bdb108969589658b069c5b',
+                               'checksum_type': 'md5',
+                               'filename': 'ppc64le.log',
+                               'filesize': 14
+                               },
+                              {'checksum': 'bb6976a430d9a614fe09e87f3ae26a39',
+                               'checksum_type': 'md5',
+                               'filename': 'aarch64.log',
+                               'filesize': 14
+                               },
+                              {'checksum': '782797acf067a76034d5ae0f58618e2f',
+                               'checksum_type': 'md5',
+                               'filename': 'x86_64.log',
+                               'filesize': 14
+                               }
+                              ]
 
     logger = flexmock()
     flexmock(logger).should_receive('error')
-    osbs_logs = OSBSLogs(logger)
+    osbs_logs = OSBSLogs(logger, ['x86_64', 'ppc64le', 'aarch64', 's390x'])
     osbs = OSBS()
-    output = osbs_logs.get_log_files(osbs, 'test-pipeline-run')
-    assert output[0].metadata == osbs_logfile_metadata
+    outputs = osbs_logs.get_log_files(osbs, 'test-pipeline-run')
+    for index, output in enumerate(outputs):
+        assert output.metadata == osbs_logfiles_metadata[index]
 
 
 @pytest.mark.parametrize('raise_error', [


### PR DESCRIPTION
build logs for platforms are put into arch-specific
logs

* CLOUDBLD-8139

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
