### PR TITLE
push oci image as v2s2

### DIFF
--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -86,6 +86,7 @@ class TagAndPushPlugin(PostBuildPlugin):
 
             if image['type'] == IMAGE_TYPE_OCI:
                 source_img = 'oci:{path}:{ref_name}'.format(**image)
+                cmd.append('--format=v2s2')
             elif image['type'] == IMAGE_TYPE_DOCKER_ARCHIVE:
                 source_img = 'docker-archive://{path}'.format(**image)
             else:

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -501,6 +501,7 @@ def test_tag_and_push_plugin_oci(workflow, tmpdir, monkeypatch,
         else:
             assert args[-2] == 'oci:' + oci_dir + ':' + REF_NAME
             assert args[-1] == 'docker://' + LOCALHOST_REGISTRY + '/' + TEST_IMAGE_NAME
+            assert '--format=v2s2' in args
         return ''
 
     (flexmock(retries)


### PR DESCRIPTION
quay.io started supporting oci images, but RH doesn't support OCI images

* CLOUDBLD-8942

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
