### PR TITLE
Remove generate_koji_upload_dir

### DIFF
--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -17,7 +17,6 @@ import platform
 from atomic_reactor.inner import DockerBuildWorkflow, ImageBuildWorkflowData
 
 import koji
-import koji_cli.lib
 
 from atomic_reactor import __version__ as atomic_reactor_version
 from atomic_reactor.constants import (DEFAULT_DOWNLOAD_BLOCK_SIZE,
@@ -493,15 +492,6 @@ def get_output(workflow: DockerBuildWorkflow,
         output_files.append(image)
 
     return output_files, extra_output_file
-
-
-def generate_koji_upload_dir():
-    """
-    Create a path name for uploading files to
-
-    :return: str, path name expected to be unique
-    """
-    return koji_cli.lib.unique_path('koji-upload')
 
 
 def get_output_metadata(path, filename):


### PR DESCRIPTION
This method is not used anymore. The upload server-side directory is
generated inside the KojiImportBase class.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
