### PR TITLE
use single quotes when passing user params

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -48,7 +48,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
 
     - name: binary-container-prebuild
       runAfter:
@@ -72,7 +72,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
 
     - name: binary-container-build-x86-64
       runAfter:
@@ -98,7 +98,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
         - name: platform
           value: x86_64
 
@@ -126,7 +126,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
         - name: platform
           value: s390x
 
@@ -154,7 +154,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
         - name: platform
           value: ppc64le
 
@@ -182,7 +182,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
         - name: platform
           value: aarch64
 
@@ -211,7 +211,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
 
     - name: binary-container-set-results
       runAfter:
@@ -246,4 +246,4 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -45,7 +45,7 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'
 
     - name: source-container-set-results
       runAfter:
@@ -80,4 +80,4 @@ spec:
         - name: pipeline-run-name
           value: "$(context.pipelineRun.name)"
         - name: user-params
-          value: "$(params.user-params)"
+          value: '$(params.user-params)'

--- a/tekton/tasks/binary-container-build.yaml
+++ b/tekton/tasks/binary-container-build.yaml
@@ -39,7 +39,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/binary-container-exit.yaml
+++ b/tekton/tasks/binary-container-exit.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/binary-container-postbuild.yaml
+++ b/tekton/tasks/binary-container-postbuild.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/binary-container-prebuild.yaml
+++ b/tekton/tasks/binary-container-prebuild.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/clone.yaml
+++ b/tekton/tasks/clone.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/source-container-build.yaml
+++ b/tekton/tasks/source-container-build.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 1300m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml

--- a/tekton/tasks/source-container-exit.yaml
+++ b/tekton/tasks/source-container-exit.yaml
@@ -35,7 +35,7 @@ spec:
           cpu: 395m
       script: >
         atomic-reactor -v task
-        --user-params="$(params.user-params)"
+        --user-params='$(params.user-params)'
         --build-dir=$(workspaces.ws-build-dir.path)
         --context-dir=$(workspaces.ws-context-dir.path)
         --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml


### PR DESCRIPTION
When using double quotes it causes json string
to be rendered wrong. This doesn't cause issue
if python is able to typecast, i.e. `abcdef12` is
cast to string but in case python is not able to
cast we see failures. i.e. git_ref=`12345678`,
release=`1.12` etc. fail in schema validation.

* CLOUDBLD-9866

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
