### PR TITLE
Separate source container exit task

### DIFF
--- a/atomic_reactor/cli/parser.py
+++ b/atomic_reactor/cli/parser.py
@@ -50,12 +50,19 @@ def parse_args(args: Optional[Sequence[str]] = None) -> dict:
     )
     worker.set_defaults(func=task.worker)
 
-    source_build = tasks.add_parser(
-        "source-build",
+    source_container_build = tasks.add_parser(
+        "source-container-build",
         help="build a source container",
         description="Build a source container.",
     )
-    source_build.set_defaults(func=task.source_build)
+    source_container_build.set_defaults(func=task.source_container_build)
+
+    source_container_exit = tasks.add_parser(
+        "source-container-exit",
+        help="exit a source container build",
+        description="Execute source container exit steps.",
+    )
+    source_container_exit.set_defaults(func=task.source_container_exit)
 
     clone = tasks.add_parser(
         "clone",

--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -10,7 +10,9 @@ from atomic_reactor.tasks.binary import BinaryBuildTask, BinaryExitTask, \
 from atomic_reactor.tasks.clone import CloneTask
 from atomic_reactor.tasks.common import TaskParams
 from atomic_reactor.tasks.orchestrator import OrchestratorTask, OrchestratorTaskParams
-from atomic_reactor.tasks.sources import SourceBuildTask, SourceBuildTaskParams
+from atomic_reactor.tasks.sources import (
+    SourceExitTask, SourceBuildTask, SourceBuildTaskParams
+)
 from atomic_reactor.tasks.worker import WorkerTask, WorkerTaskParams
 
 
@@ -34,13 +36,23 @@ def worker(task_args: dict):
     return task.execute()
 
 
-def source_build(task_args: dict):
+def source_container_build(task_args: dict):
     """Run a source container build.
 
-    :param task_args: CLI arguments for a source-build task
+    :param task_args: CLI arguments for a source-container-build task
     """
     params = SourceBuildTaskParams.from_cli_args(task_args)
     task = SourceBuildTask(params)
+    return task.execute()
+
+
+def source_container_exit(task_args: dict):
+    """Run source container exit steps.
+
+    :param task_args: CLI arguments for a source-container-exit task
+    """
+    params = SourceBuildTaskParams.from_cli_args(task_args)
+    task = SourceExitTask(params)
     return task.execute()
 
 

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -19,9 +19,29 @@ spec:
     - name: ws-reactor-config-map
 
   tasks:
-    - name: build-source-container
+    - name: source-container-build
       taskRef:
-        name: build-source-container-0-1
+        name: source-container-build-0-1
+      workspaces:
+      - name: ws-build-dir
+        workspace: ws-build-dir
+      - name: ws-context-dir
+        workspace: ws-context-dir
+      - name: ws-registries-secret
+        workspace: ws-registries-secret
+      - name: ws-koji-secret
+        workspace: ws-koji-secret
+      - name: ws-reactor-config-map
+        workspace: ws-reactor-config-map
+      params:
+        - name: OSBS_IMAGE
+          value: "$(params.OSBS_IMAGE)"
+        - name: USER_PARAMS
+          value: "$(params.USER_PARAMS)"
+  finally:
+    - name: source-container-exit
+      taskRef:
+        name: source-container-exit-0-1
       workspaces:
       - name: ws-build-dir
         workspace: ws-build-dir

--- a/tekton/tasks/source-container-build.yaml
+++ b/tekton/tasks/source-container-build.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: build-source-container-0-1  # dot is not allowed in the name
+  name: source-container-build-0-1  # dot is not allowed in the name
 spec:
   description: >-
     OSBS task for building source container image
@@ -21,7 +21,7 @@ spec:
     - name: ws-reactor-config-map
 
   steps:
-    - name: build-source-container-image
+    - name: source-container-build
       image: $(params.OSBS_IMAGE)
       resources:
         requests:
@@ -36,4 +36,4 @@ spec:
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        source-build
+        source-container-build

--- a/tekton/tasks/source-container-exit.yaml
+++ b/tekton/tasks/source-container-exit.yaml
@@ -1,0 +1,39 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: source-container-exit-0-1  # dot is not allowed in the name
+spec:
+  description: >-
+    OSBS task for executing source container exit task
+  params:
+    - name: OSBS_IMAGE
+      description: The location of the OSBS builder image (FQDN pullspec)
+      type: string
+    - name: USER_PARAMS
+      type: string
+      description: User parameters in JSON format
+
+  workspaces:
+    - name: ws-build-dir
+    - name: ws-context-dir
+    - name: ws-registries-secret  # access with $(workspaces.ws-registries-secret.path)/token
+    - name: ws-koji-secret  # access with $(workspaces.ws-koji-secret.path)/token
+    - name: ws-reactor-config-map
+
+  steps:
+    - name: source-container-exit
+      image: $(params.OSBS_IMAGE)
+      resources:
+        requests:
+          memory: 300Mi
+          cpu: 250m
+        limits:
+          memory: 600Mi
+          cpu: 395m
+      script: >
+        atomic-reactor -v task
+        --user-params="$(params.USER_PARAMS)"
+        --build-dir=$(workspaces.ws-build-dir.path)
+        --context-dir=$(workspaces.ws-context-dir.path)
+        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
+        source-container-exit

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -26,13 +26,18 @@ from atomic_reactor.cli import main, parser, task
 )
 def test_run(verbose, quiet, expect_loglevel):
     # the task should be called with task arguments only
-    flexmock(task).should_receive("source_build").with_args({"user_params": "{}"})
+    flexmock(task).should_receive("source_container_build").with_args({"user_params": "{}"})
     (
         flexmock(parser)
         .should_receive("parse_args")
         .and_return(
             # parse args will return global arguments mixed with task task arguments
-            {"verbose": verbose, "quiet": quiet, "user_params": "{}", "func": task.source_build}
+            {
+                "verbose": verbose,
+                "quiet": quiet,
+                "user_params": "{}",
+                "func": task.source_container_build,
+            }
         )
     )
     flexmock(atomic_reactor).should_receive("set_logging").with_args(level=expect_loglevel)

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -48,8 +48,12 @@ def test_parse_args_version(capsys):
     [
         # required args only
         (
-            ["task", *REQUIRED_COMMON_ARGS, "source-build"],
-            {**EXPECTED_ARGS, "func": task.source_build},
+            ["task", *REQUIRED_COMMON_ARGS, "source-container-build"],
+            {**EXPECTED_ARGS, "func": task.source_container_build},
+        ),
+        (
+            ["task", *REQUIRED_COMMON_ARGS, "source-container-exit"],
+            {**EXPECTED_ARGS, "func": task.source_container_exit},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "clone"],
@@ -83,8 +87,8 @@ def test_parse_args_version(capsys):
         ),
         # all common task args
         (
-            ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "source-build"],
-            {**EXPECTED_ARGS, "config_file": "config.yaml", "func": task.source_build},
+            ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "source-container-build"],
+            {**EXPECTED_ARGS, "config_file": "config.yaml", "func": task.source_container_build},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "clone"],
@@ -141,7 +145,11 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
         ),
         # args in the wrong place
         (
-            ["task", *REQUIRED_COMMON_ARGS, "--verbose", "source-build"],
+            ["task", *REQUIRED_COMMON_ARGS, "--verbose", "source-container-build"],
+            "unrecognized arguments: --verbose",
+        ),
+        (
+            ["task", *REQUIRED_COMMON_ARGS, "--verbose", "source-container-exit"],
             "unrecognized arguments: --verbose",
         ),
         (
@@ -161,7 +169,11 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
             "unrecognized arguments: --verbose",
         ),
         (
-            ["task", *REQUIRED_COMMON_ARGS, "source-build", "--user-params={}"],
+            ["task", *REQUIRED_COMMON_ARGS, "source-container-build", "--user-params={}"],
+            "unrecognized arguments: --user-params",
+        ),
+        (
+            ["task", *REQUIRED_COMMON_ARGS, "source-container-exit", "--user-params={}"],
             "unrecognized arguments: --user-params",
         ),
         (
@@ -182,7 +194,11 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
         ),
         # missing common arguments
         (
-            ["task", "source-build"],
+            ["task", "source-container-build"],
+            "the following arguments are required: --build-dir, --context-dir",
+        ),
+        (
+            ["task", "source-container-exit"],
             "the following arguments are required: --build-dir, --context-dir",
         ),
         (

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -46,7 +46,7 @@ def test_worker():
 
 def test_source_build():
     mock(sources.SourceBuildTask)
-    assert task.source_build(TASK_ARGS) == TASK_RESULT
+    assert task.source_container_build(TASK_ARGS) == TASK_RESULT
 
 
 def test_binary_container_prebuild():


### PR DESCRIPTION
* COULDBLD-8272

Split the exit plugin definition into a separate exit task, and always
execute this exit task as the last step in the pipeline.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
