### PR TITLE
Bump osbs-client ref

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -65,7 +65,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@0b9153cf2a5c0fb7d56f64dd9b0819e2da6b3968
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ jsonschema
 paramiko
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@0b9153cf2a5c0fb7d56f64dd9b0819e2da6b3968#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3a67d8a1b5e961cd35cbf9293ee98ea2bbd4ebb7
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@0b9153cf2a5c0fb7d56f64dd9b0819e2da6b3968
     # via -r requirements.in
 paramiko==2.9.2
     # via -r requirements.in


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
