### PR TITLE
Fix dockerfile parsing in sendmail plugin

### DIFF
--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -81,4 +81,4 @@ def binary_container_exit(task_args: dict):
     """
     params = TaskParams.from_cli_args(task_args)
     task = BinaryExitTask(params)
-    return task.execute()
+    return task.execute(init_build_dirs=True)

--- a/atomic_reactor/plugins/exit_sendmail.py
+++ b/atomic_reactor/plugins/exit_sendmail.py
@@ -19,7 +19,6 @@ from atomic_reactor.plugin import ExitPlugin, PluginFailedException
 from atomic_reactor.plugins.post_koji_import import KojiImportPlugin
 from atomic_reactor.plugins.exit_store_metadata import StoreMetadataPlugin
 from atomic_reactor.utils.koji import get_koji_task_owner
-from atomic_reactor.util import df_parser
 from atomic_reactor.constants import PLUGIN_SENDMAIL_KEY
 from atomic_reactor.config import get_koji_session, get_smtp_session
 from osbs.utils import Labels, ImageName
@@ -153,7 +152,9 @@ class SendMailPlugin(ExitPlugin):
     def _get_image_name_and_repos(self):
 
         repos = []
-        dockerfile = df_parser(self.workflow.df_path, workflow=self.workflow)
+        dockerfile = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
+            self.workflow.imageutil.base_image_inspect()
+        )
         labels = Labels(dockerfile.labels)
         _, image_name = labels.get_name_and_value(Labels.LABEL_TYPE_NAME)
 

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -65,5 +65,5 @@ def test_binary_container_postbuild():
 
 
 def test_binary_container_exit():
-    mock(binary.BinaryExitTask)
+    mock(binary.BinaryExitTask, init_build_dirs=True)
     assert task.binary_container_exit(TASK_ARGS) == TASK_RESULT


### PR DESCRIPTION
CLOUDBLD-8266

Parse the dockerfile from any build dir, not the source dir.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
