### PR TITLE
Drop build-host label, log the build host instead

### DIFF
--- a/atomic_reactor/plugins/pre_add_labels_in_df.py
+++ b/atomic_reactor/plugins/pre_add_labels_in_df.py
@@ -81,8 +81,7 @@ class AddLabelsPlugin(PreBuildPlugin):
                  auto_labels=("build-date",
                               "architecture",
                               "vcs-type",
-                              "vcs-ref",
-                              "com.redhat.build-host"),
+                              "vcs-ref"),
                  aliases=None,
                  dont_overwrite_if_in_dockerfile=("distribution-scope",
                                                   "com.redhat.license_terms")):
@@ -137,13 +136,7 @@ class AddLabelsPlugin(PreBuildPlugin):
         # build date
         dt = datetime.datetime.utcfromtimestamp(atomic_reactor_start_time)
 
-        generated = {
-            'build-date': dt.isoformat(),
-            'architecture': platform,
-            # OSBS2 TBD: the build-host label will either be dropped or will require
-            #   extra logic in the build task implementation
-            # 'com.redhat.build-host': <not yet known>,
-        }
+        generated = {'build-date': dt.isoformat(), 'architecture': platform}
 
         # VCS info
         vcs = self.workflow.source.get_vcs_info()

--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -95,6 +95,9 @@ class BinaryBuildTask(Task[BinaryBuildTaskParams]):
                 remote_resource, registries_authfile=get_authfile_path(config.registry)
             )
 
+            # log the image+host for auditing purposes
+            logger.info("Building image=%s on host=%s", dest_tag, remote_resource.host.hostname)
+
             output_lines = podman_remote.build_container(
                 build_dir=build_dir,
                 build_args=data.buildargs,

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -158,7 +158,7 @@ containing the Dockerfile.
   - Labels that are specified in the builder configuration, such as the vendor
     name, distribution scope, and authoritative registry, are added to the
     Dockerfile using LABEL. This plugin also adds automatic labels such as the
-    build date, architecture, build host, info url, and git reference.
+    build date, architecture, info url, and git reference.
 - **change_from_in_dockerfile**
   - Status: Enabled
   - The FROM line in the Dockerfile is changed so that it references the


### PR DESCRIPTION
CLOUDBLD-8832

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
