### PR TITLE
new tasks for binary & source pipelines which set pipeline run results

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -18,6 +18,14 @@ spec:
     - name: ws-koji-secret
     - name: ws-reactor-config-map
 
+  results:
+    - name: repositories
+      value: $(tasks.binary-container-set-results.results.repositories)
+    - name: koji-build-id
+      value: $(tasks.binary-container-set-results.results.koji-build-id)
+    - name: remote_sources
+      value: $(tasks.binary-container-set-results.results.remote_sources)
+
   tasks:
     - name: clone
       taskRef:
@@ -38,6 +46,7 @@ spec:
           value: "$(params.OSBS_IMAGE)"
         - name: USER_PARAMS
           value: "$(params.USER_PARAMS)"
+
     - name: binary-container-prebuild
       runAfter:
         - clone
@@ -59,6 +68,7 @@ spec:
           value: "$(params.OSBS_IMAGE)"
         - name: USER_PARAMS
           value: "$(params.USER_PARAMS)"
+
     - name: binary-container-build-x86-64
       runAfter:
         - binary-container-prebuild
@@ -82,6 +92,7 @@ spec:
           value: "$(params.USER_PARAMS)"
         - name: PLATFORM
           value: x86_64
+
     - name: binary-container-build-s390x
       runAfter:
         - binary-container-prebuild
@@ -105,6 +116,7 @@ spec:
           value: "$(params.USER_PARAMS)"
         - name: PLATFORM
           value: s390x
+
     - name: binary-container-build-ppc64le
       runAfter:
         - binary-container-prebuild
@@ -128,6 +140,7 @@ spec:
           value: "$(params.USER_PARAMS)"
         - name: PLATFORM
           value: ppc64le
+
     - name: binary-container-build-aarch64
       runAfter:
         - binary-container-prebuild
@@ -151,6 +164,7 @@ spec:
           value: "$(params.USER_PARAMS)"
         - name: PLATFORM
           value: aarch64
+
     - name: binary-container-postbuild
       runAfter:
         - binary-container-build-x86-64
@@ -175,6 +189,19 @@ spec:
           value: "$(params.OSBS_IMAGE)"
         - name: USER_PARAMS
           value: "$(params.USER_PARAMS)"
+
+    - name: binary-container-set-results
+      runAfter:
+        - binary-container-postbuild
+      taskRef:
+        name: binary-container-set-results-0-1
+      workspaces:
+        - name: ws-context-dir
+          workspace: ws-context-dir
+      params:
+        - name: OSBS_IMAGE
+          value: "$(params.OSBS_IMAGE)"
+
   finally:
     - name: binary-container-exit
       taskRef:

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -18,6 +18,12 @@ spec:
     - name: ws-koji-secret
     - name: ws-reactor-config-map
 
+  results:
+    - name: repositories
+      value: $(tasks.source-container-set-results.results.repositories)
+    - name: koji-build-id
+      value: $(tasks.source-container-set-results.results.koji-build-id)
+
   tasks:
     - name: source-container-build
       taskRef:
@@ -38,6 +44,19 @@ spec:
           value: "$(params.OSBS_IMAGE)"
         - name: USER_PARAMS
           value: "$(params.USER_PARAMS)"
+
+    - name: source-container-set-results
+      runAfter:
+        - source-container-build
+      taskRef:
+        name: source-container-set-results-0-1
+      workspaces:
+        - name: ws-context-dir
+          workspace: ws-context-dir
+      params:
+        - name: OSBS_IMAGE
+          value: "$(params.OSBS_IMAGE)"
+
   finally:
     - name: source-container-exit
       taskRef:

--- a/tekton/tasks/binary-container-set-results.yaml
+++ b/tekton/tasks/binary-container-set-results.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: binary-container-set-results-0-1  # dot is not allowed in the name
+spec:
+  description: >-
+    OSBS task for setting results for binary container build
+  params:
+    - name: OSBS_IMAGE
+      description: The location of the OSBS builder image (FQDN pullspec)
+      type: string
+
+  workspaces:
+    - name: ws-context-dir
+
+  results:
+    - name: repositories
+    - name: koji-build-id
+    - name: remote_sources
+
+  steps:
+    - name: binary-container-set-results
+      image: $(params.OSBS_IMAGE)
+      resources:
+        requests:
+          memory: 300Mi
+          cpu: 250m
+        limits:
+          memory: 600Mi
+          cpu: 395m
+      script: |
+        jq -c '.annotations.repositories' $(workspaces.ws-context-dir.path)/workflow.json >$(results.repositories.path)
+        jq -c '.annotations.remote_sources' $(workspaces.ws-context-dir.path)/workflow.json >$(results.remote_sources.path)
+        jq -c '.labels["koji-build-id"]' $(workspaces.ws-context-dir.path)/workflow.json >$(results.koji-build-id.path)

--- a/tekton/tasks/source-container-set-results.yaml
+++ b/tekton/tasks/source-container-set-results.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: source-container-set-results-0-1  # dot is not allowed in the name
+spec:
+  description: >-
+    OSBS task for setting results for source container build
+  params:
+    - name: OSBS_IMAGE
+      description: The location of the OSBS builder image (FQDN pullspec)
+      type: string
+
+  workspaces:
+    - name: ws-context-dir
+
+  results:
+    - name: repositories
+    - name: koji-build-id
+
+  steps:
+    - name: source-container-set-results
+      image: $(params.OSBS_IMAGE)
+      resources:
+        requests:
+          memory: 300Mi
+          cpu: 250m
+        limits:
+          memory: 600Mi
+          cpu: 395m
+      script: |
+        jq -c '.annotations.repositories' $(workspaces.ws-context-dir.path)/workflow.json >$(results.repositories.path)
+        jq -c '.labels["koji-build-id"]' $(workspaces.ws-context-dir.path)/workflow.json >$(results.koji-build-id.path)


### PR DESCRIPTION
from workflow.json

* CLOUDBLD-8902

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
