### PR TITLE
get_unique_images_with_platform: return ImageNames 

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -301,14 +301,21 @@ class TagConf(ISerializer):
         """
         self._floating_images.append(ImageName.parse(image))
 
-    def get_unique_images_with_platform(self, platform):
+    def get_unique_images_with_platform(self, platform: str) -> List[ImageName]:
         """
         Add platform to unique images
 
         :param platform: str, platform to be added to unique images
         return: list of unique images with added platform
         """
-        return list(map(lambda unique_image: f'{unique_image}-{platform}', self._unique_images))
+        def add_platform(image: ImageName) -> ImageName:
+            return ImageName(
+                registry=image.registry,
+                namespace=image.namespace,
+                repo=image.repo,
+                tag=f'{image.tag}-{platform}',
+            )
+        return list(map(add_platform, self.unique_images))
 
     @classmethod
     def load(cls, data: Dict[str, Any]):

--- a/tests/plugins/test_tag_from_config.py
+++ b/tests/plugins/test_tag_from_config.py
@@ -13,7 +13,6 @@ import pytest
 
 from atomic_reactor.plugins.pre_tag_from_config import TagFromConfigPlugin
 from atomic_reactor.constants import INSPECT_CONFIG
-from atomic_reactor.inner import TagConf
 
 
 DF_CONTENT_LABELS = '''\
@@ -223,16 +222,3 @@ def test_tag_suffixes_from_user_params(user_params, is_orchestrator, expect_suff
     flexmock(plugin).should_receive("is_in_orchestrator").and_return(is_orchestrator)
 
     assert plugin.tag_suffixes == expect_suffixes
-
-
-def test_tag_conf_get_unique_images_with_platform():
-    image = 'registry.com/org/hello:world-16111-20220103213046'
-    platform = 'x86_64'
-
-    tag_conf = TagConf()
-    tag_conf.add_unique_image(image)
-
-    expected = [f'{image}-{platform}']
-    actual = tag_conf.get_unique_images_with_platform(platform)
-
-    assert actual == expected

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1248,6 +1248,18 @@ class TestTagConf:
         assert expected_unique_images == tag_conf.unique_images
         assert expected_floating_images == tag_conf.floating_images
 
+    def test_get_unique_images_with_platform(self):
+        image = 'registry.com/org/hello:world-16111-20220103213046'
+        platform = 'x86_64'
+
+        tag_conf = TagConf()
+        tag_conf.add_unique_image(image)
+
+        expected = [f'{image}-{platform}']
+        actual = tag_conf.get_unique_images_with_platform(platform)
+
+        assert actual == expected
+
 
 class TestWorkflowData:
     """Test class ImageBuildWorkflowData."""

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1255,7 +1255,7 @@ class TestTagConf:
         tag_conf = TagConf()
         tag_conf.add_unique_image(image)
 
-        expected = [f'{image}-{platform}']
+        expected = [ImageName.parse(f'{image}-{platform}')]
         actual = tag_conf.get_unique_images_with_platform(platform)
 
         assert actual == expected


### PR DESCRIPTION
Return ImageNames instead of strings, the rest of the TagConf properties
contain ImageNames as well.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
