### PR TITLE
Refactor resource manager module

### DIFF
--- a/atomic_reactor/utils/resource_manager.py
+++ b/atomic_reactor/utils/resource_manager.py
@@ -7,53 +7,154 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import backoff
-import json
-import jsonschema
 import logging
+import os
 import paramiko
 import random
-import os
+import time
 from contextlib import contextmanager
 from datetime import datetime
+from functools import cached_property
 from shlex import quote
-from typing import List
+from typing import List, Optional, Tuple
+from paramiko.channel import ChannelFile  # just for type annotation
 
-RESOURCE_LOCK_SCHEMA = 'schemas/resource-lock-content.json'
-SSH_COMMAND_TIMEOUT = 45
-TIMEOUT_FAIL_BUILD = 3000
-RELATIVE_PATH = 'resource_manager'
-RESOURCE_INFO_JSON = 'info.json'
+SSH_COMMAND_TIMEOUT = 30
+SLOTS_RELATIVE_PATH = "osbs_slots"
 RETRY_ON_SSH_EXCEPTIONS = (paramiko.ssh_exception.NoValidConnectionsError,
                            paramiko.ssh_exception.SSHException)
-BACKOFF_FACTOR = 5
+BACKOFF_FACTOR = 3
 MAX_RETRIES = 3
 
 logger = logging.getLogger(__name__)
 
-
-class ResourceManagerError(RuntimeError):
-    """ Base module exception """
-
-
-class LockError(ResourceManagerError):
-    """ Attempt for resource locking returned non-zero exitcode """
+__all__ = [
+    "RemoteHost",
+    "RemoteHostsPool",
+    "LockedResource",
+]
 
 
-class LockRetry(ResourceManagerError):
-    """ Retry locking, no resources were available """
+class RemoteHostError(RuntimeError):
+    pass
+
+
+class SlotLockError(RemoteHostError):
+    pass
+
+
+class SlotReadError(RemoteHostError):
+    pass
+
+
+class SlotWriteError(RemoteHostError):
+    pass
+
+
+class SSHRetrySession(paramiko.SSHClient):
+    """ paramiko SSHClient with retry mechanism """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @backoff.on_exception(
+        backoff.expo,
+        RETRY_ON_SSH_EXCEPTIONS,
+        factor=BACKOFF_FACTOR,
+        max_tries=MAX_RETRIES,
+        jitter=None,  # use deterministic backoff, do not apply random jitter
+        logger=logger,
+    )
+    def exec_command(self, *args, **kwargs):
+        return super().exec_command(*args, **kwargs)
+
+    @backoff.on_exception(
+        backoff.expo,
+        RETRY_ON_SSH_EXCEPTIONS,
+        factor=BACKOFF_FACTOR,
+        max_tries=MAX_RETRIES,
+        jitter=None,  # use deterministic backoff, do not apply random jitter
+        logger=logger,
+    )
+    def connect(self, *args, **kwargs):
+        super().connect(*args, **kwargs)
+
+    def run(self, cmd: str) -> Tuple[str, str, int]:
+        _, stdout, stderr = self.exec_command(cmd, timeout=SSH_COMMAND_TIMEOUT)
+        out = stdout.read().decode().strip()
+        err = stderr.read().decode().strip()
+        code = stdout.channel.recv_exit_status()
+        return out, err, code
+
+
+class SlotData:
+
+    def __init__(self, prid: Optional[str] = None, timestamp: Optional[str] = None):
+        """ Instantiate slot data with values of prid and timestamp """
+        # A valid slot contains empty content or content in format:
+        # "prid@timestamp"
+        # prid: pipelinerun id
+        # timestamp: datetime string in iso format
+        self.prid = prid
+        self.timestamp = timestamp
+
+    @classmethod
+    def from_string(cls, string: Optional[str]):
+        """ Instantiate from a string """
+
+        # We don't validate the string here, call is_valid to check slot data
+        if not string:
+            return cls()
+
+        values = string.split("@")
+        prid = values[0]
+        timestamp = "".join(values[1:])
+        return cls(prid=prid, timestamp=timestamp)
+
+    @property
+    def is_empty(self):
+        return not any((self.prid, self.timestamp))
+
+    @property
+    def is_valid(self):
+        # Empty slot data is valid
+        if self.is_empty:
+            return True
+
+        # String of prid cannot contain "@"
+        if not isinstance(self.prid, str) or "@" in self.prid:
+            return False
+
+        # Verify timestamp string is valid datetime string
+        try:
+            datetime.fromisoformat(self.timestamp)
+        except ValueError:
+            return False
+        return True
+
+    def to_string(self):
+        if self.is_empty:
+            return ""
+        return f"{self.prid}@{self.timestamp}"
+
+    @property
+    def datetime(self):
+        return datetime.fromisoformat(self.timestamp)
 
 
 class RemoteHost:
 
-    def __init__(self, *, hostname: str, username: str, ssh_keyfile: str):
-        """
+    def __init__(self, *, hostname: str, username: str, ssh_keyfile: str, slots: int):
+        """ Instantiate RemoteHost with hostname, username, ssh key file and slot number
+
         :param hostname: str, remote hostname for ssh connection
         :param username: str, username for ssh connection
         :param ssh_keyfile: str, filepath to ssh private key
+        :param slots: int, number of max allowed slots on remote host
         """
         self._hostname = hostname
         self._username = username
         self._ssh_keyfile = ssh_keyfile
+        self._slots = slots
 
     @property
     def hostname(self):
@@ -67,186 +168,393 @@ class RemoteHost:
     def ssh_keyfile(self):
         return self._ssh_keyfile
 
-    def _validate_resource_lock(self, payload: dict):
-        """ Validate resource lock json file against schema """
-        with open(RESOURCE_LOCK_SCHEMA, 'r') as f:
-            schema_data = f.read()
-        schema = json.loads(schema_data)
+    @property
+    def slots(self):
+        return self._slots
+
+    @cached_property
+    def slots_dir(self):
+        home, _, _ = self._run("pwd")
+        return os.path.join(home, SLOTS_RELATIVE_PATH)
+
+    def _is_valid_slot_id(self, slot_id: int) -> bool:
+        """ Check if a slot id is valid """
+        valid_slots = list(range(self.slots))
+        if slot_id not in valid_slots:
+            logger.error("%s: invalid slot id %s, should be in: %s",
+                         self.hostname, slot_id, valid_slots)
+            return False
+        return True
+
+    def _get_slot_path(self, slot_id: int) -> str:
+        """ Get the absolute path of slot file """
+        return os.path.join(self.slots_dir, f"slot_{slot_id}")
+
+    def _get_slot_lock_path(self, slot_id: int) -> str:
+        """ Get the absolute path of slot's lock file """
+        return os.path.join(self.slots_dir, f"slot_{slot_id}.lock")
+
+    @backoff.on_exception(
+        backoff.expo,
+        SlotLockError,
+        factor=BACKOFF_FACTOR,
+        max_tries=MAX_RETRIES,
+        jitter=None,  # use deterministic backoff, do not apply random jitter
+        logger=logger,
+    )
+    def _get_blocking_session_with_locked_slot(
+        self, session: SSHRetrySession, slot_id: int
+    ) -> Tuple[ChannelFile, ChannelFile, ChannelFile]:
+        """
+        Lock the slot in SSH session and keep it blocked
+
+        :param session: SSHRetrySession, an SSH session
+        :param slot_id: int, slot ID
+        :return: A tuple of stdin, stdout, stderr of the running command
+        """
+        # Run `cat` in the session to keep the slot lock file being locked
+        lock_path = quote(self._get_slot_lock_path(slot_id))
+        cmd = f"flock --conflict-exit-code 42 --nonblocking {lock_path} cat"
+
+        _errmsg = f"{self.hostname}: failed to acquire lock on slot {slot_id}"
         try:
-            jsonschema.validate(payload, schema)
-        except jsonschema.ValidationError as err:
-            logger.warning("Invalid json file: %s", err)
+            logger.info("%s: acquiring lock on slot %s", self.hostname, slot_id)
+            stdin, stdout, stderr = session.exec_command(cmd)
+        except Exception as ex:
+            raise SlotLockError(_errmsg) from ex
+
+        # A short time sleep to wait for the socket to be ready
+        time.sleep(0.1)
+
+        try:
+            stdin.write("verify lock\n")
+            stdin.flush()
+        except OSError as ex:
+            stdin.close()
+            if stdout.channel.recv_exit_status() == 42:
+                _errmsg = f"{_errmsg}: slot is locked by others"
+            else:
+                stderr = stderr.read().decode().strip()
+                if stderr:
+                    _errmsg = f"{_errmsg}: {stderr}"
+            logger.debug("%s: %s", _errmsg, ex)
+            raise SlotLockError(_errmsg) from ex
+        else:
+            if not stdout.readline():
+                if stdout.channel.recv_exit_status() == 42:
+                    _errmsg = f"{_errmsg}: slot is locked by others"
+                else:
+                    _errmsg = f"{_errmsg}: no output from cat command"
+                logger.debug(_errmsg)
+                raise SlotLockError(_errmsg)
+
+        # So far so good, the session is blocked there with keeping the slot lock
+        return stdin, stdout, stderr
+
+    @contextmanager
+    def _locked_slot(self, slot_id):
+        """ Context manager to return a slot with it's being locked until exit """
+        # Open two ssh sessions, one is for reading/writing the slot file,
+        # the other one is for keeping the lock for that slot file. The two
+        # sessions have same lifecycle, they're closed at the same time when
+        # errors happen or exit.
+        try:
+            # A session to run any commands, especially for reading and
+            # writing the slot file
+            slot_session = self._open_ssh_session()
+            # A special session to keep the lock of the slot
+            lock_session = self._open_ssh_session()
+        except Exception as ex:
+            raise SlotLockError(f"{self.hostname}: failed to open SSH sessions") from ex
+
+        _errmsg = f"{self.hostname}: failed to acquire lock on slot {slot_id}"
+        lock_stdin = None
+        try:
+            lock_stdin, _, _ = self._get_blocking_session_with_locked_slot(
+                lock_session, slot_id
+            )
+            yield HostSlot(self, slot_session, slot_id)
+        except Exception as ex:
+            raise SlotLockError(_errmsg) from ex
+        finally:
+            if lock_stdin:
+                lock_stdin.close()
+            slot_session.close()
+            lock_session.close()
+
+    def _run(self, cmd: str):
+        """
+        Run a shell command on host
+
+        :return: stdout, stderr and exit code of shell command
+        """
+        with self._ssh_session() as session:
+            return session.run(cmd)
 
     @contextmanager
     def _ssh_session(self):
         """ Create an SSH connection."""
+        client = self._open_ssh_session()
         try:
-            client = self._open_ssh_session()
             yield client
         finally:
             client.close()
 
-    @backoff.on_exception(
-        backoff.expo,
-        RETRY_ON_SSH_EXCEPTIONS,
-        factor=BACKOFF_FACTOR,
-        max_tries=MAX_RETRIES,
-        jitter=None,  # use deterministic backoff, do not apply random jitter
-        logger=logger,
-    )
     def _open_ssh_session(self):
         """
         Create a new SSH connection and return connection object.
         """
-        client = paramiko.SSHClient()
+        client = SSHRetrySession()
         client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        logger.debug("Open SSH connection in remote host %s", self.hostname)
-        client.connect(
-            self.hostname, username=self.username, key_filename=self.ssh_keyfile)
+        logger.debug("%s: opening SSH connection", self.hostname)
+        client.connect(self.hostname, username=self.username, key_filename=self.ssh_keyfile)
         return client
+
+    @property
+    def is_operational(self) -> bool:
+        """ Check whether this host is operational """
+        try:
+            _, _, code = self._run(f"mkdir -p {self.slots_dir}")
+        except Exception as e:
+            logger.exception("%s: host is not operational: %s", self.hostname, e)
+            return False
+        if code != 0:
+            logger.error("%s: cannot prepare slots directory", self.hostname)
+            return False
+        return True
+
+    def is_free(self, slot_id: int) -> bool:
+        """ Check whether a slot is in free state
+
+        :param slot_id: int, slot ID
+        :return: True if slot is in free state
+        :rtype: bool
+        """
+        if not self._is_valid_slot_id(slot_id):
+            return False
+
+        # We don't need to lock the slot to check whether it's free,
+        # so using a normal ssh session is good enough
+        with self._ssh_session() as session:
+            slot = HostSlot(self, session, slot_id)
+            return slot.is_free
 
     @backoff.on_exception(
         backoff.expo,
-        RETRY_ON_SSH_EXCEPTIONS,
+        (SlotLockError, SlotReadError, SlotWriteError),
         factor=BACKOFF_FACTOR,
         max_tries=MAX_RETRIES,
         jitter=None,  # use deterministic backoff, do not apply random jitter
         logger=logger,
     )
-    def _ssh_run_remote_cmd(self, client, cmd: List):
-        """
-        Run a Shell command on a remote host
+    def lock(self, slot_id: int, prid: str) -> bool:
+        """ Lock a slot for a pipelinerun
 
-        :return: stdout, stderr and exitcode of shell command
+        :param slot_id: int, slot ID
+        :param prid: str, pipelinerun ID
+        :return: True if slot is locked for the pipelinerun successfully, otherwise False
+        :rtype: bool
         """
-        logger.debug("Try to run command %s on remote host %s", cmd, self.hostname)
-        _, stdout, stderr = client.exec_command(cmd, timeout=SSH_COMMAND_TIMEOUT)
-        return stdout, stderr, stdout.channel.recv_exit_status()
+        if not self._is_valid_slot_id(slot_id):
+            return False
 
-    def _ssh_run_remote_cmd_to_get_json(self, client, cmd: List):
-        _, stdout, _ = self._ssh_run_remote_cmd(client, cmd)
+        locked = False
         try:
-            json_stdout = json.loads(stdout)
-        except ValueError as ex:  # Not valid JSON
-            logger.warning("Json load failed. Not a valid JSON. %s", ex)
-            return None
-        except TypeError as ex:  # Not an object
-            logger.warning("Json load failed. Not an object. %s", ex)
-            return None
-        return json_stdout
+            with self._locked_slot(slot_id) as slot:
+                locked = slot.lock(prid)
+        except SlotLockError as ex:
+            logger.warning("%s: failed to lock slot %s for pipelinerun %s: %s",
+                           self.hostname, slot_id, prid, ex)
+
+        if locked:
+            logger.info("%s: slot %s is locked for pipelinerun %s",
+                        self.hostname, slot.id, prid)
+        else:
+            logger.warning("%s: failed to lock slot %s for pipelinerun %s",
+                           self.hostname, slot_id, prid)
+        return locked
+
+    @backoff.on_exception(
+        backoff.expo,
+        (SlotLockError, SlotReadError, SlotWriteError),
+        factor=BACKOFF_FACTOR,
+        max_tries=MAX_RETRIES,
+        jitter=None,  # use deterministic backoff, do not apply random jitter
+        logger=logger,
+    )
+    def unlock(self, slot_id: int, prid: str) -> bool:
+        """ Unlock a slot for a pipelinerun
+
+        :param slot_id: int, slot ID
+        :param prid: str, pipelinerun ID
+        :return: True if slot is unlocked for the pipelinerun successfully, otherwise False
+        :rtype: bool
+        """
+        if not self._is_valid_slot_id(slot_id):
+            return False
+
+        unlocked = False
+        try:
+            with self._locked_slot(slot_id) as slot:
+                unlocked = slot.unlock(prid)
+        except SlotLockError as ex:
+            logger.warning("%s: failed to unlock slot %s for pipelinerun %s: %s",
+                           self.hostname, slot_id, prid, ex)
+
+        if unlocked:
+            logger.info("%s: slot %s is unlocked for pipelinerun %s",
+                        self.hostname, slot.id, prid)
+        else:
+            logger.warning("%s: failed to unlock slot %s for pipelinerun %s",
+                           self.hostname, slot_id, prid)
+        return unlocked
 
     def available_slots(self) -> List[int]:
-        """
-        Returns list of available slots
-        """
-        logger.debug("Retrieve list of available slots on host %s", self.hostname)
-
-        with self._ssh_session() as client:
-            cmd = self.get_cmd_to_read_from_json(RESOURCE_INFO_JSON)
-            resource_info = self._ssh_run_remote_cmd_to_get_json(client, cmd)
-
-            available_slots = []
-            for slot_id in range(resource_info.get('max_slot_count', 1)):
-                cmd = self.get_cmd_to_read_from_json(f'slot_{slot_id}.json')
-                slot = self._ssh_run_remote_cmd_to_get_json(client, cmd)
-
-                if slot is None:  # Json load failed - file on remote host might be corrupted
-                    logger.warning("%s - slot %s - json load failed",
-                                   resource_info['hostname'], slot_id)
-                elif slot:  # Non-empty json file was loaded
-                    prid = slot.get('prid')
-                    logger.debug("%s - slot %s is occupied by %s",
-                                 resource_info['hostname'], slot_id, prid)
-                    self._validate_resource_lock(slot)
-                elif not slot:  # Empty json file was loaded
-                    logger.debug("%s - slot %s is available",
-                                 resource_info['hostname'], slot_id)
-                    available_slots.append(slot_id)
-                else:  # Undefined state - should not happen
-                    logger.warning("%s - slot %s invalid state!",
-                                   resource_info['hostname'], slot_id)
+        """ Get slots on host which are in free state """
+        logger.debug("%s: retrieve list of available slots", self.hostname)
+        available_slots = []
+        for slot_id in range(self.slots):
+            if not self.is_free(slot_id):
+                logger.debug("%s: slot %s is not free", self.hostname, slot_id)
+                continue
+            available_slots.append(slot_id)
 
         return available_slots
 
-    def get_cmd_to_read_from_json(self, file_name: str):
-        """ Create a command to retrieve content of json file from remote host """
-        return ['cat', os.path.join(RELATIVE_PATH, file_name)]
 
-    def get_cmd_to_write_empty_slot(self, slot_id: int):
-        """ Create a command to unlock slot on remote host """
-        return ['echo', '{}', '>', os.path.join(RELATIVE_PATH, f'slot_{slot_id}.json')]
+class HostSlot:
 
-    def get_cmd_to_write_slot_in_progress(self, file_name: str, payload: str):
-        """ Create a command to lock slot for pipelinerun on remote host """
-        filepath = os.path.join(RELATIVE_PATH, file_name)
+    def __init__(self, host: RemoteHost, session: SSHRetrySession, slot_id: int):
+        """ Instantiate host slot with remote host instance, an ssh session and slot id
 
-        # TBD: Test with remote host that this is actually working with Paramiko
-        _cmd = (f'if grep -qw {{}} {filepath} ; then echo {quote(payload)} > '
-                f'{filepath} ;else exit 1; fi')
-        return f'flock {filepath} -c {quote(_cmd)}'
+        :param host: RemoteHost, RemoteHost instance
+        :param session: SSHRetrySession, SSHRetrySession instance
+        :param slot_id: int, slot ID
+        """
+        self.host = host
+        self.hostname = host.hostname
+        self.session = session
+        self.id = slot_id
+        self.path = os.path.join(self.host.slots_dir, f"slot_{slot_id}")
 
-    @backoff.on_exception(
-        backoff.expo,
-        LockError,
-        factor=BACKOFF_FACTOR,
-        max_tries=MAX_RETRIES,
-        jitter=None,  # use deterministic backoff, do not apply random jitter
-        logger=logger,
-    )
-    def lock(self, slot_id: int, prid: str):
-        logger.debug("Locking slot %s on host %s with pipelinerun ID %s",
-                     slot_id, self.hostname, prid)
+    @property
+    def _data(self) -> SlotData:
+        content = self._read()
+        return SlotData.from_string(content)
 
-        payload = json.dumps({'prid': prid, 'locked': str(datetime.utcnow().isoformat())})
+    @property
+    def prid(self) -> Optional[str]:
+        return self._data.prid
 
-        with self._ssh_session() as client:
-            cmd = self.get_cmd_to_write_slot_in_progress(f'slot_{slot_id}.json', payload)
-            _, _, exitcode = self._ssh_run_remote_cmd(client, cmd)
+    @property
+    def timestamp(self) -> Optional[str]:
+        """ Get timestamp value in slot file """
+        return self._data.timestamp
 
-            if exitcode != 0:
-                raise LockError(f'Attempt to lock slot {slot_id} with pipelinerun ID {prid} '
-                                'returned non-zero exitcode')
+    @property
+    def datetime(self) -> Optional[datetime]:
+        """ Get timestamp value in slot file as a datetime.datetime instance """
+        return self._data.datetime
 
-        logger.debug("%s - slot %s locked with pipelinerun ID %s", self.hostname, slot_id, prid)
+    def _read(self) -> str:
+        """ Read content from slot file """
+        _errmsg = f"{self.hostname}: cannot read content of slot {self.id}"
+        try:
+            # Touch the slot file to create it in case it doesn't exist
+            slot_path = quote(self.path)
+            stdout, stderr, code = self.session.run(f"touch {slot_path} && cat {slot_path}")
+        except Exception as ex:
+            raise SlotReadError(_errmsg) from ex
 
-    def unlock(self, slot_id: int, prid: int):
-        logger.debug("Unlocking slot %s on host %s with pipelinerun ID %s",
-                     slot_id, self.hostname, prid)
+        if code != 0:
+            _errmsg = f"{_errmsg}: {stderr}" if stderr else _errmsg
+            raise SlotReadError(_errmsg)
+        return stdout
 
-        with self._ssh_session() as client:
-            cmd = self.get_cmd_to_read_from_json(f'slot_{slot_id}.json')
-            slot = self._ssh_run_remote_cmd_to_get_json(client, cmd)
+    def _write(self, data: Optional[str] = None):
+        """ Write data to slot file """
+        # Empty the file by default
+        cmd = f"truncate -s 0 {quote(self.path)}"
+        if data:
+            cmd = f"echo {quote(data)} > {quote(self.path)}"
 
-            if slot:
-                self._validate_resource_lock(slot)
+        _errmsg = f"{self.hostname}: cannot write data to slot {self.id}"
+        try:
+            _, stderr, code = self.session.run(cmd)
+        except Exception as ex:
+            raise SlotWriteError({_errmsg}) from ex
 
-                if slot['prid'] != prid:
-                    logger.warning("%s - slot %s, Found pipelinerun ID: %s, expected %s. Unlocking"
-                                   " skipped!", self.hostname, slot_id, slot['prid'], prid)
-                    return
+        if code != 0:
+            _errmsg = f"{_errmsg}: {stderr}" if stderr else _errmsg
+            raise SlotWriteError(_errmsg)
 
-                cmd = self.get_cmd_to_write_empty_slot(slot_id)
-                _, _, exitcode = self._ssh_run_remote_cmd(client, cmd)
+    @property
+    def is_valid(self):
+        """ Check whether the content is valid """
+        return self._data.is_valid
 
-                if exitcode != 0:
-                    logger.warning("Unlocking slot %s on host %s failed!", slot_id, self.hostname)
-            else:
-                logger.warning("%s - slot %s is available. Unlocking skipped!",
-                               self.hostname, slot_id)
+    @property
+    def is_free(self) -> bool:
+        """ Check whether the slot is in free state """
+        return self._data.is_empty
+
+    def is_locked_by(self, prid: str) -> bool:
+        """ Check whether the slot is locked by a pipelinerun """
+        return self._data.prid == prid
+
+    def lock(self, prid: str) -> bool:
+        """ Lock the slot for a pipelinerun """
+        if not self.is_free:
+            logger.debug("%s: slot %s is not free, unable to lock it",
+                         self.hostname, self.id)
+            return False
+
+        if not self.is_valid:
+            logger.warning("%s: slot %s contains invalid content, it's probably corrupted, "
+                           "unable to lock it.", self.hostname, self.id)
+            return False
+
+        data = SlotData(prid=prid, timestamp=datetime.utcnow().isoformat())
+        self._write(data.to_string())
+        return True
+
+    def unlock(self, prid: str) -> bool:
+        """ Unlock the slot for a pipelinerun """
+        if self.is_free:
+            logger.warning("%s: slot %s is free, skip unlocking", self.hostname, self.id)
+            # Should we return False instead?
+            return True
+
+        if not self.is_valid:
+            logger.warning("%s: slot %s contains invalid content, it's probably corrupted, "
+                           "unable to unlock it.", self.hostname, self.id)
+            return False
+
+        if not self.is_locked_by(prid):
+            logger.warning("%s: cannot unlock slot %s, it's not locked by %s",
+                           self.hostname, self.id, prid)
+            return False
+
+        # Empty the slot
+        self._write()
+        return True
 
 
 class LockedResource:
 
     def __init__(self, host: RemoteHost, slot: int, prid: str):
+        """ Instantiate a locked resource with remote host, slot id and pipelinerun id
+
+        :param host: RemoteHost, RemoteHost instance
+        :param slot: int, slot ID
+        :param prid: str, pipeline run ID
         """
-        :param slot: int, Remote host slot ID
-        :param prid: str, Pipeline run ID
-        """
+        self.host = host
         self.slot = slot
         self.prid = prid
-        self.host = host
 
     def unlock(self):
+        """ Unlock the resource for pipelinerun """
         self.host.unlock(self.slot, self.prid)
 
 
@@ -260,7 +568,7 @@ class RemoteHostsPool:
 
     @classmethod
     def from_config(cls, config: dict):
-        """ Instantiate remote hosts loaded from configmap
+        """ Instantiate remote hosts loaded from a config in dict format
 
         :param config: dict, Arch specific remote hosts dictionary from configmap
 
@@ -270,45 +578,67 @@ class RemoteHostsPool:
           enabled: true
           auth: qa-vm-secret-filepath
           username: cloud-user
+          slots: 3
           ...
         hostname-remote-host2:
           ...
         """
-
-        # Add enabled clusters to list hosts
-        hosts = [RemoteHost(hostname=hostname, username=attr['username'], ssh_keyfile=attr['auth'])
-                 for hostname, attr in config.items() if attr['enabled']]
+        hosts = []
+        for hostname, attr in config.items():
+            if not attr.get("enabled", False):
+                continue
+            host = RemoteHost(
+                hostname=hostname, username=attr["username"], ssh_keyfile=attr["auth"],
+                slots=attr.get("slots", 1)
+            )
+            # Check whether host is operational before use it
+            if host.is_operational:
+                hosts.append(host)
 
         return cls(hosts)
 
-    @backoff.on_exception(
-        backoff.constant,
-        LockRetry,
-        max_time=TIMEOUT_FAIL_BUILD,
-        jitter=None,
-    )
-    def lock_resource(self, prid: str) -> LockedResource:
-        """ Lock resources for build """
+    def lock_resource(self, prid: str) -> Optional[LockedResource]:
+        """
+        Lock resource for a pipelinerun
 
-        # Slots should be randomized here to avoid always locking the lowest numbers first
+        :param prid: str, pipelinerun ID
+        """
+
+        if not self.hosts:
+            logger.error("There is no available remote host in pool")
+            return None
+
         resources = []
         for host in self.hosts:
             available_slots = host.available_slots()
+            if not available_slots:
+                logger.info("%s: no available slots", host.hostname)
+                continue
+            logger.info("%s: available slots: %s", host.hostname, available_slots)
+            # random.shuffle the slots to reduce the chance of multiple clients
+            # trying to lock the free slots in the same order
             random.shuffle(available_slots)
             resources.append((host, available_slots))
 
-        # Sort list based on number of available slots
-        resources.sort(key=lambda x: len(x[1]), reverse=True)
+        if not resources:
+            logger.error("There is no remote host slot available for pipelinerun %s", prid)
+            return None
 
-        # Try to lock resources
+        # Sort list based on ratio of available_slots/all_slots
+        resources.sort(key=lambda x: len(x[1])/x[0].slots, reverse=True)
+
+        # Try to lock a remote host slot for pipelinerun
         for host, slots in resources:
             for slot in slots:
+                locked = False
                 try:
-                    host.lock(slot, prid)
+                    locked = host.lock(slot, prid)
                 except Exception as ex:
                     # Specific exceptions should be handled in nested methods
-                    logger.warning("Locking failed on slot %s, host %s - %s", slot, host, ex)
-                else:
+                    logger.warning("%s: unable to lock slot %s for pipelinerun %s: %s",
+                                   host.hostname, slot, prid, ex)
+                if locked:
                     return LockedResource(host, slot, prid)
 
-        raise LockRetry(f'No remote host resources were available for pipelinerun ID {prid}')
+        logger.info("Cannot find remote host resource for pipelinerun %s", prid)
+        return None

--- a/tests/utils/test_resource_manager.py
+++ b/tests/utils/test_resource_manager.py
@@ -1,0 +1,348 @@
+"""
+Copyright (c) 2022 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import backoff
+import pytest
+import re
+from flexmock import flexmock, Mock
+from functools import wraps
+from typing import Callable, Optional, Tuple
+
+
+def _do_nothing_decorator(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+# Disable backoff retries in tests before import our module
+flexmock(backoff).should_receive("on_exception").and_return(_do_nothing_decorator)
+
+
+from atomic_reactor.utils.resource_manager import (  # noqa
+    SSHRetrySession, RemoteHost, RemoteHostsPool
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_ssh_session():
+    """ Mock the ssh session with things we don't want to test or change """
+    flexmock(SSHRetrySession).should_receive("connect")
+    flexmock(RemoteHost).should_receive("slots_dir").and_return("/home/builder/osbs_slots")
+    yield
+
+
+def make_ssh_result(
+    stdout: str = "",
+    stderr: str = "",
+    code: int = 0
+) -> Tuple[None, Mock, Mock]:
+    """ Produce a fake non-blocking ssh exec_command result """
+
+    chan = flexmock()
+    chan.should_receive("recv_exit_status").and_return(code)
+
+    out = flexmock(channel=chan)
+    out.should_receive("read.decode.strip").and_return(stdout)
+
+    err = flexmock()
+    err.should_receive("read.decode.strip").and_return(stderr)
+    return None, out, err
+
+
+def make_flock_ssh_result(
+    stdout: str = "",
+    stderr: str = "",
+    code: int = 0,
+    stdin_write_callback: Optional[Callable] = None
+) -> Tuple[Mock, Mock, Mock]:
+    """ Produce a fake ssh flock exec_command result """
+    # This ssh flock command is blocking in session, stdin need to be mocked
+    stdin = flexmock()
+    if stdin_write_callback is None:
+        stdin.should_receive("write")
+    else:
+        stdin.should_receive("write").replace_with(stdin_write_callback)
+    stdin.should_receive("flush")
+    stdin.should_receive("close")
+
+    chan = flexmock()
+    chan.should_receive("recv_exit_status").and_return(code)
+    out = flexmock(channel=chan)
+    out.should_receive("read.decode.strip").and_return(stdout)
+    out.should_receive("readline").and_return(stdout)
+
+    err = flexmock()
+    err.should_receive("read.decode.strip").and_return(stderr)
+    return stdin, out, err
+
+
+@pytest.mark.parametrize(("mkdir_stderr", "mkdir_code", "expected_result"), (
+    ("", 0, True),
+    ("mkdir: cannot create directory: ... permission denied", 1, False),
+))
+def test_host_is_operational(mkdir_stderr, mkdir_code, expected_result):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "mkdir -p /home/builder/osbs_slots":
+            return make_ssh_result(stderr=mkdir_stderr, code=mkdir_code)
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+
+    assert host.is_operational is expected_result
+
+
+def test_check_slot_is_free_with_invalid_id(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+    # slot id starts from 0
+    free = host.is_free(3)
+    assert "remote-host-001: invalid slot id 3, should be in" in caplog.text
+    assert not free
+
+
+@pytest.mark.parametrize(("cat_stdout", "cat_stderr", "cat_code", "expected_result"), (
+    ("", "", 0, True),
+    ("pr123@2022-02-15T10:22:33.234234", "", 0, False),
+))
+def test_check_slot_is_free(cat_stdout, cat_stderr, cat_code, expected_result):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result(cat_stdout, cat_stderr, cat_code)
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    free = host.is_free(2)
+    assert free is expected_result
+
+
+def test_lock_a_free_slot(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result()
+
+        if cmd == ("flock --conflict-exit-code 42 --nonblocking "
+                   "/home/builder/osbs_slots/slot_2.lock cat"):
+            return make_flock_ssh_result(stdout="verify lock")
+
+        write_patt = re.compile(r"echo pr123@.*> /home/builder/osbs_slots/slot_2")
+        if write_patt.match(cmd):
+            return make_ssh_result()
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    locked = host.lock(2, "pr123")
+    assert locked
+    assert "remote-host-001: slot 2 is locked for pipelinerun pr123" in caplog.text
+
+
+def test_lock_an_occupied_slot(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result(stdout="123@2022-02-15T10:12:13.780426")
+
+        if cmd == ("flock --conflict-exit-code 42 --nonblocking "
+                   "/home/builder/osbs_slots/slot_2.lock cat"):
+            return make_flock_ssh_result(stdout="")
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    locked = host.lock(2, "pr234")
+    assert not locked
+    assert "remote-host-001: failed to lock slot 2 for pipelinerun pr234" in caplog.text
+
+
+def test_lock_slot_with_other_locking_on_it(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result()
+
+        if cmd == ("flock --conflict-exit-code 42 --nonblocking "
+                   "/home/builder/osbs_slots/slot_2.lock cat"):
+            return make_flock_ssh_result(code=42)
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    locked = host.lock(2, "pr123")
+    assert not locked
+    assert "failed to acquire lock on slot 2: slot is locked by others" in caplog.text
+
+
+def test_lock_slot_with_flock_cat_error(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result()
+
+        if cmd == ("flock --conflict-exit-code 42 --nonblocking "
+                   "/home/builder/osbs_slots/slot_2.lock cat"):
+            return make_flock_ssh_result(
+                code=66,
+                stdin_write_callback=lambda x: (_ for _ in ()).throw(OSError("socket is closed"))
+            )
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    locked = host.lock(2, "pr123")
+    assert not locked
+    assert "failed to acquire lock on slot 2: socket is closed" in caplog.text
+
+
+def test_lock_an_invalid_slot(caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+    # Need to return different content for the same read slot commands,
+    # which is not easy in a single mocked_command, so set it one by one
+    read_slot = "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2"
+    cmd_kwargs = {"timeout": int}
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .with_args(read_slot, **cmd_kwargs)
+        .and_return(make_ssh_result())  # return empty slot for the first call
+        .and_return(make_ssh_result(stdout="invalid_slot_content"))  # return invalid content
+    )
+    flock = "flock --conflict-exit-code 42 --nonblocking /home/builder/osbs_slots/slot_2.lock cat"
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .with_args(flock)
+        .and_return(make_flock_ssh_result(stdout="verify lock"))
+    )
+    locked = host.lock(2, "pr123")
+    assert not locked
+    assert "slot 2 contains invalid content, it's probably corrupted" in caplog.text
+
+
+@pytest.mark.parametrize(("slot_content", "expected_log", "expected_result"), (
+    ("pr123@2022-02-15T10:22:33.234234", "slot 2 is unlocked for pipelinerun pr123", True),
+    ("pr124@2022-02-15T10:22:33.234234", "failed to unlock slot 2 for pipelinerun pr123", False),
+))
+def test_unlock_host_slot(slot_content, expected_log, expected_result, caplog):
+    host = RemoteHost(hostname="remote-host-001", username="builder",
+                      ssh_keyfile="/path/to/key", slots=3)
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "touch /home/builder/osbs_slots/slot_2 && cat /home/builder/osbs_slots/slot_2":
+            return make_ssh_result(stdout=slot_content)
+
+        if cmd == ("flock --conflict-exit-code 42 --nonblocking "
+                   "/home/builder/osbs_slots/slot_2.lock cat"):
+            return make_flock_ssh_result(stdout="verify lock")
+
+        write_patt = re.compile(r"truncate -s 0 /home/builder/osbs_slots/slot_2")
+        if write_patt.match(cmd):
+            return make_ssh_result()
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+    unlocked = host.unlock(2, "pr123")
+    assert unlocked is expected_result
+    assert expected_log in caplog.text
+
+
+@pytest.mark.parametrize(("slot_content", "expected_log", "expected_result"), (
+    ("", "is locked for pipelinerun pr123", True),
+    ("pr124@2022-02-15T10:22:33.234234",
+     "no remote host slot available for pipelinerun pr123", False),
+))
+def test_pool_lock_resource(slot_content, expected_log, expected_result, caplog):
+    hosts_config = {
+        "remote-host-001": {
+            "enabled": True,
+            "auth": "/path/to/key",
+            "username": "builder",
+            "slots": 3
+        }
+    }
+
+    def mocked_command(cmd, *args, **kwargs):
+        if cmd == "mkdir -p /home/builder/osbs_slots":
+            return make_ssh_result()
+
+        read_patt = re.compile(
+            r"touch /home/builder/osbs_slots/slot_.* && cat /home/builder/osbs_slots/slot_.*"
+        )
+        if read_patt.match(cmd):
+            return make_ssh_result(stdout=slot_content)
+
+        flock_patt = re.compile(
+            r"flock --conflict-exit-code 42 --nonblocking /home/builder/osbs_slots/slot_.*.lock cat"
+        )
+        if flock_patt.match(cmd):
+            return make_flock_ssh_result(stdout="verify lock")
+
+        write_patt = re.compile(r"echo pr123@.*> /home/builder/osbs_slots/slot_.*")
+        if write_patt.match(cmd):
+            return make_ssh_result()
+
+        assert False, f"Unexpected command: {cmd}"
+
+    (
+        flexmock(SSHRetrySession)
+        .should_receive("exec_command")
+        .replace_with(mocked_command)
+    )
+
+    pool = RemoteHostsPool.from_config(hosts_config)
+    locked = pool.lock_resource("pr123")
+    assert bool(locked) is expected_result
+    assert expected_log in caplog.text


### PR DESCRIPTION
1. Slot file content is a single line in format of "prid@timestamp".
   Empty slot file means slot is free.

2. While performing any operations against a slot which requires
   locking the slot first, there are two ssh sessions opened to
   remote host, one is for keeping the lock on that slot, the other
   one is for running arbitrary commands, we only use it to run
   commands to read and write the slot in public APIs.

   There are two files exist on host for each slot:

   [1] /path/to/slots/dir/slot_{id}: the slot file, contains data
       of lock info
   [2] /path/to/slots/dir/slot_{id}.lock: lock file of slot, before
       writing to a slot, the lock should be acquired first

The `RemostHost` and `RemoteHostsPool` classes are the main classes
that provide the public APIs.

Example usages:

    host = RemoteHost(
        hostname="remote-host-1", username="user",
        ssh_keyfile="/path/to/key", slots=3
    )

    # check host is operational
    operational = host.is_operational

    # check a slot on host is in free state
    host.is_free(2)

    # lock a slot on host for a pipelinerun
    host.lock(2, "pipelinerun-123")

    # unlock a slot on host owned by a pipelinerun
    host.unlock(2, "pipelinerun-123")

    pool = RemoteHostsPool(hosts=[host1, ...])

    # lock a slot from hosts in the pool, an available
    # free slot will be picked and locked
    pool.lock_resource("pipelinerun-123")

* CLOUDBLD-8553

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
