### PR TITLE
Continue updating metadata plugins

### DIFF
--- a/atomic_reactor/plugins/post_koji_import.py
+++ b/atomic_reactor/plugins/post_koji_import.py
@@ -22,7 +22,6 @@ from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import PostBuildPlugin
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
 from atomic_reactor.source import GitSource
-from atomic_reactor.plugins.build_orchestrate_build import get_worker_build_info
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
 from atomic_reactor.util import (OSBSLogs, get_parent_image_koji_data, get_manifest_media_version,
                                  get_platforms, is_manifest_list, map_to_user_params)
@@ -67,7 +66,7 @@ from atomic_reactor.util import (Output,
                                  get_primary_images,
                                  get_floating_images, get_unique_images,
                                  get_manifest_media_type,
-                                 get_digests_map_from_annotations, is_scratch_build,
+                                 is_scratch_build,
                                  has_operator_bundle_manifest,
                                  has_operator_appregistry_manifest,
                                  )
@@ -384,14 +383,6 @@ class KojiImportBase(PostBuildPlugin):
 
                 instance['extra']['docker']['repositories'] = repositories
                 self.log.debug("reset tags to so that docker is %s", instance['extra']['docker'])
-                # OSBS2 TBD: `get_worker_build_info` is imported from
-                # build_orchestrate_build
-                annotations = get_worker_build_info(self.workflow, platform).build.get_annotations()
-
-                digests = {}
-                if 'digests' in annotations:
-                    digests = get_digests_map_from_annotations(annotations['digests'])
-                    instance['extra']['docker']['digests'] = digests
 
     def _update_extra(self, extra):
         # Must be implemented by subclasses

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1046,17 +1046,6 @@ def get_manifest_media_version(digest):
     return found_version
 
 
-def get_digests_map_from_annotations(digests_str):
-    digests = {}
-    digests_annotations = json.loads(digests_str)
-    for digest_annotation in digests_annotations:
-        digest_version = digest_annotation['version']
-        digest = digest_annotation['digest']
-        media_type = get_manifest_media_type(digest_version)
-        digests[media_type] = digest
-    return digests
-
-
 def query_registry(
     registry_session, image: ImageName, digest=None, version='v1', is_blob=False
 ) -> requests.Response:

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1224,7 +1224,12 @@ def get_inspect_for_image(image, registry, insecure=False, dockercfg_path=None, 
 
 
 def get_config_and_id_from_registry(
-    image, registry, digest: str, insecure=False, dockercfg_path=None, version='v2'
+    image: ImageName,
+    registry: str,
+    digest: str,
+    insecure: bool = False,
+    dockercfg_path: Optional[str] = None,
+    version: str = 'v2',
 ) -> Tuple[Dict, str]:
     """Return image config by digest
 
@@ -1236,7 +1241,7 @@ def get_config_and_id_from_registry(
     :param dockercfg_path: str, dirname of .dockercfg location
     :param version: str, which manifest schema versions to fetch digest
 
-    :return: dict, versions mapped to their digest
+    :return: tuple, (image config, config digest)
     """
     registry_session = RegistrySession(registry, insecure=insecure, dockercfg_path=dockercfg_path)
     registry_client = RegistryClient(registry_session)

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -462,6 +462,7 @@ def get_output(workflow: DockerBuildWorkflow,
 
     extra_output_file = None
     output_files: List[Output] = []
+    image_id: str
 
     if source_build:
         manifest = workflow.data.koji_source_manifest
@@ -476,15 +477,15 @@ def get_output(workflow: DockerBuildWorkflow,
         output_files = [add_log_type(add_buildroot_id(metadata), platform)
                         for metadata in logs or []]
 
-        # Parent of squashed built image is base image
-        # OSBS2 TBD
-        image_id = workflow.data.image_id
+        imageutil = workflow.imageutil
+        image_id = imageutil.get_inspect_for_image(pullspec, platform=platform)['Id']
+
         parent_id = None
         if not workflow.data.dockerfile_images.base_from_scratch:
-            parent_id = workflow.imageutil.base_image_inspect(platform)['Id']
+            parent_id = imageutil.base_image_inspect(platform)['Id']
 
         image_archive = str(workflow.build_dir.platform_dir(platform).exported_squashed_image)
-        layer_sizes = workflow.imageutil.get_uncompressed_image_layer_sizes(image_archive)
+        layer_sizes = imageutil.get_uncompressed_image_layer_sizes(image_archive)
 
     digests = get_manifest_digests(pullspec, workflow.conf.registry['uri'],
                                    workflow.conf.registry['insecure'],

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -515,13 +515,15 @@ def get_output(workflow: DockerBuildWorkflow,
         if version != "v1"
     }
 
+    tag_conf = workflow.data.tag_conf
     if source_build:
         image_type = IMAGE_TYPE_DOCKER_ARCHIVE
+        tags = sorted(set(image.tag for image in tag_conf.images))
     else:
         image_metadatas = workflow.data.postbuild_results[FetchDockerArchivePlugin.key]
         image_type = image_metadatas[platform]["type"]
+        tags = sorted(image.tag for image in tag_conf.get_unique_images_with_platform(platform))
 
-    tags = set(image.tag for image in workflow.data.tag_conf.images)
     metadata, output = get_image_output(image_type, image_id, platform, pullspec)
 
     metadata.update({
@@ -536,7 +538,7 @@ def get_output(workflow: DockerBuildWorkflow,
                 'id': image_id,
                 'repositories': repositories,
                 'layer_sizes': layer_sizes,
-                'tags': list(tags),
+                'tags': tags,
                 'config': config,
                 'digests': typed_digests,
             },


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
