### PR TITLE
Use resolved images as keys for parent digests

### DIFF
--- a/atomic_reactor/plugins/koji_parent.py
+++ b/atomic_reactor/plugins/koji_parent.py
@@ -16,7 +16,6 @@ from atomic_reactor.util import (
     base_image_is_custom, get_manifest_media_type, is_scratch_build,
     get_platforms, RegistrySession, RegistryClient
 )
-from copy import copy
 from osbs.utils import ImageName, Labels
 
 import json
@@ -101,11 +100,8 @@ class KojiParentPlugin(Plugin):
                 self._base_image_build = parent_build_info
 
             if parent_build_info:
-                # we need the possible floating tag
-                check_img = copy(local_tag)
-                check_img.tag = img.tag
                 try:
-                    self.check_manifest_digest(check_img, parent_build_info)
+                    self.check_manifest_digest(local_tag, parent_build_info)
                 except ValueError as exc:
                     manifest_mismatches.append(exc)
             else:

--- a/tests/plugins/test_check_base_image.py
+++ b/tests/plugins/test_check_base_image.py
@@ -549,7 +549,7 @@ class TestValidateBaseImage(object):
                                                  ['sha256'])['sha256sum']
             digest = 'sha256:{}'.format(manifest_list_digest)
             test_vals['expected_digest'] = {
-                '{}/{}'.format(SOURCE_REGISTRY, BASE_IMAGE): {
+                f'{reg_image_no_tag}@sha256:{manifest_list_digest}': {
                     MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST: digest
                 }
             }


### PR DESCRIPTION
CLOUDBLD-9980

Previously, some keys in data.parent_images_digests were the unresolved
parent images and one key (for the base image) was the resolved image,
but with its digest replaced by some tag.

Increase consistency and fix a bug by using the resolved images for all
the keys instead.

The bug was that the plugin would save 'some-image:tag' using

    self._store_manifest_digest(image, use_original_tag=True)

But look for 'some-image@sha256:digest' with

    self._get_image_with_digest(image)

It seems that the bug could only happen in builds where the
inject_parent_image plugin replaced the base image. Otherwise, the
plugin would look for 'some-image:tag' and find it successfully.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
