### PR TITLE
Implement the build task

### DIFF
--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -73,7 +73,9 @@ class BinaryBuildTask(Task[BinaryBuildTaskParams]):
                 logger.info, "Dockerfile used for build:\n%s", build_dir.dockerfile_path.read_text()
             )
 
-            output_lines = self.build_container(
+            podman_remote = PodmanRemote()
+
+            output_lines = podman_remote.build_container(
                 build_dir=build_dir,
                 build_args=data.buildargs,
                 dest_tag=dest_tag,
@@ -82,7 +84,11 @@ class BinaryBuildTask(Task[BinaryBuildTaskParams]):
                 logger.info(line.rstrip())
 
             logger.info("Build finished succesfully! Pushing image to %s", dest_tag)
-            self.push_container(dest_tag, registry_config=config.registry)
+            podman_remote.push_container(dest_tag, registry_config=config.registry)
+
+
+class PodmanRemote:
+    """Wrapper for running podman --remote commands on a remote host."""
 
     def build_container(
         self,

--- a/atomic_reactor/utils/remote_host.py
+++ b/atomic_reactor/utils/remote_host.py
@@ -150,6 +150,7 @@ class RemoteHost:
         username: str,
         ssh_keyfile: str,
         slots: int,
+        socket_path: str,
         slots_dir: Optional[str] = None,
     ):
         """ Instantiate RemoteHost with hostname, username, ssh key file and slot number
@@ -158,32 +159,38 @@ class RemoteHost:
         :param username: str, username for ssh connection
         :param ssh_keyfile: str, filepath to ssh private key
         :param slots: int, number of max allowed slots on remote host
+        :param socket_path: str, path to the podman socket on this host
         :param slots_dir: str, directory path for holding slots files
         """
         self._hostname = hostname
         self._username = username
         self._ssh_keyfile = ssh_keyfile
         self._slots = slots
+        self._socket_path = socket_path
         self._slots_dir = slots_dir
 
     @property
-    def hostname(self):
+    def hostname(self) -> str:
         return self._hostname
 
     @property
-    def username(self):
+    def username(self) -> str:
         return self._username
 
     @property
-    def ssh_keyfile(self):
+    def ssh_keyfile(self) -> str:
         return self._ssh_keyfile
 
     @property
-    def slots(self):
+    def slots(self) -> int:
         return self._slots
 
+    @property
+    def socket_path(self) -> str:
+        return self._socket_path
+
     @cached_property
-    def slots_dir(self):
+    def slots_dir(self) -> str:
         # Place the slots files under `~/$SLOTS_RELATIVE_PATH` when slots_dir is not specified
         if self._slots_dir is None:
             home, _, _ = self._run("pwd")
@@ -617,7 +624,7 @@ class RemoteHostsPool:
                 continue
             host = RemoteHost(
                 hostname=hostname, username=attr["username"], ssh_keyfile=attr["auth"],
-                slots=attr.get("slots", 1), slots_dir=slots_dir
+                slots=attr.get("slots", 1), socket_path=attr["socket_path"], slots_dir=slots_dir
             )
             # Check whether host is operational before use it
             if host.is_operational:


### PR DESCRIPTION
CLOUDBLD-8136

In the build task, acquire a slot on a remote host. Make sure to unlock
this slot after the build ends.

Run an actual build on the acquired remote host.

...and more fixes, see individual commits

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
