### PR TITLE
Annotate type of Plugin workflow argument

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -22,10 +22,13 @@ import time
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Generator
+from typing import Any, Dict, Generator, TYPE_CHECKING
 
 from atomic_reactor.util import exception_message
 from dockerfile_parse import DockerfileParser
+
+if TYPE_CHECKING:
+    from atomic_reactor.inner import DockerBuildWorkflow
 
 MODULE_EXTENSIONS = ('.py', '.pyc', '.pyo')
 logger = logging.getLogger(__name__)
@@ -112,7 +115,7 @@ class BuildPlugin(Plugin):
     flavored with BuildWorkflow instances
     """
 
-    def __init__(self, workflow, *args, **kwargs):
+    def __init__(self, workflow: "DockerBuildWorkflow", *args, **kwargs):
         """
         constructor
 

--- a/atomic_reactor/plugins/pre_bump_release.py
+++ b/atomic_reactor/plugins/pre_bump_release.py
@@ -77,7 +77,7 @@ class BumpReleasePlugin(PreBuildPlugin):
         """Get next release for build."""
         if is_scratch_build(self.workflow):
             # no need to append for scratch build
-            next_release = self.workflow.user_params.get('pipeline_run_name')
+            next_release = self.workflow.user_params['pipeline_run_name']
         elif self.append:
             next_release = self.get_next_release_append(component, version, release)
         else:

--- a/atomic_reactor/plugins/pre_check_base_image.py
+++ b/atomic_reactor/plugins/pre_check_base_image.py
@@ -127,7 +127,8 @@ class CheckBaseImagePlugin(PreBuildPlugin):
             # image tag may have been replaced with a ref for autorebuild; use original tag
             # to simplify fetching parent_images_digests data in other plugins
             image = image.copy()
-            image.tag = self.workflow.data.dockerfile_images.base_image_key.tag
+            base_image_key: ImageName = self.workflow.data.dockerfile_images.base_image_key
+            image.tag = base_image_key.tag
             image_str = image.to_str()
 
         self.workflow.data.parent_images_digests[image_str] = parent_digests


### PR DESCRIPTION
By adding this type annotation, it will make code edit tools, like IDE
or LSP backend, happy and be easy to navigate to the related
symbols.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
