### PR TITLE
initialize build_dir for post build plugins in plugin_based execute

### DIFF
--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -71,7 +71,7 @@ def binary_container_postbuild(task_args: dict):
     """
     params = TaskParams.from_cli_args(task_args)
     task = BinaryPostBuildTask(params)
-    return task.execute()
+    return task.execute(init_build_dirs=True)
 
 
 def binary_container_exit(task_args: dict):

--- a/atomic_reactor/tasks/plugin_based.py
+++ b/atomic_reactor/tasks/plugin_based.py
@@ -7,10 +7,12 @@ of the BSD license. See the LICENSE file for details.
 """
 
 import logging
+from typing import Optional
 
 from atomic_reactor import inner
 from atomic_reactor.tasks import PluginsDef
 from atomic_reactor.tasks.common import Task, ParamsT
+from atomic_reactor.util import get_platforms
 
 
 # PluginsDef can be considered as part of this module, but is defined elsewhere to avoid cyclic
@@ -40,9 +42,16 @@ class PluginBasedTask(Task[ParamsT]):
         )
         return workflow
 
-    def execute(self):
-        """Execute the plugins defined in plugins_def."""
+    def execute(self, init_build_dirs: Optional[bool] = False):
+        """Execute the plugins defined in plugins_def.
+
+        :param init_build_dirs: bool, whether to initialize build dirs
+        :return: None
+        """
         workflow = self.prepare_workflow()
+
+        if init_build_dirs:
+            workflow.build_dir.init_build_dirs(get_platforms(workflow.data), workflow.source)
 
         try:
             workflow.build_docker_image()

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -25,7 +25,7 @@ TASK_ARGS = {
 TASK_RESULT = object()
 
 
-def mock(task_cls):
+def mock(task_cls, init_build_dirs=False):
     params = flexmock()
     (
         #  mock the common TaskParams because child classes do not override from_cli_args
@@ -35,7 +35,13 @@ def mock(task_cls):
         .and_return(params)
     )
     flexmock(task_cls).should_receive("__init__").with_args(params)
-    flexmock(task_cls).should_receive("execute").and_return(TASK_RESULT)
+    if init_build_dirs:
+        (flexmock(task_cls)
+         .should_receive("execute")
+         .with_args(init_build_dirs=True)
+         .and_return(TASK_RESULT))
+    else:
+        flexmock(task_cls).should_receive("execute").and_return(TASK_RESULT)
 
 
 def test_source_build():
@@ -54,7 +60,7 @@ def test_binary_container_build():
 
 
 def test_binary_container_postbuild():
-    mock(binary.BinaryPostBuildTask)
+    mock(binary.BinaryPostBuildTask, init_build_dirs=True)
     assert task.binary_container_postbuild(TASK_ARGS) == TASK_RESULT
 
 


### PR DESCRIPTION
which is first postbuild plugin

* CLOUDBLD-9425

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
