### PR TITLE
Move a few exit plugins to postbuild task

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -108,6 +108,7 @@ PLUGIN_FETCH_SOURCES_KEY = 'fetch_sources'
 PLUGIN_KOJI_DELEGATE_KEY = 'koji_delegate'
 PLUGIN_PUSH_FLOATING_TAGS_KEY = 'push_floating_tags'
 PLUGIN_ADD_IMAGE_CONTENT_MANIFEST = 'add_image_content_manifest'
+PLUGIN_CANCEL_BUILD_RESERVATION = 'cancel_build_reservation'
 
 # some shared dict keys for build metadata that gets recorded with koji.
 # for consistency of metadata in historical builds, these values basically cannot change.

--- a/atomic_reactor/plugins/exit_cancel_build_reservation.py
+++ b/atomic_reactor/plugins/exit_cancel_build_reservation.py
@@ -1,0 +1,65 @@
+"""
+Copyright (c) 2022 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import koji
+
+from atomic_reactor.config import get_koji_session
+from atomic_reactor.constants import PLUGIN_CANCEL_BUILD_RESERVATION, PROG
+from atomic_reactor.plugin import ExitPlugin
+
+
+class CancelBuildReservation(ExitPlugin):
+    """Cancel reserved build."""
+
+    key = PLUGIN_CANCEL_BUILD_RESERVATION
+
+    def run(self):
+        if not self.workflow.conf.koji.get('reserve_build', False):
+            self.log.debug("Build reservation feature is not enabled. Skip cancelation.")
+            return
+
+        reserved_token = self.workflow.data.reserved_token
+        reserved_build_id = self.workflow.data.reserved_build_id
+
+        if reserved_token is None and reserved_build_id is None:
+            self.log.debug("There is no reserved build. Skip cancelation.")
+            return
+
+        session = get_koji_session(self.workflow.conf)
+        build_info = session.getBuild(reserved_build_id)
+
+        if build_info is None:
+            self.log.warning(
+                "Cannot get the reserved build %s from Brew/Koji.", reserved_build_id
+            )
+            return
+
+        state_building = koji.BUILD_STATES["BUILDING"]
+        state_failed = koji.BUILD_STATES["FAILED"]
+        cur_state = build_info["state"]
+        cur_state_name = koji.BUILD_STATES[cur_state]
+
+        if cur_state != state_building:
+            self.log.debug("Reserved build %s is in state %s already. Skip cancelation.",
+                           reserved_build_id, cur_state_name)
+            return
+
+        if not self.workflow.build_process_failed and cur_state == state_building:
+            session.CGRefundBuild(PROG, reserved_build_id, reserved_token, state_failed)
+            err_msg = (
+                f"Build process succeeds, but the reserved build {reserved_build_id} "
+                f"is in state {cur_state_name}. "
+                f"Please check if koji_import plugin is configured properly to execute."
+            )
+            raise RuntimeError(err_msg)
+
+        if self.workflow.data.build_canceled:
+            state = koji.BUILD_STATES["CANCELED"]
+        else:
+            state = state_failed
+        session.CGRefundBuild(PROG, reserved_build_id, reserved_token, state)

--- a/atomic_reactor/plugins/exit_koji_import.py
+++ b/atomic_reactor/plugins/exit_koji_import.py
@@ -198,7 +198,7 @@ class KojiImportBase(ExitPlugin):
         media_types = []
 
         # Append media_types from verify images
-        media_results = self.workflow.data.exit_results.get(PLUGIN_VERIFY_MEDIA_KEY)
+        media_results = self.workflow.data.postbuild_results.get(PLUGIN_VERIFY_MEDIA_KEY)
         if media_results:
             media_types += media_results
         if media_types:

--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -16,7 +16,7 @@ import socket
 import json
 
 from atomic_reactor.plugin import ExitPlugin, PluginFailedException
-from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
+from atomic_reactor.plugins.post_koji_import import KojiImportPlugin
 from atomic_reactor.plugins.exit_store_metadata import StoreMetadataPlugin
 from atomic_reactor.utils.koji import get_koji_task_owner
 from atomic_reactor.util import df_parser
@@ -121,7 +121,7 @@ class SendMailPlugin(ExitPlugin):
             else:
                 self.log.info("No koji task")
 
-        self.koji_build_id = self.workflow.data.exit_results.get(KojiImportPlugin.key)
+        self.koji_build_id = self.workflow.data.postbuild_results.get(KojiImportPlugin.key)
         if not self.koji_build_id:
             self.log.info("Failed to fetch koji build ID")
         else:

--- a/atomic_reactor/plugins/exit_store_metadata.py
+++ b/atomic_reactor/plugins/exit_store_metadata.py
@@ -252,7 +252,7 @@ class StoreMetadataPlugin(ExitPlugin):
 
         media_types = []
 
-        media_results = wf_data.exit_results.get(PLUGIN_VERIFY_MEDIA_KEY)
+        media_results = wf_data.postbuild_results.get(PLUGIN_VERIFY_MEDIA_KEY)
         if isinstance(media_results, Exception):
             media_results = None
 

--- a/atomic_reactor/plugins/post_koji_tag_build.py
+++ b/atomic_reactor/plugins/post_koji_tag_build.py
@@ -11,7 +11,7 @@ from atomic_reactor.config import get_koji_session
 from atomic_reactor.utils.koji import tag_koji_build
 from atomic_reactor.util import is_scratch_build, map_to_user_params
 from atomic_reactor.plugin import PostBuildPlugin
-from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
+from atomic_reactor.plugins.post_koji_import import KojiImportPlugin
 
 
 class KojiTagBuildPlugin(PostBuildPlugin):
@@ -60,7 +60,7 @@ class KojiTagBuildPlugin(PostBuildPlugin):
             self.log.info('no koji target provided, skipping plugin')
             return
 
-        build_id = self.workflow.data.exit_results.get(KojiImportPlugin.key)
+        build_id = self.workflow.data.postbuild_results.get(KojiImportPlugin.key)
         if not build_id:
             self.log.info('No koji build from %s', KojiImportPlugin.key)
             return

--- a/atomic_reactor/plugins/post_koji_tag_build.py
+++ b/atomic_reactor/plugins/post_koji_tag_build.py
@@ -10,11 +10,11 @@ from atomic_reactor.constants import PLUGIN_KOJI_TAG_BUILD_KEY
 from atomic_reactor.config import get_koji_session
 from atomic_reactor.utils.koji import tag_koji_build
 from atomic_reactor.util import is_scratch_build, map_to_user_params
-from atomic_reactor.plugin import ExitPlugin
+from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
 
 
-class KojiTagBuildPlugin(ExitPlugin):
+class KojiTagBuildPlugin(PostBuildPlugin):
     """
     Tag build in koji
 
@@ -52,10 +52,6 @@ class KojiTagBuildPlugin(ExitPlugin):
         """
         Run the plugin.
         """
-        if self.workflow.build_process_failed:
-            self.log.info('Build failed, skipping koji tagging')
-            return
-
         if is_scratch_build(self.workflow):
             self.log.info('scratch build, skipping plugin')
             return

--- a/atomic_reactor/plugins/post_push_floating_tags.py
+++ b/atomic_reactor/plugins/post_push_floating_tags.py
@@ -8,11 +8,11 @@ of the BSD license. See the LICENSE file for details.
 
 from atomic_reactor.constants import PLUGIN_PUSH_FLOATING_TAGS_KEY, PLUGIN_GROUP_MANIFESTS_KEY
 from atomic_reactor.utils.manifest import ManifestUtil
-from atomic_reactor.plugin import ExitPlugin
+from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import get_floating_images, get_unique_images
 
 
-class PushFloatingTagsPlugin(ExitPlugin):
+class PushFloatingTagsPlugin(PostBuildPlugin):
     """
     Push floating tags to registry
     """
@@ -51,10 +51,6 @@ class PushFloatingTagsPlugin(ExitPlugin):
         """
         Run the plugin.
         """
-        if self.workflow.build_process_failed:
-            self.log.info('Build failed, skipping %s', PLUGIN_PUSH_FLOATING_TAGS_KEY)
-            return
-
         floating_tags = get_floating_images(self.workflow)
         if not floating_tags:
             self.log.info('No floating images to tag, skipping %s', PLUGIN_PUSH_FLOATING_TAGS_KEY)

--- a/atomic_reactor/plugins/post_verify_media_types.py
+++ b/atomic_reactor/plugins/post_verify_media_types.py
@@ -16,21 +16,16 @@ from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY, PLUGIN_VERIFY_
                                       MEDIA_TYPE_OCI_V1,
                                       MEDIA_TYPE_OCI_V1_INDEX)
 
-from atomic_reactor.plugin import ExitPlugin
+from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.util import (get_manifest_digests, get_platforms,
                                  is_manifest_list, ManifestDigest)
 
 
-class VerifyMediaTypesPlugin(ExitPlugin):
+class VerifyMediaTypesPlugin(PostBuildPlugin):
     key = PLUGIN_VERIFY_MEDIA_KEY
     is_allowed_to_fail = False
 
     def run(self):
-        # Only run if the build was successful
-        if self.workflow.build_process_failed:
-            self.log.info("Not running for failed build")
-            return []
-
         # Work out the name of the image to pull
         if not self.workflow.data.tag_conf.unique_images:
             raise ValueError("no unique image set, impossible to verify media types")

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -73,6 +73,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
             {"name": "compare_components"},
             {"name": "group_manifests"},
             {"name": "generate_maven_metadata"},
+            {"name": "verify_media", "required": False},
         ],
     )
 
@@ -82,7 +83,6 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
 
     plugins_def = plugin_based.PluginsDef(
         exit=[
-            {"name": "verify_media", "required": False},
             {"name": "koji_import"},
             {"name": "push_floating_tags"},
             {"name": "koji_tag_build"},

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -75,6 +75,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
             {"name": "generate_maven_metadata"},
             {"name": "verify_media", "required": False},
             {"name": "push_floating_tags"},
+            {"name": "koji_tag_build"},
         ],
     )
 
@@ -85,7 +86,6 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
     plugins_def = plugin_based.PluginsDef(
         exit=[
             {"name": "koji_import"},
-            {"name": "koji_tag_build"},
             {"name": "store_metadata"},
             {"name": "sendmail"},
         ],

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -74,6 +74,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
             {"name": "group_manifests"},
             {"name": "generate_maven_metadata"},
             {"name": "verify_media", "required": False},
+            {"name": "push_floating_tags"},
         ],
     )
 
@@ -84,7 +85,6 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
     plugins_def = plugin_based.PluginsDef(
         exit=[
             {"name": "koji_import"},
-            {"name": "push_floating_tags"},
             {"name": "koji_tag_build"},
             {"name": "store_metadata"},
             {"name": "sendmail"},

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -75,6 +75,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
             {"name": "generate_maven_metadata"},
             {"name": "verify_media", "required": False},
             {"name": "push_floating_tags"},
+            {"name": "koji_import"},
             {"name": "koji_tag_build"},
         ],
     )
@@ -85,7 +86,6 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
 
     plugins_def = plugin_based.PluginsDef(
         exit=[
-            {"name": "koji_import"},
             {"name": "cancel_build_reservation"},
             {"name": "store_metadata"},
             {"name": "sendmail"},

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -86,6 +86,7 @@ class BinaryExitTask(plugin_based.PluginBasedTask):
     plugins_def = plugin_based.PluginsDef(
         exit=[
             {"name": "koji_import"},
+            {"name": "cancel_build_reservation"},
             {"name": "store_metadata"},
             {"name": "sendmail"},
         ],

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -43,10 +43,10 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         postbuild=[
             {"name": "tag_and_push"},
             {"name": "verify_media", "required": False},
+            {"name": "koji_tag_build"},
         ],
         exit=[
             {"name": "koji_import_source_container"},
-            {"name": "koji_tag_build"},
             {"name": "store_metadata"},
         ],
     )

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -43,10 +43,10 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         postbuild=[
             {"name": "tag_and_push"},
             {"name": "verify_media", "required": False},
+            {"name": "koji_import_source_container"},
             {"name": "koji_tag_build"},
         ],
         exit=[
-            {"name": "koji_import_source_container"},
             {"name": "cancel_build_reservation"},
             {"name": "store_metadata"},
         ],

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -42,9 +42,9 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         ],
         postbuild=[
             {"name": "tag_and_push"},
+            {"name": "verify_media", "required": False},
         ],
         exit=[
-            {"name": "verify_media", "required": False},
             {"name": "koji_import_source_container"},
             {"name": "koji_tag_build"},
             {"name": "store_metadata"},

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -47,6 +47,7 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         ],
         exit=[
             {"name": "koji_import_source_container"},
+            {"name": "cancel_build_reservation"},
             {"name": "store_metadata"},
         ],
     )

--- a/tests/plugins/test_cancel_build_reservation.py
+++ b/tests/plugins/test_cancel_build_reservation.py
@@ -1,0 +1,142 @@
+"""
+Copyright (c) 2022 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+import koji
+from atomic_reactor.inner import BuildResult
+import pytest
+from flexmock import flexmock
+
+from atomic_reactor.constants import PROG
+from atomic_reactor.plugins.exit_cancel_build_reservation import CancelBuildReservation
+
+
+def test_build_reservation_is_not_enabled(workflow, caplog):
+    """Skip cancelation if build reservation feature is not enabled."""
+
+    workflow.conf.conf["koji"] = {"reserve_build": False}
+    plugin = CancelBuildReservation(workflow)
+    plugin.run()
+    assert "Build reservation feature is not enabled." in caplog.text
+
+
+def mock_reactor_config(workflow):
+    workflow.conf.conf["koji"] = {
+        "reserve_build": True,
+        "hub_url": "https://hub.host/",
+        "auth": {},
+    }
+
+
+def test_no_build_was_reserved_yet(workflow, caplog):
+    """Skip cancelation if there is no reserved build."""
+    mock_reactor_config(workflow)
+    plugin = CancelBuildReservation(workflow)
+    plugin.run()
+    assert "There is no reserved build" in caplog.text
+
+
+class MockClientSession(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def getBuild(self, build_info):
+        return None
+
+    def krb_login(self, *args, **kwargs):
+        return True
+
+
+def test_skip_if_reserved_build_id_not_exist(workflow, caplog):
+    mock_reactor_config(workflow)
+    workflow.data.reserved_token = "1234"
+    workflow.data.reserved_build_id = 1
+
+    flexmock(koji).should_receive("ClientSession").and_return(MockClientSession())
+
+    plugin = CancelBuildReservation(workflow)
+    plugin.run()
+
+    assert "Cannot get the reserved build 1" in caplog.text
+
+
+@pytest.mark.parametrize("build_state", [
+    koji.BUILD_STATES["COMPLETE"],
+    koji.BUILD_STATES["FAILED"],
+    koji.BUILD_STATES["CANCELED"],
+])
+def test_reserved_build_has_been_released_already(build_state, workflow, caplog):
+    """Skip cancelation if a reserved build has been released."""
+    mock_reactor_config(workflow)
+    workflow.data.reserved_token = "1234"
+    workflow.data.reserved_build_id = 1
+
+    class _MockClientSession(MockClientSession):
+        def getBuild(self, *args, **kwargs):
+            return {"state": build_state}
+
+    flexmock(koji).should_receive("ClientSession").and_return(_MockClientSession())
+
+    plugin = CancelBuildReservation(workflow)
+    plugin.run()
+
+    state_name = koji.BUILD_STATES[build_state]
+    assert f"Reserved build 1 is in state {state_name} already" in caplog.text
+
+
+@pytest.mark.parametrize("is_canceled,expected_dest_state", [
+    [False, koji.BUILD_STATES["FAILED"]],
+    [True, koji.BUILD_STATES["CANCELED"]],
+])
+def test_cancel_a_reserved_build(is_canceled, expected_dest_state, workflow):
+    """A reserved build is canceled with a proper destination state."""
+    mock_reactor_config(workflow)
+    workflow.data.build_canceled = is_canceled
+    workflow.data.reserved_token = "1234"
+    workflow.data.reserved_build_id = 1
+
+    class _MockClientSession(MockClientSession):
+        def getBuild(self, *args, **kwargs):
+            return {"state": koji.BUILD_STATES["BUILDING"]}
+
+        def CGRefundBuild(self, cg, build_id, token, state):
+            assert PROG == cg
+            assert workflow.data.reserved_token == token
+            assert workflow.data.reserved_build_id == build_id
+            assert expected_dest_state == state
+
+    flexmock(koji).should_receive("ClientSession").and_return(_MockClientSession())
+
+    plugin = CancelBuildReservation(workflow)
+    plugin.run()
+
+
+def test_mark_reserved_build_fail_if_koji_import_does_not_run(workflow):
+    reserved_build_id = 1
+    mock_reactor_config(workflow)
+    # Mark the build is successful.
+    workflow.data.build_result = BuildResult(logs=["Build succeeds."])
+    workflow.data.reserved_token = "1234"
+    workflow.data.reserved_build_id = reserved_build_id
+
+    class _MockClientSession(MockClientSession):
+        def getBuild(self, *args, **kwargs):
+            return {"state": koji.BUILD_STATES["BUILDING"]}
+
+        def CGRefundBuild(self, cg, build_id, token, state):
+            assert PROG == cg
+            assert workflow.data.reserved_token == token
+            assert workflow.data.reserved_build_id == build_id
+            assert koji.BUILD_STATES["FAILED"] == state
+
+    flexmock(koji).should_receive("ClientSession").and_return(_MockClientSession())
+
+    plugin = CancelBuildReservation(workflow)
+    expected_msg = f"but the reserved build {reserved_build_id} is in state BUILDING"
+
+    with pytest.raises(RuntimeError, match=expected_msg):
+        plugin.run()

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1275,7 +1275,7 @@ class TestKojiImport(object):
                          name=name, version=version, release=release)
 
         if verify_media:
-            workflow.data.exit_results[PLUGIN_VERIFY_MEDIA_KEY] = verify_media
+            workflow.data.postbuild_results[PLUGIN_VERIFY_MEDIA_KEY] = verify_media
         expected_media_types = verify_media or []
 
         workflow.data.image_id = expect_id
@@ -2316,7 +2316,7 @@ class TestKojiImport(object):
         workflow.data.koji_source_source_url = 'git://hostname/path#123456'
 
         if verify_media:
-            workflow.data.exit_results[PLUGIN_VERIFY_MEDIA_KEY] = verify_media
+            workflow.data.postbuild_results[PLUGIN_VERIFY_MEDIA_KEY] = verify_media
         expected_media_types = verify_media or []
 
         workflow.data.image_id = expect_id

--- a/tests/plugins/test_koji_tag_build.py
+++ b/tests/plugins/test_koji_tag_build.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 import koji
 
 from atomic_reactor.plugins.post_koji_tag_build import KojiTagBuildPlugin
-from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
+from atomic_reactor.plugins.post_koji_import import KojiImportPlugin
 from atomic_reactor.plugin import PluginFailedException, PostBuildPluginsRunner
 from atomic_reactor.inner import BuildResult
 from tests.util import add_koji_map_in_workflow
@@ -79,7 +79,7 @@ def mock_environment(workflow, session=None, build_process_failed=False,
     else:
         workflow.data.build_result = BuildResult(image_id="id1234")
 
-    workflow.data.exit_results[KojiImportPlugin.key] = koji_build_id
+    workflow.data.postbuild_results[KojiImportPlugin.key] = koji_build_id
 
     (flexmock(time)
         .should_receive('sleep')

--- a/tests/plugins/test_koji_tag_build.py
+++ b/tests/plugins/test_koji_tag_build.py
@@ -8,9 +8,9 @@ of the BSD license. See the LICENSE file for details.
 
 import koji
 
-from atomic_reactor.plugins.exit_koji_tag_build import KojiTagBuildPlugin
+from atomic_reactor.plugins.post_koji_tag_build import KojiTagBuildPlugin
 from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
-from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
+from atomic_reactor.plugin import PluginFailedException, PostBuildPluginsRunner
 from atomic_reactor.inner import BuildResult
 from tests.util import add_koji_map_in_workflow
 
@@ -110,7 +110,7 @@ def create_runner(workflow, ssl_certs=False, principal=None,
     else:
         plugin_conf['args'] = {'target': koji_target}
 
-    runner = ExitPluginsRunner(workflow, [plugin_conf])
+    runner = PostBuildPluginsRunner(workflow, [plugin_conf])
 
     return runner
 

--- a/tests/plugins/test_push_floating_tags.py
+++ b/tests/plugins/test_push_floating_tags.py
@@ -18,7 +18,7 @@ from tests.mock_env import MockEnv
 from atomic_reactor.inner import BuildResult
 from atomic_reactor.util import registry_hostname, ManifestDigest, sha256sum
 from osbs.utils import ImageName
-from atomic_reactor.plugins.exit_push_floating_tags import PushFloatingTagsPlugin
+from atomic_reactor.plugins.post_push_floating_tags import PushFloatingTagsPlugin
 from atomic_reactor.constants import PLUGIN_GROUP_MANIFESTS_KEY
 
 
@@ -157,7 +157,7 @@ def mock_registries(registries, config, primary_images=None, manifest_results=No
 def mock_environment(workflow,
                      primary_images=None, floating_images=None,
                      manifest_results=None, annotations=None):
-    env = MockEnv(workflow).for_plugin("exit", PushFloatingTagsPlugin.key)
+    env = MockEnv(workflow).for_plugin("postbuild", PushFloatingTagsPlugin.key)
     env.set_plugin_result("postbuild", PLUGIN_GROUP_MANIFESTS_KEY, manifest_results)
 
     wf_data = env.workflow.data

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -10,7 +10,7 @@ from atomic_reactor.constants import DOCKERFILE_FILENAME
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.exit_sendmail import SendMailPlugin, validate_address
 from atomic_reactor.plugins.exit_store_metadata import StoreMetadataPlugin
-from atomic_reactor.plugins.exit_koji_import import KojiImportPlugin
+from atomic_reactor.plugins.post_koji_import import KojiImportPlugin
 from atomic_reactor.utils.koji import get_koji_task_owner
 from atomic_reactor.config import Configuration
 from tests.util import add_koji_map_in_workflow
@@ -203,7 +203,7 @@ class TestSendMailPlugin(object):
             'send_on': send_on,
         }
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
 
         smtp_map = {
             'from_address': 'foo@bar.com',
@@ -230,7 +230,7 @@ class TestSendMailPlugin(object):
         session = MockedClientSession('', has_kerberos=has_kerberos)
         flexmock(koji, ClientSession=lambda hub, opts: session)
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
 
         smtp_map = {
             'from_address': 'foo@bar.com',
@@ -281,7 +281,7 @@ class TestSendMailPlugin(object):
             'additional_addresses': additional_addresses
         }
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
 
         smtp_map = {
             'from_address': 'foo@bar.com',
@@ -340,7 +340,7 @@ class TestSendMailPlugin(object):
             'to_koji_pkgowner': False
         }
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
         workflow.user_params['koji_task_id'] = MOCK_KOJI_TASK_ID
 
         dockerfile = source_dir / DOCKERFILE_FILENAME
@@ -456,7 +456,7 @@ class TestSendMailPlugin(object):
         }
 
         mock_store_metadata_results(workflow)
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
 
         dockerfile = source_dir / DOCKERFILE_FILENAME
         dockerfile.write_text(MOCK_DOCKERFILE, "utf-8")
@@ -514,7 +514,7 @@ class TestSendMailPlugin(object):
             kwargs['additional_addresses'] = [MOCK_ADDITIONAL_EMAIL]
             smtp_map['additional_addresses'] = [MOCK_ADDITIONAL_EMAIL]
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
         workflow.user_params['koji_task_id'] = MOCK_KOJI_TASK_ID
         rcm = {'version': 1, 'smtp': smtp_map, 'openshift': {'url': 'https://something.com'}}
         workflow.conf = Configuration(raw_config=rcm)
@@ -554,7 +554,7 @@ class TestSendMailPlugin(object):
             'domain': MOCK_EMAIL_DOMAIN,
         }
 
-        workflow.data.exit_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
+        workflow.data.postbuild_results[KojiImportPlugin.key] = MOCK_KOJI_BUILD_ID
         workflow.user_params['koji_task_id'] = MOCK_KOJI_TASK_ID
         rcm = {'version': 1, 'smtp': smtp_map, 'openshift': {'url': 'https://something.com'}}
         workflow.conf = Configuration(raw_config=rcm)
@@ -617,7 +617,7 @@ class TestSendMailPlugin(object):
             kwargs['email_domain'] = MOCK_EMAIL_DOMAIN
             smtp_map['domain'] = MOCK_EMAIL_DOMAIN
 
-        workflow.data.exit_results[KojiImportPlugin.key] = koji_build_id
+        workflow.data.postbuild_results[KojiImportPlugin.key] = koji_build_id
         if exception_location == 'empty_submitter':
             workflow.user_params['koji_task_id'] = None
         else:

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -181,7 +181,7 @@ CMD blabla"""
     workflow.data.postbuild_results = {
         PostBuildRPMqaPlugin.key: "rpm1\nrpm2",
     }
-    workflow.data.exit_results = {
+    workflow.data.postbuild_results = {
         PLUGIN_VERIFY_MEDIA_KEY: verify_media_results,
     }
     workflow.fs_watcher._data = dict(fs_data=None)
@@ -362,7 +362,7 @@ def test_metadata_plugin_source(image_id, br_annotations, expected_br_annotation
             'image_sources_dir': 'source_dir',
         }
     }
-    workflow.data.exit_results = {
+    workflow.data.postbuild_results = {
         PLUGIN_VERIFY_MEDIA_KEY: verify_media_results,
     }
     workflow.fs_watcher._data = dict(fs_data=None)

--- a/tests/plugins/test_verify_media_types.py
+++ b/tests/plugins/test_verify_media_types.py
@@ -13,7 +13,7 @@ from atomic_reactor.constants import (PLUGIN_GROUP_MANIFESTS_KEY,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
                                       MEDIA_TYPE_OCI_V1, MEDIA_TYPE_OCI_V1_INDEX)
-from atomic_reactor.plugins.exit_verify_media_types import VerifyMediaTypesPlugin
+from atomic_reactor.plugins.post_verify_media_types import VerifyMediaTypesPlugin
 from atomic_reactor.inner import ImageBuildWorkflowData, TagConf
 from atomic_reactor.auth import HTTPRegistryAuth
 from atomic_reactor.config import Configuration
@@ -436,17 +436,6 @@ class TestVerifyImageTypes(object):
         with pytest.raises(ValueError) as exc:
             plugin.run()
         assert "no unique image set, impossible to verify media types" in str(exc.value)
-
-    @responses.activate
-    def test_verify_fail_no_build(self):
-        """
-        Build was unsuccessful, return an empty list
-        """
-        workflow = self.workflow(build_process_failed=True)
-
-        plugin = VerifyMediaTypesPlugin(workflow)
-        results = plugin.run()
-        assert results == []
 
     @responses.activate
     def test_verify_fail_bad_results(self, caplog):


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
