### PR TITLE
Various minor task fixes

### DIFF
--- a/atomic_reactor/cli/parser.py
+++ b/atomic_reactor/cli/parser.py
@@ -77,7 +77,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> dict:
         description="Build a binary container.",
     )
     binary_container_build.set_defaults(func=task.binary_container_build)
-    binary_container_build.add_argument('--platform', action="store",
+    binary_container_build.add_argument('--platform', action="store", required=True,
                                         help="platform on which to build container")
 
     binary_container_postbuild = tasks.add_parser(

--- a/atomic_reactor/tasks/common.py
+++ b/atomic_reactor/tasks/common.py
@@ -8,8 +8,11 @@ of the BSD license. See the LICENSE file for details.
 
 import abc
 from dataclasses import dataclass, fields
+from pathlib import Path
 from typing import Dict, Any, ClassVar
 
+from atomic_reactor import dirs
+from atomic_reactor import inner
 from atomic_reactor import source
 from atomic_reactor import util
 
@@ -85,3 +88,13 @@ class Task(abc.ABC):
     @abc.abstractmethod
     def execute(self):
         """Execute this task."""
+
+    def get_build_dir(self) -> dirs.RootBuildDir:
+        return dirs.RootBuildDir(Path(self._params.build_dir))
+
+    def get_context_dir(self) -> dirs.ContextDir:
+        return dirs.ContextDir(Path(self._params.context_dir))
+
+    def load_workflow_data(self) -> inner.ImageBuildWorkflowData:
+        context_dir = self.get_context_dir()
+        return inner.ImageBuildWorkflowData.load_from_dir(context_dir)

--- a/atomic_reactor/tasks/plugin_based.py
+++ b/atomic_reactor/tasks/plugin_based.py
@@ -7,13 +7,11 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import logging
-from pathlib import Path
 
 from atomic_reactor import inner
-from atomic_reactor.dirs import ContextDir, RootBuildDir
-from atomic_reactor.inner import ImageBuildWorkflowData
 from atomic_reactor.tasks import common
 from atomic_reactor.tasks import PluginsDef
+
 
 # PluginsDef can be considered as part of this module, but is defined elsewhere to avoid cyclic
 #   imports between the `inner` module and this module
@@ -25,21 +23,14 @@ logger = logging.getLogger(__name__)
 class PluginBasedTask(common.Task):
     """Task that executes a predefined list of plugins."""
 
-    def _get_build_dir(self) -> RootBuildDir:
-        """Return the root build directory."""
-        return RootBuildDir(Path(self._params.build_dir))
-
     # Override this in subclasses
     plugins_def: PluginsDef = NotImplemented
 
     def execute(self):
         """Execute the plugins defined in plugins_def."""
-        context_dir = ContextDir(Path(self._params.context_dir))
-        wf_data = ImageBuildWorkflowData.load_from_dir(context_dir)
-
         workflow = inner.DockerBuildWorkflow(
-            self._get_build_dir(),
-            wf_data,
+            build_dir=self.get_build_dir(),
+            data=self.load_workflow_data(),
             source=self._params.source,
             plugins=self.plugins_def,
             user_params=self._params.user_params,
@@ -61,7 +52,7 @@ class PluginBasedTask(common.Task):
         finally:
             # For whatever the reason a build fails, always write the workflow
             # data into the data file.
-            wf_data.save(context_dir)
+            workflow.data.save(self.get_context_dir())
 
         # OSBS2 TBD: OSBS used to log the original Dockerfile after executing the workflow.
         #   It probably doesn't make sense to do that here, but it would be good to log the

--- a/atomic_reactor/tasks/plugin_based.py
+++ b/atomic_reactor/tasks/plugin_based.py
@@ -26,8 +26,8 @@ class PluginBasedTask(common.Task):
     # Override this in subclasses
     plugins_def: PluginsDef = NotImplemented
 
-    def execute(self):
-        """Execute the plugins defined in plugins_def."""
+    def prepare_workflow(self) -> inner.DockerBuildWorkflow:
+        """Fully initialize the workflow instance to be used for running the list of plugins."""
         workflow = inner.DockerBuildWorkflow(
             build_dir=self.get_build_dir(),
             data=self.load_workflow_data(),
@@ -36,6 +36,11 @@ class PluginBasedTask(common.Task):
             user_params=self._params.user_params,
             reactor_config_path=self._params.config_file,
         )
+        return workflow
+
+    def execute(self):
+        """Execute the plugins defined in plugins_def."""
+        workflow = self.prepare_workflow()
 
         try:
             try:

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -7,7 +7,6 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import ClassVar
 
 from atomic_reactor import source
@@ -51,7 +50,7 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         ],
     )
 
-    def _get_build_dir(self) -> RootBuildDir:
-        build_dir = RootBuildDir(Path(self._params.build_dir))
+    def get_build_dir(self) -> RootBuildDir:
+        build_dir = super().get_build_dir()
         build_dir.init_build_dirs(["noarch"], self._params.source)
         return build_dir

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -9,8 +9,8 @@ of the BSD license. See the LICENSE file for details.
 from dataclasses import dataclass
 from typing import ClassVar
 
+from atomic_reactor import inner
 from atomic_reactor import source
-from atomic_reactor.dirs import RootBuildDir
 from atomic_reactor.tasks import common
 from atomic_reactor.tasks import plugin_based
 
@@ -50,7 +50,12 @@ class SourceBuildTask(plugin_based.PluginBasedTask):
         ],
     )
 
-    def get_build_dir(self) -> RootBuildDir:
-        build_dir = super().get_build_dir()
-        build_dir.init_build_dirs(["noarch"], self._params.source)
-        return build_dir
+    def prepare_workflow(self) -> inner.DockerBuildWorkflow:
+        """After preparing the workflow as usual, fully initialize the root build dir.
+
+        Unlike the binary container container workflow, the platforms to be used for the build
+        are known in advance here (more accurately, source containers do not have a platform).
+        """
+        workflow = super().prepare_workflow()
+        workflow.build_dir.init_build_dirs(["noarch"], self._params.source)
+        return workflow

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -153,10 +153,6 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
             "unrecognized arguments: --verbose",
         ),
         (
-            ["task", *REQUIRED_COMMON_ARGS, "--verbose", "binary-container-build"],
-            "unrecognized arguments: --verbose",
-        ),
-        (
             ["task", *REQUIRED_COMMON_ARGS, "--verbose", "binary-container-postbuild"],
             "unrecognized arguments: --verbose",
         ),
@@ -174,10 +170,6 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "binary-container-prebuild", "--user-params={}"],
-            "unrecognized arguments: --user-params",
-        ),
-        (
-            ["task", *REQUIRED_COMMON_ARGS, "binary-container-build", "--user-params={}"],
             "unrecognized arguments: --user-params",
         ),
         (
@@ -202,10 +194,6 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
             "the following arguments are required: --build-dir, --context-dir",
         ),
         (
-            ["task", "binary-container-build"],
-            "the following arguments are required: --build-dir, --context-dir",
-        ),
-        (
             ["task", "binary-container-postbuild"],
             "the following arguments are required: --build-dir, --context-dir",
         ),
@@ -213,6 +201,11 @@ def test_parse_args_valid(cli_args, expect_parsed_args):
             ["task", "binary-container-exit"],
             "the following arguments are required: --build-dir, --context-dir",
         ),
+        # missing --platform for binary-container-build
+        (
+            ["task", *REQUIRED_COMMON_ARGS, "binary-container-build"],
+            "the following arguments are required: --platform",
+        )
     ],
 )
 def test_parse_args_invalid(cli_args, expect_error, capsys):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,11 +67,8 @@ def user_params(monkeypatch):
 
 
 @pytest.fixture
-def workflow(build_dir, source_dir, user_params):
-    return DockerBuildWorkflow(
-        build_dir=RootBuildDir(build_dir),
-        source=DummySource(None, None, workdir=source_dir),
-    )
+def workflow(build_dir, dummy_source, user_params):
+    return DockerBuildWorkflow(build_dir=RootBuildDir(build_dir), source=dummy_source)
 
 
 @pytest.mark.optionalhook
@@ -95,6 +92,11 @@ def source_dir(tmpdir):
     The directory holding source files and can be passed to the mock Source object.
     """
     return Path(tmpdir.join("source_dir").mkdir())
+
+
+@pytest.fixture
+def dummy_source(source_dir):
+    return DummySource(None, None, workdir=source_dir)
 
 
 @pytest.fixture

--- a/tests/tasks/test_common.py
+++ b/tests/tasks/test_common.py
@@ -12,6 +12,8 @@ from typing import Optional, ClassVar
 from flexmock import flexmock
 import pytest
 
+from atomic_reactor import dirs
+from atomic_reactor import inner
 from atomic_reactor import source
 from atomic_reactor import util
 from atomic_reactor.tasks import common
@@ -142,3 +144,24 @@ class TestTaskParams:
         expect_err = r"TaskParams instance has no source \(no git_uri in user params\)"
         with pytest.raises(ValueError, match=expect_err):
             _ = params.source
+
+
+class TestTask:
+    """Tests for the Task class."""
+
+    class ConcreteTask(common.Task):
+        def execute(self):
+            return None
+
+    def test_load_workflow_data(self, tmp_path):
+        params = common.TaskParams(
+            build_dir="", context_dir=str(tmp_path), config_file="", user_params={}
+        )
+
+        expect_data = inner.ImageBuildWorkflowData()
+        (flexmock(inner.ImageBuildWorkflowData)
+         .should_receive("load_from_dir")
+         .with_args(dirs.ContextDir)
+         .and_return(expect_data))
+
+        assert self.ConcreteTask(params).load_workflow_data() == expect_data

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -73,7 +73,7 @@ class TestPluginBasedTask:
 
         # Help to verify the RootBuildDir object is passed to the workflow object.
         (flexmock(plugin_based.PluginBasedTask)
-         .should_receive("_get_build_dir")
+         .should_receive("get_build_dir")
          .and_return(root_build_dir))
 
         # The test methods inside this test case do not involve the workflow
@@ -89,8 +89,8 @@ class TestPluginBasedTask:
             .should_call("__init__")
             .once()
             .with_args(
-                root_build_dir,
-                wf_data,
+                build_dir=root_build_dir,
+                data=wf_data,
                 source=expect_source,
                 plugins=expect_plugins,
                 user_params={"a": "b"},

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -16,7 +16,6 @@ import pytest
 
 from atomic_reactor.inner import ImageBuildWorkflowData, BuildResult
 from atomic_reactor.plugin import BuildCanceledException
-from atomic_reactor.source import DummySource
 from atomic_reactor.tasks.common import TaskParams
 from atomic_reactor.util import DockerfileImages
 from osbs.exceptions import OsbsValidationException
@@ -50,7 +49,7 @@ class TestPluginBasedTask:
     """Tests for the PluginBasedTask class"""
 
     @pytest.fixture
-    def task_with_mocked_deps(self, monkeypatch, build_dir, tmpdir):
+    def task_with_mocked_deps(self, monkeypatch, build_dir, dummy_source, tmpdir):
         """Create a PluginBasedTask instance with mocked task parameters.
 
         Mock DockerBuildWorkflow accordingly. Return the mocked workflow instance for further
@@ -62,7 +61,7 @@ class TestPluginBasedTask:
                                  user_params={"a": "b"},
                                  config_file="config.yaml")
 
-        expect_source = DummySource("git", "https://git.host/", workdir=build_dir)
+        expect_source = dummy_source
         (flexmock(task_params)
          .should_receive("source")
          .and_return(expect_source))
@@ -142,7 +141,7 @@ class TestPluginBasedTask:
     ["normal_return", "error_raised", "failed", "terminated"]
 )
 def test_ensure_workflow_data_is_saved_in_various_conditions(
-    build_result, build_dir, tmpdir
+    build_result, build_dir, dummy_source, tmpdir
 ):
     context_dir = tmpdir.join("context_dir").mkdir()
     params = TaskParams(build_dir=str(build_dir),
@@ -151,7 +150,7 @@ def test_ensure_workflow_data_is_saved_in_various_conditions(
                         user_params={})
     (flexmock(params)
      .should_receive("source")
-     .and_return(DummySource("git", "https://git.host/")))
+     .and_return(dummy_source))
 
     task = plugin_based.PluginBasedTask(params)
 
@@ -212,7 +211,7 @@ def test_ensure_workflow_data_is_saved_in_various_conditions(
     assert {} == wf_data.prebuild_results
 
 
-def test_workflow_data_is_restored_before_starting_to_build(build_dir, tmpdir):
+def test_workflow_data_is_restored_before_starting_to_build(build_dir, dummy_source, tmpdir):
     context_dir = tmpdir.join("context_dir").mkdir()
 
     # Write workflow data as it was saved by a previous task
@@ -233,7 +232,7 @@ def test_workflow_data_is_restored_before_starting_to_build(build_dir, tmpdir):
                         user_params={})
     (flexmock(params)
      .should_receive("source")
-     .and_return(DummySource("git", "https://git.host/")))
+     .and_return(dummy_source))
 
     task = plugin_based.PluginBasedTask(params)
 

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -57,12 +57,15 @@ class TestPluginBasedTask:
         customization in individual tests.
         """
         context_dir = tmpdir.join("context_dir")
-        expect_source = flexmock()
-        task_params = flexmock(build_dir=build_dir,
-                               context_dir=str(context_dir),
-                               source=expect_source,
-                               user_params={"a": "b"},
-                               config_file="config.yaml")
+        task_params = TaskParams(build_dir=build_dir,
+                                 context_dir=str(context_dir),
+                                 user_params={"a": "b"},
+                                 config_file="config.yaml")
+
+        expect_source = DummySource("git", "https://git.host/", workdir=build_dir)
+        (flexmock(task_params)
+         .should_receive("source")
+         .and_return(expect_source))
 
         expect_plugins = flexmock()
         monkeypatch.setattr(plugin_based.PluginBasedTask, "plugins_def", expect_plugins)
@@ -84,7 +87,7 @@ class TestPluginBasedTask:
         mocked_workflow = flexmock(inner.DockerBuildWorkflow)
         (
             mocked_workflow
-            .should_receive("__init__")
+            .should_call("__init__")
             .once()
             .with_args(
                 root_build_dir,

--- a/tests/tasks/test_sources.py
+++ b/tests/tasks/test_sources.py
@@ -6,23 +6,40 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+import pytest
+
 from atomic_reactor import source
 from atomic_reactor.tasks import sources
+
+
+@pytest.fixture
+def params(build_dir) -> sources.SourceBuildTaskParams:
+    return sources.SourceBuildTaskParams(
+        # build_dir has to be an existing directory because DummySource creates a subdirectory
+        #   as soon as an instance is created
+        build_dir=str(build_dir),
+        context_dir="/context",
+        config_file="config.yaml",
+        user_params={},
+    )
 
 
 class TestSourceBuildTaskParams:
     """Tests for the SourceBuildTaskParams class."""
 
-    def test_source_property(self, tmpdir):
-        params = sources.SourceBuildTaskParams(
-            # build_dir has to be an existing directory because DummySource creates a subdirectory
-            #   as soon as an instance is created
-            build_dir=str(tmpdir),
-            context_dir="/context",
-            config_file="config.yaml",
-            user_params={},
-        )
+    def test_source_property(self, params):
         src = params.source
 
         assert isinstance(src, source.DummySource)
-        assert src.workdir == str(tmpdir)
+        assert src.workdir == params.build_dir
+
+
+class TestSourceBuildTask:
+    """Tests for the SourceBuildTask class."""
+
+    def test_prepare_workflow(self, params):
+        task = sources.SourceBuildTask(params)
+
+        workflow = task.prepare_workflow()
+        assert workflow.build_dir.platforms == ["noarch"]
+        assert workflow.build_dir.has_sources


### PR DESCRIPTION
A collection of small fixes in preparation for implementing the build task.

In particular, the hope is that the build task may not have to be plugin-based.
It's not clear if that is realistic yet, but even for a plugin-based build task, these
changes will be helpful.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
