### PR TITLE
Convert flatpak_create_oci to postbuild

### DIFF
--- a/atomic_reactor/plugins/post_flatpak_create_oci.py
+++ b/atomic_reactor/plugins/post_flatpak_create_oci.py
@@ -16,7 +16,7 @@ import subprocess
 from flatpak_module_tools.flatpak_builder import FlatpakBuilder, FLATPAK_METADATA_ANNOTATIONS
 
 from atomic_reactor.constants import IMAGE_TYPE_OCI, IMAGE_TYPE_OCI_TAR
-from atomic_reactor.plugin import PrePublishPlugin
+from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.pre_flatpak_update_dockerfile import get_flatpak_source_info
 from atomic_reactor.utils import retries
 from atomic_reactor.utils.rpm import parse_rpm_output
@@ -59,7 +59,7 @@ class StreamAdapter(object):
         pass
 
 
-class FlatpakCreateOciPlugin(PrePublishPlugin):
+class FlatpakCreateOciPlugin(PostBuildPlugin):
     key = 'flatpak_create_oci'
     is_allowed_to_fail = False
 

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -25,14 +25,14 @@ from atomic_reactor.constants import (
     IMAGE_TYPE_OCI_TAR,
     SUBPROCESS_MAX_RETRIES,
 )
-from atomic_reactor.plugin import PrePublishPluginsRunner, PluginFailedException
+from atomic_reactor.plugin import PostBuildPluginsRunner, PluginFailedException
 from osbs.utils import ImageName
 
 from tests.flatpak import (MODULEMD_AVAILABLE,
                            setup_flatpak_source_info, build_flatpak_test_configs)
 
 if MODULEMD_AVAILABLE:
-    from atomic_reactor.plugins.prepub_flatpak_create_oci import FlatpakCreateOciPlugin
+    from atomic_reactor.plugins.post_flatpak_create_oci import FlatpakCreateOciPlugin
     from gi.repository import Modulemd
 
 CONTAINER_ID = 'CONTAINER-ID'
@@ -574,7 +574,7 @@ def test_flatpak_create_oci(workflow, source_dir, config_name, flatpak_metadata,
 
     setup_flatpak_source_info(workflow, config)
 
-    runner = PrePublishPluginsRunner(
+    runner = PostBuildPluginsRunner(
         workflow,
         [{
             'name': FlatpakCreateOciPlugin.key,
@@ -681,7 +681,7 @@ def test_flatpak_create_oci(workflow, source_dir, config_name, flatpak_metadata,
 @pytest.mark.skipif(not MODULEMD_AVAILABLE,  # noqa
                     reason="libmodulemd not available")
 def test_skip_plugin(workflow, caplog):
-    runner = PrePublishPluginsRunner(
+    runner = PostBuildPluginsRunner(
         workflow,
         [{
             'name': FlatpakCreateOciPlugin.key,


### PR DESCRIPTION
The plugin is referenced in tasks.binary.BinaryPostBuildTask as a
postbuild plugin. Because the plugin is currently defined as prepublish,
the postbuild task cannot find it and fails immediately. Convert the
plugin to a postbuild one.

This is just to unblock testing, the plugin still doesn't work at all
but at least it will not block non-flatpak builds now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
