### PR TITLE
Log the stderr if mkdir -p slots_dir fails

### DIFF
--- a/atomic_reactor/utils/remote_host.py
+++ b/atomic_reactor/utils/remote_host.py
@@ -328,12 +328,12 @@ class RemoteHost:
     def is_operational(self) -> bool:
         """ Check whether this host is operational """
         try:
-            _, _, code = self._run(f"mkdir -p {quote(self.slots_dir)}")
+            _, stderr, code = self._run(f"mkdir -p {quote(self.slots_dir)}")
         except Exception as e:
             logger.exception("%s: host is not operational: %s", self.hostname, e)
             return False
         if code != 0:
-            logger.error("%s: cannot prepare slots directory", self.hostname)
+            logger.error("%s: cannot prepare slots directory:\n%s", self.hostname, stderr)
             return False
         return True
 

--- a/tests/utils/test_remote_host.py
+++ b/tests/utils/test_remote_host.py
@@ -90,7 +90,7 @@ def make_flock_ssh_result(
     ("", 0, True),
     ("mkdir: cannot create directory: ... permission denied", 1, False),
 ))
-def test_host_is_operational(mkdir_stderr, mkdir_code, expected_result):
+def test_host_is_operational(mkdir_stderr, mkdir_code, expected_result, caplog):
     host = RemoteHost(hostname="remote-host-001", username="builder",
                       ssh_keyfile="/path/to/key", slots=3)
 
@@ -106,7 +106,11 @@ def test_host_is_operational(mkdir_stderr, mkdir_code, expected_result):
         .replace_with(mocked_command)
     )
 
-    assert host.is_operational is expected_result
+    operational = host.is_operational
+    assert operational is expected_result
+
+    if not operational:
+        assert mkdir_stderr in caplog.text
 
 
 @pytest.mark.disable_autouse


### PR DESCRIPTION
It is useful to see the exact error rather than just a generic message.

Example:

... ERROR - osbs-remote-host-x86-64-1...: cannot prepare slots directory:
Could not chdir to home directory /home/osbs-podman-dev: No such file or directory
mkdir: cannot create directory '/run/user/2022': Permission denied

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
