### PR TITLE
Fix conversion of config blob to inspect format

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1453,9 +1453,7 @@ def test_get_all_manifests(tmpdir, image, registry, insecure, creds, path, versi
 MOCK_INSPECT_DATA = {
     'created': 'create_time',
     'os': 'os version',
-    'container_config': 'container config',
     'architecture': 'arch',
-    'docker_version': 'docker version',
     'config': 'conf',
     'rootfs': {'type': 'layers', 'diff_ids': ['sha256:123456', 'sha256:abcdef']}
 }
@@ -1464,9 +1462,7 @@ MOCK_CONFIG_DIGEST = '987654321'
 MOCK_EXPECT_INSPECT = {
     'Created': 'create_time',
     'Os': 'os version',
-    'ContainerConfig': 'container config',
     'Architecture': 'arch',
-    'DockerVersion': 'docker version',
     'Config': 'conf',
     'RootFS': {'Type': 'layers', 'Layers': ['sha256:123456', 'sha256:abcdef']},
     'Id': MOCK_CONFIG_DIGEST


### PR DESCRIPTION
CLOUDBLD-9746

The container_config and docker_version keys are docker-specific. Now
that we have moved to building with podman, we should not try to use
them anymore.

Use the OCI spec [1] as reference, handle the keys accordingly.

Note: this spec is for the OCI config, not the Docker config, but it
aims to be compatible with the Docker format and it is a better formal
specification than the non-existent Docker one.

[1]: https://github.com/opencontainers/image-spec/blob/main/config.md#properties

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
