### PR TITLE
Remove orchestrator check from push_floating_tags

### DIFF
--- a/atomic_reactor/plugins/post_push_floating_tags.py
+++ b/atomic_reactor/plugins/post_push_floating_tags.py
@@ -56,11 +56,6 @@ class PushFloatingTagsPlugin(PostBuildPlugin):
             self.log.info('No floating images to tag, skipping %s', PLUGIN_PUSH_FLOATING_TAGS_KEY)
             return
 
-        #  can't run in the worker build
-        if not self.workflow.is_orchestrator_build():
-            self.log.warning('%s cannot be used by a worker builder', PLUGIN_PUSH_FLOATING_TAGS_KEY)
-            return
-
         manifest_data = self.workflow.data.postbuild_results.get(PLUGIN_GROUP_MANIFESTS_KEY)
         if not manifest_data or not manifest_data.get("manifest_digest"):
             self.log.info('No manifest digest available, skipping %s',

--- a/tests/plugins/test_push_floating_tags.py
+++ b/tests/plugins/test_push_floating_tags.py
@@ -333,11 +333,6 @@ NOGROUP_OCI_RESULTS = {
          'x86_64': ['namespace/httpd:unique-tag-x86_64']
      },
      'No floating images to tag, skipping push_floating_tags'),
-    ("called_from_worker",
-     GROUPED_V2_RESULTS, 'v2',
-     ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
-     {},
-     'push_floating_tags cannot be used by a worker builder'),
     ("No_results",
      None, 'oci',
      ['namespace/httpd:2.4-1', 'namespace/httpd:latest'],
@@ -385,9 +380,6 @@ def test_floating_tags_push(workflow, tmpdir, test_name, manifest_results,
                            primary_images=primary_images,
                            floating_images=floating_tags,
                            manifest_results=manifest_results)
-
-    if per_platform_images:
-        env.make_orchestrator()
 
     registries_list = [
         {


### PR DESCRIPTION
Also clean up unit tests

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
