### PR TITLE
Add tox to test container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.egg-info/
 .eggs/
 build/
+*~
 
 # Unit test / coverage reports
 .cache
@@ -11,3 +12,4 @@ build/
 .coverage.*
 htmlcov
 __pytest_reports
+.tox/

--- a/README.md
+++ b/README.md
@@ -74,6 +74,30 @@ missing C libraries in the Dockerfile(s) as well as the test.sh script
 - [Dockerfile](Dockerfile)
 - [test.sh](test.sh)
 
+## Running tests
+
+The prerequisite of running tests is to create a test environment container by
+`test.sh`. For example:
+
+```bash
+OS=fedora OS_VERSION=35 PYTHON_VERSION=3 ACTION=test ./test.sh
+```
+
+When the container is ready and running, you have choice to test your changes
+by executing `pytest` directly:
+
+```bash
+podman exec -it atomic-reactor-fedora-35-py3 python3 -m pytest tests/
+```
+
+or by `tox`:
+
+```bash
+podman exec -it atomic-reactor-fedora-35-py3 tox -e test
+```
+
+The `tox.ini` has defined several testenvs, use `tox -l` to check them.
+
 ## Usage
 
 If you would like to build your images within build containers, you need to

--- a/test.sh
+++ b/test.sh
@@ -89,6 +89,7 @@ function setup_osbs() {
 
   # Pip install packages for unit tests
   $RUN "${PIP_INST[@]}" -r tests/requirements.txt
+  $RUN "${PIP_INST[@]}" tox
 }
 
 case ${ACTION} in

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+envlist = test,flake8,pylint,bandit,mypy
+
+[testenv]
+basepython=python3
+skip_install = true
+
+[testenv:test]
+sitepackages = true
+commands = python3 -m pytest --cov=atomic_reactor {posargs:"tests"}
+
+[testenv:pylint]
+deps = pylint==2.9.6
+commands = python3 -m pylint atomic_reactor tests
+
+[testenv:flake8]
+deps = flake8
+commands = python3 -m flake8 atomic_reactor tests
+
+[testenv:bandit]
+deps = bandit
+commands = bandit-baseline -r atomic_reactor -ll -ii
+
+[testenv:mypy]
+deps = mypy==0.910
+commands =
+    mypy \
+        --install-types \
+        --non-interactive \
+        --ignore-missing-imports \
+        --package {posargs:"atomic_reactor"}


### PR DESCRIPTION
With this patch, I can easily run various tests with a simple tox
command instead of repeating `python3 -m pytest ...', `python3 -m
pylint' and other checks. Meanwhile, the tox.ini also includes flake8
and mypy, which I used frequently before creating a pull request.

Hope this is also helpful for you.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
