### PR TITLE
Update group_manifests for Tekton

### DIFF
--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -384,11 +384,8 @@ OTHER_V2 = 'registry.example.com:5001'
      "Without grouping only one source is expected"),
     # Have to copy the manifest and link blobs from one repository to another
     ("tag_link_manifests",
-     True, False, [REGISTRY_V2],
+     False, False, [REGISTRY_V2],
      {
-         'ppc64le': {
-             REGISTRY_V2: ['worker-build:worker-build-ppc64le-latest'],
-         },
          'x86_64': {
              REGISTRY_V2: ['worker-build:worker-build-x86_64-latest'],
          }


### PR DESCRIPTION
CLOUDBLD-8263

Stop taking the manifest digests of built images from worker build
annotations. Instead, get the pullspecs of built images from tag_conf
and query the registry to find their manifest digests.

And other cleanups, see individual commits.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
