### PR TITLE
squash all layers for flatpak builds

### DIFF
--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -237,9 +237,10 @@ class TestBinaryBuildTask:
         assert "Platform aarch64 is not enabled for this build" in caplog.text
 
     @pytest.mark.parametrize('fail_image_size_check', (True, False))
+    @pytest.mark.parametrize('is_flatpak', (True, False))
     def test_run_build(
         self, x86_task_params, x86_build_dir, mock_podman_remote, mock_locked_resource, caplog,
-            fail_image_size_check
+            fail_image_size_check, is_flatpak
     ):
         mock_workflow_data(enabled_platforms=["x86_64"])
         if fail_image_size_check:
@@ -248,11 +249,12 @@ class TestBinaryBuildTask:
             mock_config(REGISTRY_CONFIG, REMOTE_HOST_CONFIG, image_size_limit=1234)
         x86_build_dir.dockerfile_path.write_text(DOCKERFILE_CONTENT)
 
-        def mock_build_container(*, build_dir, build_args, dest_tag):
+        def mock_build_container(*, build_dir, build_args, dest_tag, squash_all):
             assert build_dir.path == x86_build_dir.path
             assert build_dir.platform == "x86_64"
             assert build_args == BUILD_ARGS
             assert dest_tag == X86_UNIQUE_IMAGE
+            assert squash_all == is_flatpak
 
             yield from ["output line 1", "output line 2"]
 
@@ -277,6 +279,8 @@ class TestBinaryBuildTask:
         )
 
         flexmock(mock_locked_resource).should_receive("unlock").once()
+
+        x86_task_params.user_params['flatpak'] = is_flatpak
 
         task = BinaryBuildTask(x86_task_params)
         if fail_image_size_check:
@@ -438,21 +442,29 @@ class TestPodmanRemote:
             PodmanRemote.setup_for(X86_LOCKED_RESOURCE)
 
     @pytest.mark.parametrize("authfile", [None, AUTHFILE_PATH])
-    def test_build_container(self, authfile, x86_build_dir):
+    @pytest.mark.parametrize('is_flatpak', (True, False))
+    def test_build_container(self, authfile, is_flatpak, x86_build_dir):
+        options = [
+            f"--tag={X86_UNIQUE_IMAGE}",
+            "--no-cache",
+            "--pull-always",
+        ]
+        if is_flatpak:
+            options.append("--squash-all")
+        else:
+            options.append("--squash")
+        options.append("--build-arg=REMOTE_SOURCES=unpacked_remote_sources")
+        if authfile:
+            options.append(f"--authfile={authfile}")
+
         expect_cmd = [
             "/usr/bin/podman",
             "--remote",
             "--connection=connection-name",
             "build",
-            f"--tag={X86_UNIQUE_IMAGE}",
-            "--no-cache",
-            "--pull-always",
-            "--squash",
-            "--build-arg=REMOTE_SOURCES=unpacked_remote_sources",
+            *options,
             str(x86_build_dir.path),
         ]
-        if authfile:
-            expect_cmd.insert(-1, f"--authfile={authfile}")
 
         mock_popen(0, ["starting the build\n", "finished successfully\n"], expect_cmd=expect_cmd)
 
@@ -461,6 +473,7 @@ class TestPodmanRemote:
             build_dir=x86_build_dir,
             build_args=BUILD_ARGS,
             dest_tag=X86_UNIQUE_IMAGE,
+            squash_all=is_flatpak
         )
 
         assert list(output_lines) == ["starting the build\n", "finished successfully\n"]
@@ -482,6 +495,7 @@ class TestPodmanRemote:
             build_dir=x86_build_dir,
             build_args=BUILD_ARGS,
             dest_tag=X86_UNIQUE_IMAGE,
+            squash_all=False,
         )
 
         for expect_line in output_lines:


### PR DESCRIPTION
* CLOUDBLD-8138

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
