### PR TITLE
test.sh: add repo dir as safe directory

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -90,6 +90,9 @@ function setup_osbs() {
   # Pip install packages for unit tests
   $RUN "${PIP_INST[@]}" -r tests/requirements.txt
   $RUN "${PIP_INST[@]}" tox
+
+  # workaround for https://github.com/actions/checkout/issues/766
+  $RUN git config --global --add safe.directory "$PWD"
 }
 
 case ${ACTION} in


### PR DESCRIPTION
Workaround for https://github.com/actions/checkout/issues/766

When running in github actions, the user that clones the repository is
different than the user inside the container created by test.sh.

A recent release of git to address a CVE [1] makes it so that git
refuses to work with a repository owned by a different user by default.
This breaks the Bandit action, because bandit runs git commands.

Configure the repo directory as safe to make git ignore the different
user problem. Do so in the common setup_osbs() function for consistency.

[1]: https://github.blog/2022-04-12-git-security-vulnerability-announced

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
