### PR TITLE
fix extension of image to .tar.gz

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -412,16 +412,14 @@ def get_exported_image_metadata(path, image_type):
     return metadata
 
 
-def get_image_upload_filename(metadata, image_id, platform):
-    saved_image = metadata.get('path')
-    image_type = metadata.get('type')
+def get_image_upload_filename(image_type, image_id, platform):
     if image_type == IMAGE_TYPE_DOCKER_ARCHIVE:
         base_name = 'docker-image'
     elif image_type == IMAGE_TYPE_OCI_TAR:
         base_name = 'oci-image'
     else:
         raise ValueError("Unhandled image type for upload: {}".format(image_type))
-    ext = saved_image.split('.', 1)[1]
+    ext = 'tar.gz'
     name_fmt = '{base_name}-{id}.{platform}.{ext}'
     return name_fmt.format(base_name=base_name, id=image_id,
                            platform=platform, ext=ext)

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -330,7 +330,7 @@ def get_buildroot():
     return buildroot
 
 
-def get_image_output(workflow, image_id, arch, pullspec):
+def get_image_output(image_type, image_id, arch, pullspec):
     """
     Create the output for the image
 
@@ -341,8 +341,7 @@ def get_image_output(workflow, image_id, arch, pullspec):
 
     """
     # OSBS2 TBD exported_image_sequence will not work for multiple platform
-    image_name = get_image_upload_filename(workflow.data.exported_image_sequence[-1],
-                                           image_id, arch)
+    image_name = get_image_upload_filename(image_type, image_id, arch)
 
     readme_content = ('Archive is just a placeholder for the koji archive, if you need the '
                       f'content you can use pullspec of the built image: {pullspec}')
@@ -502,7 +501,8 @@ def get_output(workflow, buildroot_id, pullspec, platform, source_build=False, l
     }
 
     tags = set(image.tag for image in workflow.data.tag_conf.images)
-    metadata, output = get_image_output(workflow, image_id, platform, pullspec)
+    metadata, output = get_image_output(workflow.data.exported_image_sequence[-1].get('type'),
+                                        image_id, platform, pullspec)
 
     metadata.update({
         'arch': arch,

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -396,7 +396,7 @@ def mock_environment(workflow, source_dir: Path, session=None, name=None, oci=Fa
 
     build_dir_path = workflow.build_dir.any_platform.path
 
-    image_tar = build_dir_path / 'image.tar.xz'
+    image_tar = build_dir_path / 'image.tar.gz'
     image_tar.write_text('x' * 2**12, "utf-8")
     setattr(workflow.data,
             'exported_image_sequence',
@@ -2427,7 +2427,7 @@ class TestKojiImport(object):
         build_id = runner.plugins_results[KojiImportSourceContainerPlugin.key]
         assert build_id == "123"
 
-        uploaded_oic_file = 'oci-image-{}.{}.tar.xz'.format(expect_id, os.uname()[4])
+        uploaded_oic_file = 'oci-image-{}.{}.tar.gz'.format(expect_id, os.uname()[4])
         assert set(session.uploaded_files.keys()) == {
             OSBS_BUILD_LOG_FILENAME,
             uploaded_oic_file,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -238,22 +238,17 @@ def test_get_hexdigests(tmpdir, content, algorithms, expected, write_to_file, sh
         assert checksums == expected
 
 
-@pytest.mark.parametrize('path, image_type, expected', [
-    ('foo.tar', IMAGE_TYPE_DOCKER_ARCHIVE, 'docker-image-XXX.x86_64.tar'),
-    ('foo.tar.gz', IMAGE_TYPE_DOCKER_ARCHIVE, 'docker-image-XXX.x86_64.tar.gz'),
-    ('foo.tar.gz', IMAGE_TYPE_OCI_TAR, 'oci-image-XXX.x86_64.tar.gz'),
-    ('foo', IMAGE_TYPE_OCI, None),
+@pytest.mark.parametrize('image_type, expected', [
+    (IMAGE_TYPE_DOCKER_ARCHIVE, 'docker-image-XXX.x86_64.tar.gz'),
+    (IMAGE_TYPE_OCI_TAR, 'oci-image-XXX.x86_64.tar.gz'),
+    (IMAGE_TYPE_OCI, None),
 ])
-def test_get_image_upload_filename(path, image_type, expected):
-    metadata = {
-        'path': path,
-        'type': image_type,
-    }
+def test_get_image_upload_filename(image_type, expected):
     if expected is None:
         with pytest.raises(ValueError):
-            get_image_upload_filename(metadata, 'XXX', 'x86_64')
+            get_image_upload_filename(image_type, 'XXX', 'x86_64')
     else:
-        assert get_image_upload_filename(metadata, 'XXX', 'x86_64') == expected
+        assert get_image_upload_filename(image_type, 'XXX', 'x86_64') == expected
 
 
 def test_get_versions_of_tools():


### PR DESCRIPTION
It should always be .tar.gz for image extension

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
