### PR TITLE
Don't raise error when buildstep provides no results

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -837,13 +837,13 @@ class DockerBuildWorkflow(object):
             try:
                 self.data.build_result = buildstep_runner.run()
 
-                if self.data.build_result.is_failed():
+                if self.data.build_result and self.data.build_result.is_failed():
                     raise PluginFailedException(self.data.build_result.fail_reason)
             except PluginFailedException as ex:
                 logger.error('buildstep plugin failed: %s', ex)
                 raise
 
-            if self.data.build_result.is_image_available():
+            if self.data.build_result and self.data.build_result.is_image_available():
                 self.data.image_id = self.data.build_result.image_id
 
             # run prepublish plugins

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -339,7 +339,7 @@ class PluginsRunner(object):
             raise PluginFailedException("Multiple plugins raised an exception: " +
                                         str(failed_msgs))
 
-        if not plugin_successful and buildstep_phase and not plugin_response:
+        if not plugin_successful and buildstep_phase and not plugin_response and available_plugins:
             self.on_plugin_failed("BuildStepPlugin", "No appropriate build step")
             raise PluginFailedException("No appropriate build step")
 
@@ -469,7 +469,8 @@ class BuildStepPluginsRunner(BuildPluginsRunner):
         plugins_results = super(BuildStepPluginsRunner, self).run(
             keep_going=keep_going, buildstep_phase=buildstep_phase
         )
-        return list(plugins_results.values())[0]
+        if plugins_results:
+            return list(plugins_results.values())[0]
 
 
 class PrePublishPlugin(BuildPlugin):

--- a/atomic_reactor/tasks/plugin_based.py
+++ b/atomic_reactor/tasks/plugin_based.py
@@ -53,7 +53,7 @@ class PluginBasedTask(common.Task):
                 logger.error("task failed: %s", e)
                 raise
 
-            if result.is_failed():
+            if result and result.is_failed():
                 msg = f"task failed: {result.fail_reason}"
                 logger.error(msg)
                 raise RuntimeError(msg)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -71,6 +71,7 @@ class X(object):
     pass
 
 
+@pytest.mark.skip(reason="Currently no plugin is required, will be reworked")
 @pytest.mark.parametrize('runner_type', [  # noqa
     PreBuildPluginsRunner,
     PrePublishPluginsRunner,
@@ -247,6 +248,7 @@ def test_non_buildstep_phase_raises_InappropriateBuildStepError(caplog, workflow
         runner.run()
 
 
+@pytest.mark.skip(reason="Currently no plugin is required, will be reworked")
 def test_no_appropriate_buildstep_build_plugin(caplog, workflow):  # noqa
     """
     test that build fails if there isn't any


### PR DESCRIPTION
The prebuild task currently fails because in
build_docker_image method we run all plugin runners
and we expect results from buildstep plugin.

This is a workaround and temporary fix. This whole process
of running plugins will be reworked later.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
