### PR TITLE
use just one PVC for `build-dir` and `context-dir`

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -12,8 +12,7 @@ spec:
       description: User parameters in JSON format
 
   workspaces:
-    - name: ws-build-dir
-    - name: ws-context-dir
+    - name: ws-container
     - name: ws-registries-secret
     - name: ws-koji-secret
     - name: ws-reactor-config-map
@@ -33,9 +32,11 @@ spec:
         name: clone-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -57,9 +58,11 @@ spec:
         name: binary-container-prebuild-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -81,9 +84,11 @@ spec:
         name: binary-container-build-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -109,9 +114,11 @@ spec:
         name: binary-container-build-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -137,9 +144,11 @@ spec:
         name: binary-container-build-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -165,9 +174,11 @@ spec:
         name: binary-container-build-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -196,9 +207,11 @@ spec:
         name: binary-container-postbuild-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -220,7 +233,8 @@ spec:
         name: binary-container-set-results-0-1
       workspaces:
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
       params:
         - name: osbs-image
           value: "$(params.osbs-image)"
@@ -231,9 +245,11 @@ spec:
         name: binary-container-exit-0-1
       workspaces:
         - name: ws-build-dir
-          workspace: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -12,8 +12,7 @@ spec:
       description: User parameters in JSON format
 
   workspaces:
-    - name: ws-build-dir
-    - name: ws-context-dir
+    - name: ws-container
     - name: ws-registries-secret
     - name: ws-koji-secret
     - name: ws-reactor-config-map
@@ -30,9 +29,11 @@ spec:
         name: source-container-build-0-1
       workspaces:
       - name: ws-build-dir
-        workspace: ws-build-dir
+        workspace: ws-container
+        subPath: build-dir
       - name: ws-context-dir
-        workspace: ws-context-dir
+        workspace: ws-container
+        subPath: context-dir
       - name: ws-registries-secret
         workspace: ws-registries-secret
       - name: ws-koji-secret
@@ -54,7 +55,8 @@ spec:
         name: source-container-set-results-0-1
       workspaces:
         - name: ws-context-dir
-          workspace: ws-context-dir
+          workspace: ws-container
+          subPath: context-dir
       params:
         - name: osbs-image
           value: "$(params.osbs-image)"
@@ -65,9 +67,11 @@ spec:
         name: source-container-exit-0-1
       workspaces:
       - name: ws-build-dir
-        workspace: ws-build-dir
+        workspace: ws-container
+        subPath: build-dir
       - name: ws-context-dir
-        workspace: ws-context-dir
+        workspace: ws-container
+        subPath: context-dir
       - name: ws-registries-secret
         workspace: ws-registries-secret
       - name: ws-koji-secret


### PR DESCRIPTION
Using `subPath` for each task to mount `build-dir`
and `context-dir` allows us to use one PVC for both.
This helps halve the number of PVCs needed for each run,
effectively doubling number of pipeline runs we can do
at a time.

* CLOUDBLD-9935

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
