### PR TITLE
Add remote hosts to configmap

### DIFF
--- a/atomic_reactor/config.py
+++ b/atomic_reactor/config.py
@@ -161,6 +161,7 @@ class ReactorConfigKeys(object):
     CONTENT_VERSIONS_KEY = 'content_versions'
     REGISTRIES_ORGANIZATION_KEY = 'registries_organization'
     REGISTRIES_KEY = 'registries'
+    REMOTE_HOSTS_KEY = 'remote_hosts'
     YUM_PROXY_KEY = 'yum_proxy'
     SOURCE_REGISTRY_KEY = 'source_registry'
     PULL_REGISTRIES_KEY = 'pull_registries'
@@ -336,6 +337,10 @@ class Configuration(object):
                 raise RuntimeError("specify both koji_principal and koji_keytab or neither")
 
         return koji_map
+
+    @property
+    def remote_hosts(self):
+        return self._get_value(ReactorConfigKeys.REMOTE_HOSTS_KEY, fallback={})
 
     @property
     def koji_path_info(self):

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -122,6 +122,62 @@
         "additionalProperties": false,
         "required": ["hub_url", "root_url", "auth"]
     },
+    "remote_hosts": {
+        "description": "Remote-host instance",
+        "type": "object",
+        "properties": {
+            "slots_dir": {
+                "description": "Remote-host slots directory",
+                "type": "string"
+            },
+            "pools": {
+                "description": "Pool of Remote-hosts",
+                "type": "object",
+                "patternProperties": {
+                    "^[a-zA-Z0-9_]+$": {
+                        "description": "Remote host platforms",
+                        "type": "object",
+                        "patternProperties": {
+                            "^[a-zA-Z0-9_.-]+$": {
+                                "description": "Platform specific hosts",
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "description": "User name used to SSH to host",
+                                        "type": "string"
+                                    },
+                                    "auth": {
+                                        "description": "File path to SSH private key to access host",
+                                        "type": "string"
+                                    },
+                                    "enabled": {
+                                        "description": "Whether this host can be used",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "slots": {
+                                        "description": "Available slots on host",
+                                        "type": "integer",
+                                        "minimum": 0
+                                    },
+                                    "socket_path": {
+                                        "description": "User podman socket path",
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "required": ["username", "auth", "enabled", "slots", "socket_path"]
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+               "additionalProperties": false
+            }
+        },
+        "additionalProperties": false,
+        "required": ["slots_dir", "pools"]
+    },
     "pnc": {
         "description": "Project Newcastle instance",
         "type": "object",


### PR DESCRIPTION
Update the reactor-config-map schema, Configuration object and add a remote hosts property.

CLOUDBLD-8995

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
