### PR TITLE
utils.resource_manager: ignore bandit B601 check

### DIFF
--- a/atomic_reactor/utils/resource_manager.py
+++ b/atomic_reactor/utils/resource_manager.py
@@ -65,7 +65,7 @@ class SSHRetrySession(paramiko.SSHClient):
         logger=logger,
     )
     def exec_command(self, *args, **kwargs):
-        return super().exec_command(*args, **kwargs)
+        return super().exec_command(*args, **kwargs)  # nosec ignore B601
 
     @backoff.on_exception(
         backoff.expo,
@@ -79,7 +79,7 @@ class SSHRetrySession(paramiko.SSHClient):
         super().connect(*args, **kwargs)
 
     def run(self, cmd: str) -> Tuple[str, str, int]:
-        _, stdout, stderr = self.exec_command(cmd, timeout=SSH_COMMAND_TIMEOUT)
+        _, stdout, stderr = self.exec_command(cmd, timeout=SSH_COMMAND_TIMEOUT)  # nosec ignore B601
         out = stdout.read().decode().strip()
         err = stderr.read().decode().strip()
         code = stdout.channel.recv_exit_status()
@@ -219,7 +219,7 @@ class RemoteHost:
         _errmsg = f"{self.hostname}: failed to acquire lock on slot {slot_id}"
         try:
             logger.info("%s: acquiring lock on slot %s", self.hostname, slot_id)
-            stdin, stdout, stderr = session.exec_command(cmd)
+            stdin, stdout, stderr = session.exec_command(cmd)  # nosec ignore B601
         except Exception as ex:
             raise SlotLockError(_errmsg) from ex
 

--- a/atomic_reactor/utils/resource_manager.py
+++ b/atomic_reactor/utils/resource_manager.py
@@ -314,7 +314,7 @@ class RemoteHost:
     def is_operational(self) -> bool:
         """ Check whether this host is operational """
         try:
-            _, _, code = self._run(f"mkdir -p {self.slots_dir}")
+            _, _, code = self._run(f"mkdir -p {quote(self.slots_dir)}")
         except Exception as e:
             logger.exception("%s: host is not operational: %s", self.hostname, e)
             return False


### PR DESCRIPTION
Bandit reports 'B601: paramiko_calls' issue with code using paramiko's
`exec_command` call, variables in commands have been `shlex.quote`ed,
it should be safe and we can ignore the B601 warnings.

Signed-off-by: Qixiang Wan <qwan@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
