### PR TITLE
Fix manifest querying logic in group_manifest

### DIFF
--- a/atomic_reactor/plugins/post_group_manifests.py
+++ b/atomic_reactor/plugins/post_group_manifests.py
@@ -85,7 +85,7 @@ class GroupManifestsPlugin(PostBuildPlugin):
             # At this point, only the unique image has been built and pushed. Primary tags will
             #   be pushed by this plugin, floating tags by the push_floating_tags plugin.
             image = tag_conf.get_unique_images_with_platform(platform)[0]
-            manifest_digests = client.get_manifest_digests(image)
+            manifest_digests = client.get_manifest_digests(image, versions=("v2", "oci"))
 
             if len(manifest_digests) != 1:
                 raise RuntimeError(

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -601,7 +601,7 @@ def test_get_built_images_multiple_manifest_types(workflow):
     (
         flexmock(RegistryClient)
         .should_receive("get_manifest_digests")
-        .with_args(ImageName.parse(f"{UNIQUE_IMAGE}-x86_64"))
+        .with_args(ImageName.parse(f"{UNIQUE_IMAGE}-x86_64"), versions=("v2", "oci"))
         .and_return(ManifestDigest({"v2": make_digest("foo"), "oci": make_digest("bar")}))
     )
 


### PR DESCRIPTION
CLOUDBLD-8263

The code currently assumes that the built image must always have exactly
one manifest, but that is not necessarily true. When the format of the
image is docker v2, we get both v1 and v2 manifest digests:

```json
{"v1": "sha256:...", "v2": "sha256:..."}
```

In OSBS 1, when gathering the manifests to combine into a manifest list,
the ManifestUtil class would select only "valid" media types. Those were
v2_list, v2, oci_index and oci. In practice, only v2 and oci were valid
(v2_list and oci_index are already manifest lists).

Handle only v2 and oci in the new implementation as well. These two
*should* be mutually exclusive.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
