### PR TITLE
Make group_manifests return manifest in str type

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -134,7 +134,11 @@ class GroupManifestsPlugin(PostBuildPlugin):
                                                                                 source_digest,
                                                                                 source_repo,
                                                                                 images)
-        return {'manifest': manifest, 'media_type': media, 'manifest_digest': digest}
+        return {
+            'manifest': manifest.decode('utf-8'),
+            'media_type': media,
+            'manifest_digest': digest,
+        }
 
     def run(self):
         primary_images = get_primary_images(self.workflow)

--- a/atomic_reactor/utils/manifest.py
+++ b/atomic_reactor/utils/manifest.py
@@ -7,6 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import json
+from typing import Tuple
 import requests
 
 from atomic_reactor.plugin import PluginFailedException
@@ -64,7 +65,7 @@ class ManifestUtil(object):
 
         return sources
 
-    def get_manifest(self, session, repository, ref):
+    def get_manifest(self, session, repository, ref) -> Tuple[bytes, str, str, int]:
         """
         Downloads a manifest from a registry. ref can be a digest, or a tag.
         """
@@ -134,7 +135,7 @@ class ManifestUtil(object):
         for digest in references:
             self.link_blob_into_repository(session, digest, source_repo, target_repo)
 
-    def store_manifest_in_repository(self, session, manifest, media_type,
+    def store_manifest_in_repository(self, session, manifest: bytes, media_type,
                                      source_repo, target_repo, ref=None):
         """
         Stores the manifest into target_repo, possibly tagging it. This may involve
@@ -160,7 +161,7 @@ class ManifestUtil(object):
                                dockercfg_path=secret_path,
                                access=('pull', 'push'))
 
-    def add_tag_and_manifest(self, session, image_manifest, media_type,
+    def add_tag_and_manifest(self, session, image_manifest: bytes, media_type,
                              source_repo, configured_tags):
         for image in configured_tags:
             target_repo = image.to_str(registry=False, tag=False)

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1400,8 +1400,6 @@ class TestWorkflowData:
                         },
                     },
                 },
-                # bytes should be handled properly.
-                "plugin_b": {"data": "OSBS".encode()},
             },
         )
 


### PR DESCRIPTION
It's unnecessary to keep the manifest in bytes in the plugin's return
value. With this change, the workflow data encoder and decoder do not
need to serialize bytes object.

By the way, generally, a plugin's return value should be JSON-compatible
as much as possible, unless it must be and the aforementioned encoder
and decoder have to be updated accordingly.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
