### PR TITLE
PR checklist: add typing annotations

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,6 +2,7 @@
 
 - [ ] Commit messages are descriptive enough
 - [ ] Code coverage from testing does not decrease and new code is covered
+- [ ] Python type annotations added to new code
 - [ ] JSON/YAML configuration changes are updated in the relevant schema
 - [ ] Changes to metadata also update the documentation for the metadata
 - [ ] Pull request has a link to an osbs-docs PR for user documentation updates


### PR DESCRIPTION
To make sure annotations are not forgotten

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
