### PR TITLE
Don't combine stdout and stderr in retries.run_cmd

### DIFF
--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -96,8 +96,19 @@ def run_cmd(cmd: List[str]) -> bytes:
     :return: bytes, the combined stdout and stderr (if any) of the command
     """
     logger.debug("Running %s", " ".join(cmd))
+
     try:
-        return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        process = subprocess.run(cmd, check=True, capture_output=True)
     except subprocess.CalledProcessError as e:
-        logger.warning("%s failed with:\n%s", cmd[0], e.output.decode())
+        logger.warning(
+            "%s failed:\nSTDOUT:\n%s\nSTDERR:\n%s",
+            cmd[0],
+            e.stdout.decode(),
+            e.stderr.decode(),
+        )
         raise
+
+    if process.stderr:
+        logger.warning("%s STDERR:\n%s", cmd[0], process.stderr.decode())
+
+    return process.stdout


### PR DESCRIPTION
CLOUDBLD-9992

When the return value of the function is actually used (currently only
in get_image_size), we want to process only the stdout, not potential
warnings from stderr.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
