### PR TITLE
Remove debug message about loading plugin file

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -175,7 +175,6 @@ class PluginsRunner(object):
                 f_module = sys.modules[module_name]
             else:
                 try:
-                    logger.debug("load file '%s'", f)
                     f_module = imp.load_source(module_name, f)
                 except (IOError, OSError, ImportError, SyntaxError) as ex:
                     logger.warning("can't load module '%s': %s", f, ex)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,7 +5,7 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-
+import sys
 import time
 import inspect
 
@@ -146,21 +146,20 @@ def test_verify_required_plugins_before_first_run(caplog, workflow, runner_type,
         assert any(expected_log_message in log.getMessage() for log in caplog.records)
 
 
-def test_check_no_reload(caplog, workflow):
+def test_check_no_reload(workflow):
     """
     test if plugins are not reloaded
     """
     this_file = inspect.getfile(MyBsPlugin1)
-    expected_log_message = "load file '%s'" % this_file
     BuildStepPluginsRunner(workflow,
                            [{"name": "MyBsPlugin1"}],
                            plugin_files=[this_file])
-    assert any(expected_log_message in log.getMessage() for log in caplog.records)
-    log_len = len(caplog.records)
+    module_id_first = id(sys.modules['test_plugin'])
     BuildStepPluginsRunner(workflow,
                            [{"name": "MyBsPlugin1"}],
                            plugin_files=[this_file])
-    assert all(expected_log_message not in log.getMessage() for log in caplog.records[log_len:])
+    module_id_second = id(sys.modules['test_plugin'])
+    assert module_id_first == module_id_second
 
 @pytest.mark.parametrize('success1', [True, False])  # noqa
 @pytest.mark.parametrize('success2', [True, False])


### PR DESCRIPTION
This debug message generates a lot of unwanted log entries in tasks and
makes logs hard to navigate.

Removing it.

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
