### PR TITLE
Output from bsi should be decoded in the build result

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -121,7 +121,7 @@ class SourceContainerPlugin(BuildStepPlugin):
         cmd.append('{}'.format(image_output_dir))
 
         try:
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             self.log.error("BSI failed with output:\n%s", e.output)
             return BuildResult(logs=e.output, fail_reason='BSI utility failed build source image')


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
