### PR TITLE
Update paramiko version

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -69,7 +69,7 @@ osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@ab8a5e5cd9
     # via -r requirements.in
 packaging==21.2
     # via pytest
-paramiko==2.9.2
+paramiko==2.10.3
     # via -r requirements.in
 pep8==1.7.1
     # via -r requirements-devel.in
@@ -149,6 +149,7 @@ six==1.16.0
     #   dockerfile-parse
     #   koji
     #   osbs-client
+    #   paramiko
     #   python-dateutil
     #   requests-mock
     #   responses

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ dockerfile-parse>=0.0.13
 flatpak-module-tools >= 0.11,!=0.13,<=0.13.1;python_version<"3.9"
 flatpak-module-tools >= 0.11;python_version>="3.9"
 jsonschema
-paramiko
+paramiko>=2.10.1
 PyYAML
 ruamel.yaml
 git+https://github.com/containerbuildsystem/osbs-client@ab8a5e5cd97911cd5a37b0d49f2d4ecf1083ddd4#egg=osbs-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ krb5==0.2.0
     # via pyspnego
 osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@ab8a5e5cd97911cd5a37b0d49f2d4ecf1083ddd4
     # via -r requirements.in
-paramiko==2.9.2
+paramiko==2.10.3
     # via -r requirements.in
 pycairo==1.20.1
     # via pygobject
@@ -101,6 +101,7 @@ six==1.16.0
     #   dockerfile-parse
     #   koji
     #   osbs-client
+    #   paramiko
     #   python-dateutil
 urllib3==1.26.7
     # via requests


### PR DESCRIPTION
Manually update paramiko versio because dependabot PR failed

In Paramiko before 2.10.1, a race condition (between creation and chmod) in the write_private_key_file function could allow unauthorized information disclosure.

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
