### PR TITLE
Build task stub

### DIFF
--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -5,8 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from atomic_reactor.tasks.binary import BinaryBuildTask, BinaryExitTask, \
-    BinaryPostBuildTask, BinaryPreBuildTask, BinaryBuildTaskParams
+from atomic_reactor.tasks.binary import BinaryExitTask, BinaryPostBuildTask, BinaryPreBuildTask
+from atomic_reactor.tasks.binary_container_build import BinaryBuildTask, BinaryBuildTaskParams
 from atomic_reactor.tasks.clone import CloneTask
 from atomic_reactor.tasks.common import TaskParams
 from atomic_reactor.tasks.orchestrator import OrchestratorTask, OrchestratorTaskParams

--- a/atomic_reactor/plugins/build_orchestrate_build.py
+++ b/atomic_reactor/plugins/build_orchestrate_build.py
@@ -290,7 +290,7 @@ class OrchestrateBuildPlugin(BuildStepPlugin):
                                   ignored
         """
         super(OrchestrateBuildPlugin, self).__init__(workflow)
-        self.platforms = get_platforms(self.workflow)
+        self.platforms = get_platforms(self.workflow.data)
 
         self.build_kwargs = build_kwargs or {}
         self.config_kwargs = config_kwargs or {}

--- a/atomic_reactor/plugins/post_koji_import.py
+++ b/atomic_reactor/plugins/post_koji_import.py
@@ -457,7 +457,7 @@ class KojiImportBase(PostBuildPlugin):
         buildroot = self.get_buildroot()
         buildroot_id = buildroot[0]['id']
         output, output_file = self.get_output(buildroot_id)
-        osbs_logs = OSBSLogs(self.log, get_platforms(self.workflow))
+        osbs_logs = OSBSLogs(self.log, get_platforms(self.workflow.data))
         output_files = [add_log_type(add_buildroot_id(md, buildroot_id))
                         for md in osbs_logs.get_log_files(self.osbs, self.pipeline_run_name)]
 

--- a/atomic_reactor/plugins/post_verify_media_types.py
+++ b/atomic_reactor/plugins/post_verify_media_types.py
@@ -111,7 +111,7 @@ class VerifyMediaTypesPlugin(PostBuildPlugin):
                            'because group manifests plugin did not run')
             return False
 
-        platforms = get_platforms(self.workflow)
+        platforms = get_platforms(self.workflow.data)
         if not platforms:
             self.log.debug('Cannot check if only manifest list digest should be returned '
                            'because we have no platforms list')

--- a/atomic_reactor/plugins/pre_add_filesystem.py
+++ b/atomic_reactor/plugins/pre_add_filesystem.py
@@ -98,7 +98,7 @@ class AddFilesystemPlugin(PreBuildPlugin):
         self.poll_interval = poll_interval
         self.blocksize = blocksize
         self.repos = repos or []
-        self.architectures = get_platforms(self.workflow)
+        self.architectures = get_platforms(self.workflow.data)
         self.scratch = util.is_scratch_build(self.workflow)
         self.koji_target = koji_target
         self.session = None

--- a/atomic_reactor/plugins/pre_check_base_image.py
+++ b/atomic_reactor/plugins/pre_check_base_image.py
@@ -182,7 +182,7 @@ class CheckBaseImagePlugin(PreBuildPlugin):
 
     def _validate_platforms_in_image(self, image: ImageName) -> None:
         """Ensure that the image provides all platforms expected for the build."""
-        expected_platforms = get_platforms(self.workflow)
+        expected_platforms = get_platforms(self.workflow.data)
         if not expected_platforms:
             self.log.info('Skipping validation of available platforms '
                           'because expected platforms are unknown')

--- a/atomic_reactor/plugins/pre_inject_yum_repos.py
+++ b/atomic_reactor/plugins/pre_inject_yum_repos.py
@@ -50,7 +50,7 @@ class InjectYumReposPlugin(PreBuildPlugin):
         self.include_koji_repo = False
         self._builder_ca_bundle = None
         self._ca_bundle_pem = None
-        self.platforms = get_platforms(workflow)
+        self.platforms = get_platforms(workflow.data)
 
         resolve_comp_result = self.workflow.data.prebuild_results.get(PLUGIN_RESOLVE_COMPOSES_KEY)
         self.include_koji_repo = resolve_comp_result['include_koji_repo']

--- a/atomic_reactor/plugins/pre_koji_parent.py
+++ b/atomic_reactor/plugins/pre_koji_parent.py
@@ -69,7 +69,7 @@ class KojiParentPlugin(PreBuildPlugin):
         self._base_image_build = None
         self._parent_builds = {}
         self._poll_start = None
-        self.platforms = get_platforms(self.workflow)
+        self.platforms = get_platforms(self.workflow.data)
         # RegistryClient instances cached by registry name
         self.registry_clients = {}
         self._deep_manifest_list_inspection = self.workflow.conf.deep_manifest_list_inspection

--- a/atomic_reactor/plugins/pre_resolve_composes.py
+++ b/atomic_reactor/plugins/pre_resolve_composes.py
@@ -81,7 +81,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
         self.parent_compose_ids = []
         self.include_koji_repo = False
         self.yum_repourls = defaultdict(list)
-        self.architectures = get_platforms(self.workflow) or []
+        self.architectures = get_platforms(self.workflow.data)
 
     def run(self):
         if self.allow_inheritance():
@@ -184,7 +184,7 @@ class ResolveComposesPlugin(PreBuildPlugin):
 
         pulp_data = util.read_content_sets(self.workflow) or {}
 
-        platforms = get_platforms(self.workflow)
+        platforms = get_platforms(self.workflow.data)
         if platforms:
             platforms = sorted(platforms)  # sorted to keep predictable for tests
 

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -6,15 +6,7 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from dataclasses import dataclass
 from atomic_reactor.tasks import plugin_based
-from atomic_reactor.tasks.common import TaskParams
-
-
-@dataclass(frozen=True)
-class BinaryBuildTaskParams(TaskParams):
-    """Binary container build task parameters"""
-    platform: str
 
 
 class BinaryPreBuildTask(plugin_based.PluginBasedTask):
@@ -46,16 +38,6 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
             {"name": "distribution_scope"},
             {"name": "add_buildargs_in_dockerfile"},
             {"name": "tag_from_config"},
-        ],
-    )
-
-
-class BinaryBuildTask(plugin_based.PluginBasedTask):
-    """Binary container build task."""
-
-    plugins_def = plugin_based.PluginsDef(
-        buildstep=[
-            {"name": "binary_container"},
         ],
     )
 

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -7,9 +7,10 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from atomic_reactor.tasks import plugin_based
+from atomic_reactor.tasks.common import TaskParams
 
 
-class BinaryPreBuildTask(plugin_based.PluginBasedTask):
+class BinaryPreBuildTask(plugin_based.PluginBasedTask[TaskParams]):
     """Binary container pre-build task."""
 
     plugins_def = plugin_based.PluginsDef(
@@ -42,7 +43,7 @@ class BinaryPreBuildTask(plugin_based.PluginBasedTask):
     )
 
 
-class BinaryPostBuildTask(plugin_based.PluginBasedTask):
+class BinaryPostBuildTask(plugin_based.PluginBasedTask[TaskParams]):
     """Binary container post-build task."""
 
     plugins_def = plugin_based.PluginsDef(
@@ -63,7 +64,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask):
     )
 
 
-class BinaryExitTask(plugin_based.PluginBasedTask):
+class BinaryExitTask(plugin_based.PluginBasedTask[TaskParams]):
     """Binary container exit-build task."""
 
     plugins_def = plugin_based.PluginsDef(

--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -7,7 +7,12 @@ of the BSD license. See the LICENSE file for details.
 """
 import logging
 from dataclasses import dataclass
+from typing import Dict, Iterator
 
+from osbs.utils import ImageName
+
+from atomic_reactor import dirs
+from atomic_reactor import util
 from atomic_reactor.tasks.common import Task, TaskParams
 
 
@@ -24,4 +29,68 @@ class BinaryBuildTask(Task):
     """Binary container build task."""
 
     def execute(self):
-        logger.warning("This task doesn't do anything yet.")
+        """Build a container image for the platform specified in the task parameters.
+
+        The built image will be pushed to the unique tag for this platform, which can be found
+        in tag_conf.get_unique_images_with_platform() (where tag_conf comes from context data).
+        """
+        platform = self._params.platform
+
+        data = self.load_workflow_data()
+        enabled_platforms = util.get_platforms(data)
+
+        if platform not in enabled_platforms:
+            logger.info(
+                r"Platform %s is not enabled for this build (enabled platforms: %s). Exiting.",
+                platform,
+                enabled_platforms,
+            )
+            return
+
+        build_dir = self.get_build_dir().platform_dir(platform)
+        dest_tag = data.tag_conf.get_unique_images_with_platform(platform)[0]
+
+        logger.info("Building for the %s platform from %s", platform, build_dir.dockerfile_path)
+
+        try:
+            output_lines = self.build_container(
+                build_dir=build_dir,
+                build_args=data.buildargs,
+                dest_tag=dest_tag,
+            )
+            for line in output_lines:
+                logger.info(line)
+
+            logger.info("Build finished succesfully! Pushing image to %s", dest_tag)
+            self.push_container(dest_tag)
+        finally:
+            logger.info("Dockerfile used for build:\n%s", build_dir.dockerfile_path.read_text())
+
+    def build_container(
+        self,
+        *,
+        build_dir: dirs.BuildDir,
+        build_args: Dict[str, str],
+        dest_tag: ImageName,
+    ) -> Iterator[str]:
+        """Build a container image from the specified build directory.
+
+        Pass the specified build arguments as ARG values using --build-arg.
+
+        The built image will be available locally on the machine that built it, tagged with
+        the specified dest_tag.
+
+        This method returns an iterator which yields individual lines from the stdout
+        and stderr of the build process as they become available.
+        """
+        lines = [
+            "I'm building an image.",
+            "Or at least pretending to.",
+            "I don't actually work yet.",
+            "Goodbye! ^.^",
+        ]
+        yield from lines
+
+    def push_container(self, dest_tag: ImageName) -> None:
+        """Push the built container (named dest_tag) to the registry (as dest_tag)."""
+        return None

--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -39,10 +39,10 @@ class BinaryBuildTaskParams(TaskParams):
     platform: str
 
 
-class BinaryBuildTask(Task):
+class BinaryBuildTask(Task[BinaryBuildTaskParams]):
     """Binary container build task."""
 
-    def execute(self):
+    def execute(self) -> None:
         """Build a container image for the platform specified in the task parameters.
 
         The built image will be pushed to the unique tag for this platform, which can be found

--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -1,0 +1,27 @@
+"""
+Copyright (c) 2022 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+import logging
+from dataclasses import dataclass
+
+from atomic_reactor.tasks.common import Task, TaskParams
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BinaryBuildTaskParams(TaskParams):
+    """Binary container build task parameters"""
+    platform: str
+
+
+class BinaryBuildTask(Task):
+    """Binary container build task."""
+
+    def execute(self):
+        logger.warning("This task doesn't do anything yet.")

--- a/atomic_reactor/tasks/clone.py
+++ b/atomic_reactor/tasks/clone.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 from atomic_reactor.tasks import common
 
 
-class CloneTask(common.Task):
+class CloneTask(common.Task[common.TaskParams]):
     """Clone task."""
 
     def execute(self):

--- a/atomic_reactor/tasks/common.py
+++ b/atomic_reactor/tasks/common.py
@@ -9,7 +9,7 @@ of the BSD license. See the LICENSE file for details.
 import abc
 from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Dict, Any, ClassVar
+from typing import Dict, Any, ClassVar, Generic, TypeVar
 
 from atomic_reactor import config
 from atomic_reactor import dirs
@@ -79,10 +79,13 @@ class TaskParams:
         return {k: v for k, v in args.items() if v is not None or k not in known_args}
 
 
-class Task(abc.ABC):
+ParamsT = TypeVar("ParamsT", bound=TaskParams)
+
+
+class Task(abc.ABC, Generic[ParamsT]):
     """Task; the main execution unit in atomic-reactor."""
 
-    def __init__(self, params: TaskParams):
+    def __init__(self, params: ParamsT):
         """Initialize a Task."""
         self._params = params
 

--- a/atomic_reactor/tasks/common.py
+++ b/atomic_reactor/tasks/common.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Dict, Any, ClassVar
 
+from atomic_reactor import config
 from atomic_reactor import dirs
 from atomic_reactor import inner
 from atomic_reactor import source
@@ -98,3 +99,6 @@ class Task(abc.ABC):
     def load_workflow_data(self) -> inner.ImageBuildWorkflowData:
         context_dir = self.get_context_dir()
         return inner.ImageBuildWorkflowData.load_from_dir(context_dir)
+
+    def load_config(self) -> config.Configuration:
+        return config.Configuration(self._params.config_file)

--- a/atomic_reactor/tasks/plugin_based.py
+++ b/atomic_reactor/tasks/plugin_based.py
@@ -9,8 +9,8 @@ of the BSD license. See the LICENSE file for details.
 import logging
 
 from atomic_reactor import inner
-from atomic_reactor.tasks import common
 from atomic_reactor.tasks import PluginsDef
+from atomic_reactor.tasks.common import Task, ParamsT
 
 
 # PluginsDef can be considered as part of this module, but is defined elsewhere to avoid cyclic
@@ -20,7 +20,7 @@ __all__ = ["PluginsDef", "PluginBasedTask"]
 logger = logging.getLogger(__name__)
 
 
-class PluginBasedTask(common.Task):
+class PluginBasedTask(Task[ParamsT]):
     """Task that executes a predefined list of plugins."""
 
     # Override this in subclasses

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -28,7 +28,7 @@ class SourceBuildTaskParams(common.TaskParams):
         return source.DummySource(None, None, workdir=self.build_dir)
 
 
-class SourceBuildBaseTask(plugin_based.PluginBasedTask):
+class SourceBuildBaseTask(plugin_based.PluginBasedTask[SourceBuildTaskParams]):
     """Base task for defining different build phases for source container build."""
 
     def prepare_workflow(self) -> inner.DockerBuildWorkflow:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -48,7 +48,6 @@ from atomic_reactor.constants import (DOCKERFILE_FILENAME, REPO_CONTAINER_CONFIG
                                       REPO_FETCH_ARTIFACTS_URL,
                                       REPO_FETCH_ARTIFACTS_PNC,
                                       USER_CONFIG_FILES, REPO_FETCH_ARTIFACTS_KOJI)
-
 from atomic_reactor.auth import HTTPRegistryAuth
 from atomic_reactor.types import ISerializer, ImageInspectionData
 
@@ -490,12 +489,10 @@ def get_orchestrator_platforms(workflow):
         return None
 
 
-def get_platforms(workflow):
-    koji_platforms = workflow.data.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
+def get_platforms(workflow_data) -> List[str]:
+    koji_platforms = workflow_data.prebuild_results.get(PLUGIN_CHECK_AND_SET_PLATFORMS_KEY)
     if koji_platforms:
         return koji_platforms
-
-    # Not an orchestrator build
     return []
 
 

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -9,8 +9,14 @@ of the BSD license. See the LICENSE file for details.
 from flexmock import flexmock
 
 from atomic_reactor.cli import task
-from atomic_reactor.tasks import orchestrator, worker, sources, common, binary
-
+from atomic_reactor.tasks import (
+    orchestrator,
+    worker,
+    sources,
+    common,
+    binary,
+    binary_container_build,
+)
 TASK_ARGS = {
     "build_dir": "/build",
     "context_dir": "/context",
@@ -55,7 +61,7 @@ def test_binary_container_prebuild():
 
 
 def test_binary_container_build():
-    mock(binary.BinaryBuildTask)
+    mock(binary_container_build.BinaryBuildTask)
     assert task.binary_container_build(TASK_ARGS) == TASK_RESULT
 
 

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -1,0 +1,131 @@
+"""
+Copyright (c) 2022 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Any, Dict, List
+
+from osbs.utils import ImageName
+
+import pytest
+from flexmock import flexmock
+
+from atomic_reactor import dirs
+from atomic_reactor import inner
+from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+from atomic_reactor.tasks.binary_container_build import BinaryBuildTask, BinaryBuildTaskParams
+
+CONTEXT_DIR = "/workspace/ws-context-dir"
+CONFIG_PATH = "/etc/atomic-reactor/config.yaml"
+
+NOARCH_UNIQUE_IMAGE = ImageName.parse("registry.example.org/osbs/spam:v1.0")
+X86_UNIQUE_IMAGE = ImageName.parse("registry.example.org/osbs/spam:v1.0-x86_64")
+
+BUILD_ARGS = {"REMOTE_SOURCES": "unpacked_remote_sources"}
+
+DOCKERFILE_CONTENT = dedent(
+    """\
+    FROM fedora:35
+
+    RUN echo "Hello there."
+    """
+)
+
+
+@pytest.fixture
+def base_task_params(build_dir: Path) -> Dict[str, Any]:
+    return {
+        "build_dir": str(build_dir),
+        "context_dir": CONTEXT_DIR,
+        "config_file": CONFIG_PATH,
+        "user_params": {},
+    }
+
+
+@pytest.fixture
+def x86_task_params(base_task_params) -> BinaryBuildTaskParams:
+    return BinaryBuildTaskParams(**base_task_params, platform="x86_64")
+
+
+@pytest.fixture
+def aarch64_task_params(base_task_params) -> BinaryBuildTaskParams:
+    return BinaryBuildTaskParams(**base_task_params, platform="aarch64")
+
+
+@pytest.fixture
+def x86_build_dir(build_dir: Path) -> dirs.BuildDir:
+    x86_dir = build_dir / "x86_64"
+    x86_dir.mkdir(exist_ok=True)
+    return dirs.BuildDir(x86_dir, "x86_64")
+
+
+def mock_workflow_data(*, enabled_platforms: List[str]) -> inner.ImageBuildWorkflowData:
+    """Make load_workflow_data() return mocked workflow data. Also return this data."""
+    tag_conf = inner.TagConf()
+    tag_conf.add_unique_image(NOARCH_UNIQUE_IMAGE)
+
+    mocked_data = inner.ImageBuildWorkflowData(
+        tag_conf=tag_conf,
+        prebuild_results={PLUGIN_CHECK_AND_SET_PLATFORMS_KEY: enabled_platforms},
+        buildargs=BUILD_ARGS,
+    )
+
+    (
+        flexmock(BinaryBuildTask)
+        .should_receive("load_workflow_data")
+        .and_return(mocked_data)
+    )
+    return mocked_data
+
+
+class TestBinaryBuildTask:
+    """Tests from the BinaryBuildTask class."""
+
+    def test_platform_is_not_enabled(self, aarch64_task_params, caplog):
+        mock_workflow_data(enabled_platforms=["x86_64"])
+        flexmock(BinaryBuildTask).should_receive("build_container").never()
+
+        task = BinaryBuildTask(aarch64_task_params)
+        task.execute()
+
+        assert "Platform aarch64 is not enabled for this build" in caplog.text
+
+    def test_run_build(self, x86_task_params, x86_build_dir, caplog):
+        mock_workflow_data(enabled_platforms=["x86_64"])
+        x86_build_dir.dockerfile_path.write_text(DOCKERFILE_CONTENT)
+
+        def mock_build_container(*, build_dir, build_args, dest_tag):
+            assert build_dir.path == x86_build_dir.path
+            assert build_dir.platform == "x86_64"
+            assert build_args == BUILD_ARGS
+            assert dest_tag == X86_UNIQUE_IMAGE
+
+            yield from ["output line 1", "output line 2"]
+
+        (
+            flexmock(BinaryBuildTask)
+            .should_receive("build_container")
+            .once()
+            .replace_with(mock_build_container)
+        )
+        (
+            flexmock(BinaryBuildTask)
+            .should_receive("push_container")
+            .with_args(X86_UNIQUE_IMAGE)
+            .once()
+        )
+
+        task = BinaryBuildTask(x86_task_params)
+        task.execute()
+
+        assert (
+            f"Building for the x86_64 platform from {x86_build_dir.dockerfile_path}" in caplog.text
+        )
+        assert "output line 1" in caplog.text
+        assert "output line 2" in caplog.text
+        assert DOCKERFILE_CONTENT in caplog.text

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -6,9 +6,12 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
+import io
+import re
+import subprocess
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from osbs.utils import ImageName
 
@@ -18,7 +21,13 @@ from flexmock import flexmock
 from atomic_reactor import dirs
 from atomic_reactor import inner
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
-from atomic_reactor.tasks.binary_container_build import BinaryBuildTask, BinaryBuildTaskParams
+from atomic_reactor.tasks.binary_container_build import (
+    BinaryBuildTask,
+    BinaryBuildTaskParams,
+    BuildProcessError,
+    PushError,
+)
+from atomic_reactor.utils import retries
 
 CONTEXT_DIR = "/workspace/ws-context-dir"
 CONFIG_PATH = "/etc/atomic-reactor/config.yaml"
@@ -83,6 +92,34 @@ def mock_workflow_data(*, enabled_platforms: List[str]) -> inner.ImageBuildWorkf
     return mocked_data
 
 
+class MockedPopen:
+    def __init__(self, rc: int, output_lines: List[str]):
+        self._rc = rc
+        self.stdout = io.StringIO("".join(output_lines))
+
+    def poll(self):
+        if self.stdout.tell() >= len(self.stdout.getvalue()):
+            # no more output, the process has ended
+            return self._rc
+        return None
+
+
+def mock_popen(
+    rc: int, output_lines: List[str], expect_cmd: Optional[List[str]] = None
+) -> None:
+    """Make subprocess.Popen returned a mocked Popen.
+
+    The output_lines should end with '\n', otherwise they wil be combined to a single line.
+    Optionally, pass in the expected command to be checked.
+    """
+    def popen(cmd, *args, **kwargs):
+        if expect_cmd:
+            assert cmd == expect_cmd
+        return MockedPopen(rc, output_lines)
+
+    flexmock(subprocess).should_receive("Popen").replace_with(popen)
+
+
 class TestBinaryBuildTask:
     """Tests from the BinaryBuildTask class."""
 
@@ -129,3 +166,84 @@ class TestBinaryBuildTask:
         assert "output line 1" in caplog.text
         assert "output line 2" in caplog.text
         assert DOCKERFILE_CONTENT in caplog.text
+
+    def test_print_dockerfile_on_failure(self, x86_task_params, x86_build_dir, caplog):
+        mock_workflow_data(enabled_platforms=["x86_64"])
+        x86_build_dir.dockerfile_path.write_text(DOCKERFILE_CONTENT)
+
+        (
+            flexmock(BinaryBuildTask)
+            .should_receive("build_container")
+            .and_raise(BuildProcessError("something went wrong"))
+        )
+
+        task = BinaryBuildTask(x86_task_params)
+        with pytest.raises(BuildProcessError):
+            task.execute()
+
+        assert DOCKERFILE_CONTENT in caplog.text
+
+    def test_build_container(self, x86_task_params, x86_build_dir):
+        # TBD: add the actual expect_cmd later
+        mock_popen(0, ["starting the build\n", "finished successfully\n"], expect_cmd=None)
+
+        task = BinaryBuildTask(x86_task_params)
+        output_lines = task.build_container(
+            build_dir=x86_build_dir,
+            build_args=BUILD_ARGS,
+            dest_tag=X86_UNIQUE_IMAGE,
+        )
+
+        assert list(output_lines) == ["starting the build\n", "finished successfully\n"]
+
+    @pytest.mark.parametrize(
+        "output_lines, expect_err_line",
+        [
+            (["starting the build\n", "failed :(\n"], "failed :("),
+            ([], "<no output!>"),
+        ]
+    )
+    def test_build_container_fails(
+        self, output_lines, expect_err_line, x86_task_params, x86_build_dir
+    ):
+        mock_popen(1, output_lines)
+
+        task = BinaryBuildTask(x86_task_params)
+        returned_lines = task.build_container(
+            build_dir=x86_build_dir,
+            build_args=BUILD_ARGS,
+            dest_tag=X86_UNIQUE_IMAGE,
+        )
+
+        for expect_line in output_lines:
+            assert next(returned_lines) == expect_line
+
+        err_msg = rf"Build failed \(rc=1\). {re.escape(expect_err_line)}"
+
+        with pytest.raises(BuildProcessError, match=err_msg):
+            next(returned_lines)
+
+    def test_push_container(self, x86_task_params):
+        (
+            flexmock(retries)
+            .should_receive("run_cmd")
+            .with_args(["echo", str(X86_UNIQUE_IMAGE)])  # TBD: change me later
+            .once()
+        )
+
+        task = BinaryBuildTask(x86_task_params)
+        task.push_container(X86_UNIQUE_IMAGE)
+
+    def test_push_container_fails(self, x86_task_params):
+        (
+            flexmock(retries)
+            .should_receive("run_cmd")
+            .and_raise(subprocess.CalledProcessError(1, 'some command'))
+        )
+
+        task = BinaryBuildTask(x86_task_params)
+
+        err_msg = r"Push failed \(rc=1\). Check the logs for more details."
+
+        with pytest.raises(PushError, match=err_msg):
+            task.push_container(X86_UNIQUE_IMAGE)


### PR DESCRIPTION
CLOUDBLD-8657

Implement the build task stub. It doesn't do anything useful, but the path from here to a functional build task should be relatively short. More info in the individual commits.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
