### PR TITLE
Remove build_result attribute from workflow data

### DIFF
--- a/atomic_reactor/plugins/exit_store_metadata.py
+++ b/atomic_reactor/plugins/exit_store_metadata.py
@@ -146,7 +146,8 @@ class StoreMetadataPlugin(ExitPlugin):
     def make_labels(self):
         labels = {}
         self._update_labels(labels, self.workflow.data.labels)
-        self._update_labels(labels, self.workflow.data.build_result.labels)
+        if self.workflow.data.build_result:
+            self._update_labels(labels, self.workflow.data.build_result.labels)
 
         if 'sources_for_koji_build_id' in labels:
             labels['sources_for_koji_build_id'] = str(labels['sources_for_koji_build_id'])
@@ -171,7 +172,8 @@ class StoreMetadataPlugin(ExitPlugin):
             annotations.update(updates)
 
     def apply_build_result_annotations(self, annotations):
-        self._update_annotations(annotations, self.workflow.data.build_result.annotations)
+        if self.workflow.data.build_result:
+            self._update_annotations(annotations, self.workflow.data.build_result.annotations)
 
     def apply_plugin_annotations(self, annotations):
         self._update_annotations(annotations, self.workflow.data.annotations)

--- a/atomic_reactor/schemas/workflow_data.json
+++ b/atomic_reactor/schemas/workflow_data.json
@@ -53,9 +53,7 @@
     "labels": {"type": "object"},
 
     "image_id": {"type": ["string", "null"]},
-    "parent_images_digests": {"type": "object"},
-
-    "build_result": {"$ref": "#/definitions/build_result"}
+    "parent_images_digests": {"type": "object"}
   },
   "required": [
     "dockerfile_images", "tag_conf",
@@ -64,8 +62,7 @@
     "plugins_timestamps", "plugins_durations", "plugins_errors", "build_canceled", "plugin_failed",
     "reserved_build_id", "reserved_token", "koji_source_nvr", "koji_source_source_url", "koji_source_manifest",
     "buildargs", "exported_image_sequence", "files", "image_components", "all_yum_repourls",
-    "annotations", "labels", "image_id", "parent_images_digests",
-    "build_result"
+    "annotations", "labels", "image_id", "parent_images_digests"
   ],
   "additionalProperties": false,
   "definitions": {
@@ -151,33 +148,6 @@
         }
       },
       "required": ["primary_images", "unique_images", "floating_images", "__type__"],
-      "additionalProperties": false
-    },
-    "build_result": {
-      "type": "object",
-      "properties": {
-        "__type__": {"type": "string"},
-        "logs": {
-          "type": ["array", "null"],
-          "items": {"type": "string"}
-        },
-        "fail_reason": {"type": ["string", "null"]},
-        "image_id": {"type": ["string", "null"]},
-        "annotations": {"type": ["object", "null"]},
-        "labels": {"type": ["object", "null"]},
-        "skip_layer_squash": {"type": "boolean"},
-        "source_docker_archive": {"type": ["string", "null"]}
-      },
-      "required": [
-        "logs",
-        "fail_reason",
-        "image_id",
-        "annotations",
-        "labels",
-        "skip_layer_squash",
-        "source_docker_archive",
-        "__type__"
-      ],
       "additionalProperties": false
     },
     "manifest_digest": {

--- a/tests/plugins/test_squash.py
+++ b/tests/plugins/test_squash.py
@@ -32,6 +32,7 @@ SET_DEFAULT_LAYER_ID = object()
 
 @pytest.fixture
 def workflow(workflow):
+    workflow.data.build_result = BuildResult()
     workflow.data.dockerfile_images = DockerfileImages(['Fedora:22'])
     workflow.data.image_id = 'image_id'
     flexmock(workflow, image='image')

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -13,6 +13,8 @@ import random
 import pytest
 import koji as koji
 import osbs
+
+from atomic_reactor.inner import BuildResult
 import atomic_reactor.plugins.post_tag_and_push
 from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
 from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
@@ -79,6 +81,12 @@ PUSH_ERROR_LOGS = [
     {"status": "The push refers to a repository [xyz/abc] (len: 1)"},
     {"errorDetail": {"message": "error message detail"}, "error": "error message"},
 ]
+
+
+@pytest.fixture
+def workflow(workflow):
+    workflow.data.build_result = BuildResult()
+    return workflow
 
 
 @pytest.mark.skip(reason="plugin needs rework, should be used just for source container also, "

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1268,7 +1268,7 @@ class TestWorkflowData:
         data = ImageBuildWorkflowData()
         assert data.dockerfile_images.is_empty
         assert data.tag_conf.is_empty
-        assert "not built" == data.build_result.fail_reason
+        assert data.build_result is None
         assert {} == data.prebuild_results
 
     def test_load_from_empty_dump(self):


### PR DESCRIPTION
Saving the build_result in workflow data causes various issues, like
accidentally overwriting it with None in tasks that don't run any
buildstep plugins. Plus it causes duplication, the build result is
already getting saved in the buildstep_result attribute (as a plugin
result)

Make build_result a property derived from buildstep_result. Add a
setter to avoid having to fix unit tests that set buildstep_result
directly.

Remove build_result from the workflow.json schema, but note that the
custom JSON-encoder|decoder code is still needed (for the BuildResult
object in buildstep_result).

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
