### PR TITLE
Don't handle platforms config in get_platforms_in_limits

### DIFF
--- a/atomic_reactor/plugins/pre_check_and_set_platforms.py
+++ b/atomic_reactor/plugins/pre_check_and_set_platforms.py
@@ -90,7 +90,12 @@ class CheckAndSetPlatformsPlugin(PreBuildPlugin):
                   ' {}'.format(defined_but_disabled)
             raise RuntimeError(msg)
 
-        final_platforms = get_platforms_in_limits(self.workflow, enabled_platforms)
+        source_config = self.workflow.source.config
+        final_platforms = get_platforms_in_limits(
+            enabled_platforms,
+            source_config.excluded_platforms,
+            source_config.only_platforms,
+        )
 
         self.log.info("platforms in limits : %s", final_platforms)
 

--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import tempfile
 from textwrap import dedent
+from typing import Any, List
 import collections
 try:
     from urlparse import urlparse
@@ -31,6 +32,12 @@ logger = logging.getLogger(__name__)
 # Intended for use as vcs-type, vcs-url and vcs-ref docker labels as defined
 # in https://github.com/projectatomic/ContainerApplicationGenericLabels
 VcsInfo = collections.namedtuple('VcsInfo', ['vcs_type', 'vcs_url', 'vcs_ref'])
+
+
+def make_list(value: Any) -> List[Any]:
+    if not isinstance(value, list):
+        return [value]
+    return value
 
 
 class SourceConfig(object):
@@ -64,6 +71,18 @@ class SourceConfig(object):
         self.remote_source = self.data.get('remote_source')
         self.remote_sources = self.data.get('remote_sources')
         self.operator_manifests = self.data.get('operator_manifests')
+
+        self.platforms = self.data.get('platforms') or {'not': [], 'only': []}
+        self.platforms['not'] = make_list(self.platforms.get('not', []))
+        self.platforms['only'] = make_list(self.platforms.get('only', []))
+
+    @property
+    def excluded_platforms(self) -> List[str]:
+        return self.platforms['not']
+
+    @property
+    def only_platforms(self) -> List[str]:
+        return self.platforms['only']
 
 
 class Source(object):

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -17,7 +17,7 @@ import requests
 from requests.exceptions import SSLError, HTTPError, RetryError
 import shutil
 import tempfile
-from typing import Any, Final, Iterator, Sequence, Dict, Union, List, BinaryIO, Tuple, Optional, Set
+from typing import Any, Final, Iterator, Sequence, Dict, Union, List, BinaryIO, Tuple, Optional
 import logging
 import uuid
 import yaml
@@ -1535,42 +1535,6 @@ class OSBSLogs(object):
 class DefaultKeyDict(dict):
     def __missing__(self, key):
         return key
-
-
-def get_platforms_in_limits(
-    input_platforms: Optional[Sequence[str]] = None,
-    excludes: Optional[List[str]] = None,
-    only: Optional[List[str]] = None,
-) -> Optional[Set[str]]:
-    """Limit platforms in a specific range.
-
-    :param input_platforms: a sequence of platforms to be filtered.
-    :type input_platforms: list[str] or set[str]
-    :param excludes: exclude these platforms from ``input_platforms``. If
-        omitted, whether a platform is included in the final result depends on
-        the argument ``only``.
-    :type excludes: list[str]
-    :param only: the result should only include these platforms.
-    :type only: list[str]
-    :return: the limited platforms. If no input platforms, None is returned.
-    :rtype: set[str] or None
-    """
-    if not input_platforms:
-        return None
-
-    if not isinstance(input_platforms, set):
-        expected_platforms = set(input_platforms)
-    else:
-        expected_platforms = deepcopy(input_platforms)
-
-    only_platforms = set(only or [])
-    excludes_platforms = set(excludes or [])
-
-    if only_platforms:
-        if only_platforms == excludes_platforms:
-            logger.warning('only and not platforms are the same: %r', only_platforms)
-        expected_platforms &= only_platforms
-    return expected_platforms - excludes_platforms
 
 
 def dump_stacktraces(sig, frame):

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -109,26 +109,26 @@ class TestSourceConfigSchemaValidation(object):
             # empty config
             """\
             """,
-            {'data': {}}
+            {'platforms': {'not': [], 'only': []}},
         ), (
             """\
             platforms:
               only: s390x
             """,
-            {'data': {'platforms': {'only': 's390x'}}}
+            {'platforms': {'only': ['s390x'], 'not': []}},
         ), (
             """\
             platforms:
               not: s390x
             """,
-            {'data': {'platforms': {'not': 's390x'}}}
+            {'platforms': {'not': ['s390x'], 'only': []}},
         ), (
             """\
             platforms:
               not: s390x
               only: s390x
             """,
-            {'data': {'platforms': {'only': 's390x', 'not': 's390x'}}}
+            {'platforms': {'only': ['s390x'], 'not': ['s390x']}},
         ), (
             """\
             platforms:
@@ -137,12 +137,12 @@ class TestSourceConfigSchemaValidation(object):
               only:
                - s390x
             """,
-            {'data': {'platforms': {'only': ['s390x'], 'not': ['s390x']}}}
+            {'platforms': {'only': ['s390x'], 'not': ['s390x']}},
         ), (
             """\
             platforms:
             """,
-            {'data': {'platforms': None}}
+            {'platforms': {'not': [], 'only': []}},
         ), (
             """\
             flatpak:
@@ -309,6 +309,8 @@ class TestSourceConfigSchemaValidation(object):
               "enable_repo_replacements": False,
               "enable_registry_replacements": True,
           }}
+        ), (
+            "", {'platforms': {'not': [], 'only': []}},
         ),
     ])
     def test_valid_source_config(self, tmpdir, yml_config, attrs_updated):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -70,7 +70,6 @@ from atomic_reactor.util import (LazyGit, figure_out_build_file,
 from tests.constants import MOCK, REACTOR_CONFIG_MAP
 import atomic_reactor.util
 from atomic_reactor.constants import INSPECT_CONFIG
-from atomic_reactor.source import SourceConfig
 from osbs.utils import ImageName
 from osbs.exceptions import OsbsValidationException
 from tests.mock_env import MockEnv
@@ -1421,105 +1420,49 @@ def test_get_all_manifests(tmpdir, image, registry, insecure, creds, path, versi
         assert all_manifests == {}
 
 
-@pytest.mark.parametrize(('valid'), [
-    True,
-    False
-])
-@pytest.mark.parametrize(('platforms', 'config_dict', 'result'), [
+@pytest.mark.parametrize('input_platforms,excludes,only,expected', [
+    (['x86_64', 'ppc64le'], [], ['ppc64le'], ['ppc64le']),
     (
-        ['x86_64', 'ppc64le'],
-        {'platforms': {'only': 'ppc64le'}},
-        ['ppc64le']
-    ), (
         ['x86_64', 'spam', 'bacon', 'toast', 'ppc64le'],
-        {'platforms': {'not': ['spam', 'bacon', 'eggs', 'toast']}},
-        ['x86_64', 'ppc64le']
-    ), (
-        ['ppc64le', 'spam', 'bacon', 'toast'],
-        {'platforms': {'not': ['spam', 'bacon', 'eggs', 'toast'], 'only': ['ppc64le']}},
-        ['ppc64le']
-    ), (
-        ['x86_64', 'bacon', 'toast'],
-        {'platforms': {'not': 'toast', 'only': ['x86_64', 'ppc64le']}},
-        ['x86_64']
-    ), (
-        ['x86_64', 'toast'],
-        {'platforms': {'not': 'toast', 'only': 'x86_64'}},
-        ['x86_64']
-    ), (
-        ['x86_64', 'spam', 'bacon', 'toast'],
-        {'platforms': {
-            'not': ['spam', 'bacon', 'eggs', 'toast'],
-            'only': ['x86_64', 'ppc64le']
-        }},
-        ['x86_64']
-    ), (
+        ['spam', 'bacon', 'eggs', 'toast'],
+        [],
         ['x86_64', 'ppc64le'],
-        {},
-        ['x86_64', 'ppc64le']
-    ), (
-        ['x86_64', 'ppc64le'],
-        {'platforms': {'not': 'x86_64', 'only': 'x86_64'}},
-        []
-    ), (
-        ['x86_64', 'ppc64le'],
-        {'platforms': None},
-        ['x86_64', 'ppc64le']
     ),
+    (
+        ['ppc64le', 'spam', 'bacon', 'toast'],
+        ['spam', 'bacon', 'eggs', 'toast'],
+        ['ppc64le'],
+        ['ppc64le'],
+    ),
+    # only takes the priority
+    (
+        ['ppc64le', 'spam', 'bacon', 'toast'],
+        ['bacon', 'eggs', 'toast'],
+        ['ppc64le'],
+        ['ppc64le'],  # spam is not excluded, but only include ppc64le
+    ),
+    (
+        ['x86_64', 'bacon', 'toast'],
+        ['toast'],
+        ['x86_64', 'ppc64le'],
+        ['x86_64']
+    ),
+    (
+        ['x86_64', 'spam', 'bacon', 'toast'],
+        ['spam', 'bacon', 'eggs', 'toast'],
+        ['x86_64', 'ppc64le'],
+        ['x86_64'],
+    ),
+    (['x86_64', 'ppc64le'], [], [], ['x86_64', 'ppc64le']),
+    (['x86_64', 'ppc64le'], ["x86_64"], ["x86_64"], []),
 ])
-def test_get_platforms_in_limits(tmpdir, platforms, config_dict, result, valid, caplog):
-    class MockSource(object):
-        def __init__(self, build_dir):
-            self.build_dir = build_dir
-            self._config = None
+def test_get_platforms_in_limits(input_platforms, excludes, only, expected, caplog):
+    assert set(expected) == get_platforms_in_limits(
+        input_platforms, excludes=excludes, only=only
+    )
 
-        def get_build_file_path(self):
-            return self.build_dir, self.build_dir
-
-        @property
-        def config(self):
-            self._config = self._config or SourceConfig(self.build_dir)
-            return self._config
-
-    class MockWorkflow(object):
-        def __init__(self, build_dir):
-            self.source = MockSource(build_dir)
-
-    def configured_same_not_and_only(conf):
-
-        def to_set(conf):
-            return set([conf] if not isinstance(conf, list) else conf)
-
-        platforms_conf = conf.get('platforms', {})
-        if not platforms_conf:
-            return False
-
-        excluded_platforms_conf = platforms_conf.get('not', [])
-        excluded_platforms = to_set(excluded_platforms_conf)
-        if not excluded_platforms:
-            return False
-
-        only_platforms_conf = platforms_conf.get('only', [])
-        only_platforms = to_set(only_platforms_conf)
-        return excluded_platforms == only_platforms
-
-    with open(os.path.join(str(tmpdir), 'container.yaml'), 'w') as f:
-        f.write(yaml.safe_dump(config_dict))
-        f.flush()
-    if valid and platforms:
-        workflow = MockWorkflow(str(tmpdir))
-        final_platforms = get_platforms_in_limits(workflow, platforms)
-        if configured_same_not_and_only(config_dict):
-            assert 'only and not platforms are the same' in caplog.text
-        assert final_platforms == set(result)
-    elif valid:
-        workflow = MockWorkflow(str(tmpdir))
-        final_platforms = get_platforms_in_limits(workflow, platforms)
-        assert final_platforms is None
-    else:
-        workflow = MockWorkflow('bad_dir')
-        final_platforms = get_platforms_in_limits(workflow, platforms)
-        assert final_platforms == set(platforms)
+    if only and sorted(only) == sorted(excludes):
+        assert "only and not platforms are the same" in caplog.text
 
 
 MOCK_INSPECT_DATA = {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -58,7 +58,7 @@ from atomic_reactor.util import (LazyGit, figure_out_build_file,
                                  read_yaml, read_yaml_from_file_path, read_yaml_from_url,
                                  validate_with_schema,
                                  OSBSLogs,
-                                 get_platforms_in_limits, get_orchestrator_platforms,
+                                 get_orchestrator_platforms,
                                  dump_stacktraces, setup_introspection_signal_handler,
                                  allow_repo_dir_in_dockerignore,
                                  has_operator_appregistry_manifest,
@@ -1418,51 +1418,6 @@ def test_get_all_manifests(tmpdir, image, registry, insecure, creds, path, versi
             assert version in all_manifests
     else:
         assert all_manifests == {}
-
-
-@pytest.mark.parametrize('input_platforms,excludes,only,expected', [
-    (['x86_64', 'ppc64le'], [], ['ppc64le'], ['ppc64le']),
-    (
-        ['x86_64', 'spam', 'bacon', 'toast', 'ppc64le'],
-        ['spam', 'bacon', 'eggs', 'toast'],
-        [],
-        ['x86_64', 'ppc64le'],
-    ),
-    (
-        ['ppc64le', 'spam', 'bacon', 'toast'],
-        ['spam', 'bacon', 'eggs', 'toast'],
-        ['ppc64le'],
-        ['ppc64le'],
-    ),
-    # only takes the priority
-    (
-        ['ppc64le', 'spam', 'bacon', 'toast'],
-        ['bacon', 'eggs', 'toast'],
-        ['ppc64le'],
-        ['ppc64le'],  # spam is not excluded, but only include ppc64le
-    ),
-    (
-        ['x86_64', 'bacon', 'toast'],
-        ['toast'],
-        ['x86_64', 'ppc64le'],
-        ['x86_64']
-    ),
-    (
-        ['x86_64', 'spam', 'bacon', 'toast'],
-        ['spam', 'bacon', 'eggs', 'toast'],
-        ['x86_64', 'ppc64le'],
-        ['x86_64'],
-    ),
-    (['x86_64', 'ppc64le'], [], [], ['x86_64', 'ppc64le']),
-    (['x86_64', 'ppc64le'], ["x86_64"], ["x86_64"], []),
-])
-def test_get_platforms_in_limits(input_platforms, excludes, only, expected, caplog):
-    assert set(expected) == get_platforms_in_limits(
-        input_platforms, excludes=excludes, only=only
-    )
-
-    if only and sorted(only) == sorted(excludes):
-        assert "only and not platforms are the same" in caplog.text
 
 
 MOCK_INSPECT_DATA = {


### PR DESCRIPTION
Besides limiting platforms with configured "not" and "only" platforms,
the original get_platforms_in_limits also handles the reading from
loaded config and what the default value should be set. This patch moves
this operation out of it, and handles the platforms config in
SourceConfig initialization along with other configs.

Tests are updated accordingly.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
