### PR TITLE
Fix passed value in wrong type

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -124,7 +124,7 @@ class SourceContainerPlugin(BuildStepPlugin):
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, text=True)
         except subprocess.CalledProcessError as e:
             self.log.error("BSI failed with output:\n%s", e.output)
-            return BuildResult(logs=e.output, fail_reason='BSI utility failed build source image')
+            return BuildResult(logs=[e.output], fail_reason='BSI utility failed build source image')
 
         self.log.debug("Build log:\n%s\n", output)
 
@@ -155,7 +155,7 @@ class SourceContainerPlugin(BuildStepPlugin):
         shutil.rmtree(image_output_dir)
 
         return BuildResult(
-            logs=output,
+            logs=[output],
             source_docker_archive=image_tar_path,
             skip_layer_squash=True
         )


### PR DESCRIPTION
BuildResult.logs accepts None or List[str], but in the source_container
plugin, a str is passed.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

As mentioned https://github.com/containerbuildsystem/atomic-reactor/pull/1812#discussion_r809116137

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
