### PR TITLE
Remove outdated Dockerfile-related things

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -523,9 +523,7 @@ class DockerBuildWorkflow(object):
             logger.debug("build json was built by osbs-client %s", client_version)
 
         # get info about base image from dockerfile
-        build_file_path, build_file_dir = self.source.get_build_file_path()
-
-        self.df_dir = build_file_dir
+        build_file_path, _ = self.source.get_build_file_path()
 
         self.conf = Configuration(config_path=reactor_config_path)
 

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field, fields
 from textwrap import dedent
 from typing import Any, Callable, Dict, Final, List, Optional, Union
 
+from dockerfile_parse import DockerfileParser
+
 from atomic_reactor.dirs import ContextDir, RootBuildDir
 from atomic_reactor.plugin import (
     BuildCanceledException,
@@ -37,7 +39,7 @@ from atomic_reactor.constants import (
     DOCKERFILE_FILENAME,
 )
 from atomic_reactor.types import ISerializer, RpmComponent
-from atomic_reactor.util import (exception_message, DockerfileImages, df_parser,
+from atomic_reactor.util import (exception_message, DockerfileImages,
                                  base_image_is_custom, print_version_of_tools, validate_with_schema)
 from atomic_reactor.config import Configuration
 from atomic_reactor.source import Source, DummySource
@@ -561,7 +563,7 @@ class DockerBuildWorkflow(object):
         self.imageutil.set_dockerfile_images(df_images)
 
     def _parse_dockerfile_images(self, path: str) -> DockerfileImages:
-        dfp = df_parser(path)
+        dfp = DockerfileParser(path)
         if dfp.baseimage is None:
             raise RuntimeError("no base image specified in Dockerfile")
 

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -16,11 +16,12 @@ import koji
 import pytest
 import responses
 import logging
+from dockerfile_parse import DockerfileParser
 
 from atomic_reactor.plugin import (
     PreBuildPluginsRunner, PluginFailedException, BuildCanceledException)
 from atomic_reactor.plugins.pre_add_filesystem import AddFilesystemPlugin
-from atomic_reactor.util import df_parser, DockerfileImages
+from atomic_reactor.util import DockerfileImages
 from atomic_reactor.source import VcsInfo
 from atomic_reactor.constants import (DOCKERFILE_FILENAME, PLUGIN_ADD_FILESYSTEM_KEY,
                                       PLUGIN_CHECK_AND_SET_PLATFORMS_KEY,
@@ -179,7 +180,7 @@ def mock_workflow(workflow, build_dir: Path, dockerfile=DEFAULT_DOCKERFILE,
     with open(workflow.source.dockerfile_path, 'w') as f:
         f.write(dockerfile)
     workflow.build_dir.init_build_dirs(platforms, workflow.source)
-    df = df_parser(str(build_dir))
+    df = DockerfileParser(str(build_dir))
     workflow.data.dockerfile_images = DockerfileImages(df.parent_images)
     mock_get_retry_session()
 

--- a/tests/plugins/test_flatpak_create_dockerfile.py
+++ b/tests/plugins/test_flatpak_create_dockerfile.py
@@ -79,7 +79,6 @@ def mock_workflow(
     with open(mock_source.container_yaml_path, "w") as f:
         f.write(container_yaml)
     workflow.source.config = SourceConfig(str(source_dir))
-    workflow.df_dir = str(source_dir)
     workflow.build_dir.init_build_dirs(platforms, workflow.source)
 
     return workflow

--- a/tests/plugins/test_inject_yum_repos.py
+++ b/tests/plugins/test_inject_yum_repos.py
@@ -15,6 +15,7 @@ from textwrap import dedent
 import koji
 import pytest
 import responses
+from dockerfile_parse import DockerfileParser
 from flexmock import flexmock
 
 from atomic_reactor.constants import RELATIVE_REPOS_PATH, INSPECT_CONFIG, DOCKERFILE_FILENAME, \
@@ -22,7 +23,7 @@ from atomic_reactor.constants import RELATIVE_REPOS_PATH, INSPECT_CONFIG, DOCKER
 from atomic_reactor.plugin import PluginFailedException, PreBuildPluginsRunner
 from atomic_reactor.plugins.pre_inject_yum_repos import InjectYumReposPlugin
 from atomic_reactor.source import VcsInfo
-from atomic_reactor.util import df_parser, sha256sum, DockerfileImages
+from atomic_reactor.util import sha256sum, DockerfileImages
 from atomic_reactor.utils.yum import YumRepo
 from tests.constants import DOCKERFILE_GIT, DOCKERFILE_SHA1
 from tests.util import add_koji_map_in_workflow
@@ -132,8 +133,7 @@ def prepare(workflow, build_dir, inherited_user='', dockerfile=DEFAULT_DOCKERFIL
     with open(workflow.source.dockerfile_path, 'w') as f:
         f.write(dockerfile)
     workflow.build_dir.init_build_dirs(platforms, workflow.source)
-    df = df_parser(str(build_dir))
-    df.content = dockerfile
+    df = DockerfileParser(str(build_dir))
     workflow.data.dockerfile_images = DockerfileImages(df.parent_images)
     if include_koji_repo:
         session = MockedClientSession(hub='', opts=None)

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -23,7 +23,7 @@ from atomic_reactor.plugin import ExitPluginsRunner, PluginFailedException
 from atomic_reactor.plugins.pre_add_help import AddHelpPlugin
 from atomic_reactor.plugins.post_rpmqa import PostBuildRPMqaPlugin
 from atomic_reactor.plugins.exit_store_metadata import StoreMetadataPlugin
-from atomic_reactor.util import LazyGit, ManifestDigest, df_parser, DockerfileImages, RegistryClient
+from atomic_reactor.util import LazyGit, ManifestDigest, DockerfileImages, RegistryClient
 import pytest
 from tests.constants import LOCALHOST_REGISTRY, TEST_IMAGE, TEST_IMAGE_NAME
 from tests.util import add_koji_map_in_workflow, is_string_type
@@ -409,15 +409,13 @@ def test_koji_filesystem_label(res, workflow):
         assert 'filesystem-koji-task-id' not in labels
 
 
-def test_metadata_plugin_rpmqa_failure(workflow, source_dir):
+def test_metadata_plugin_rpmqa_failure(workflow):
     initial_timestamp = datetime.now()
     prepare(workflow)
     df_content = """
 FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
-    df = df_parser(str(source_dir))
-    df.content = df_content
     mock_dockerfile(workflow, df_content)
 
     workflow.data.prebuild_results = {}

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -148,7 +148,6 @@ RUN yum install -y python-django
 CMD blabla"""
 
     mock_dockerfile(workflow, df_content)
-    workflow.df_dir = str(source_dir)
 
     dockerfile = workflow.build_dir.any_platform.dockerfile_with_parent_env(
         workflow.imageutil.base_image_inspect()
@@ -420,7 +419,6 @@ CMD blabla"""
     df = df_parser(str(source_dir))
     df.content = df_content
     mock_dockerfile(workflow, df_content)
-    workflow.df_dir = str(source_dir)
 
     workflow.data.prebuild_results = {}
     workflow.data.postbuild_results = {
@@ -466,7 +464,6 @@ CMD blabla"""
 def test_exit_before_dockerfile_created(workflow, source_dir):
     prepare(workflow, no_dockerfile=True)
     workflow.data.exit_results = {}
-    workflow.df_dir = str(source_dir)
 
     runner = ExitPluginsRunner(
         workflow,
@@ -493,7 +490,6 @@ FROM fedora
 RUN yum install -y python-django
 CMD blabla"""
     mock_dockerfile(workflow, df_content)
-    workflow.df_dir = str(source_dir)
 
     runner = ExitPluginsRunner(
         workflow,
@@ -549,7 +545,6 @@ def test_set_koji_annotations_whitelist(workflow, source_dir, koji_conf):
         CMD cowsay moo
         ''')
     mock_dockerfile(workflow, df_content)
-    workflow.df_dir = str(source_dir)
     runner = ExitPluginsRunner(
         workflow,
         [{


### PR DESCRIPTION
workflow.df_dir is useless
util.df_parser() is useless

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
