### PR TITLE
handle logs for source build

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -496,7 +496,7 @@ def get_platforms(workflow):
         return koji_platforms
 
     # Not an orchestrator build
-    return None
+    return []
 
 
 # copypasted and slightly modified from


### PR DESCRIPTION
when it's a source build `check_and_set_platforms`
plugin doesn't run and `platforms` are set to none.

We need to identify this as source build and handle it
accordingly.

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
