### PR TITLE
Push built image as docker v2s2

### DIFF
--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -186,7 +186,8 @@ class PodmanRemote:
         Pass the specified build arguments as ARG values using --build-arg.
 
         The built image will be available locally on the machine that built it, tagged with
-        the specified dest_tag.
+        the specified dest_tag. This method does not specify the format of the built image
+        (nor does the format really matter), but podman will typically default to 'oci'.
 
         This method returns an iterator which yields individual lines from the stdout
         and stderr of the build process as they become available.
@@ -240,10 +241,12 @@ class PodmanRemote:
     def push_container(self, dest_tag: ImageName, *, insecure: bool = False) -> None:
         """Push the built container (named dest_tag) to the registry (as dest_tag).
 
+        Push the container as v2s2 (Docker v2 schema 2) regardless of the original format.
+
         :param dest_tag: the name of the built container, and the destination for the push
         :param insecure: disable --tls-verify?
         """
-        push_cmd = [*self._podman_remote_cmd, "push", str(dest_tag)]
+        push_cmd = [*self._podman_remote_cmd, "push", str(dest_tag), "--format=v2s2"]
         if self._registries_authfile:
             push_cmd.append(f"--authfile={self._registries_authfile}")
         if insecure:

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -374,10 +374,10 @@ class TestPodmanRemote:
             "system",
             "connection",
             "add",
-            PIPELINE_RUN_NAME,
-            "ssh://osbs-podman-dev@osbs-remote-host-x86-64-1.example.com",
             "--identity=/workspace/ws-remote-host-auth/remote-host-auth",
             "--socket-path=/run/user/2022/podman/podman.sock",
+            PIPELINE_RUN_NAME,
+            "ssh://osbs-podman-dev@osbs-remote-host-x86-64-1.example.com",
         ]
         (
             flexmock(subprocess)
@@ -411,14 +411,14 @@ class TestPodmanRemote:
             "--connection=connection-name",
             "build",
             f"--tag={X86_UNIQUE_IMAGE}",
-            str(x86_build_dir.path),
             "--no-cache",
             "--pull-always",
             "--squash",
             "--build-arg=REMOTE_SOURCES=unpacked_remote_sources",
+            str(x86_build_dir.path),
         ]
         if authfile:
-            expect_cmd.append(f"--authfile={authfile}")
+            expect_cmd.insert(-1, f"--authfile={authfile}")
 
         mock_popen(0, ["starting the build\n", "finished successfully\n"], expect_cmd=expect_cmd)
 
@@ -466,13 +466,13 @@ class TestPodmanRemote:
             "--remote",
             "--connection=connection-name",
             "push",
-            str(X86_UNIQUE_IMAGE),
             "--format=v2s2",
+            str(X86_UNIQUE_IMAGE),
         ]
         if authfile:
-            expect_cmd.append(f"--authfile={authfile}")
+            expect_cmd.insert(-1, f"--authfile={authfile}")
         if insecure:
-            expect_cmd.append("--tls-verify=false")
+            expect_cmd.insert(-1, "--tls-verify=false")
 
         flexmock(retries).should_receive("run_cmd").with_args(expect_cmd).once()
 

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -467,6 +467,7 @@ class TestPodmanRemote:
             "--connection=connection-name",
             "push",
             str(X86_UNIQUE_IMAGE),
+            "--format=v2s2",
         ]
         if authfile:
             expect_cmd.append(f"--authfile={authfile}")


### PR DESCRIPTION
CLOUDBLD-8136

By default, the podman build command uses the oci format. The podman
push command defaults to the format of the built image.

Explicitly specify v2s2, because some parts of the RH container pipeline
do not support oci yet.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
