### PR TITLE
Remove invalid param for flatpak_update_dockerfile

### DIFF
--- a/atomic_reactor/plugins/flatpak_update_dockerfile.py
+++ b/atomic_reactor/plugins/flatpak_update_dockerfile.py
@@ -21,15 +21,13 @@ from atomic_reactor.plugins.flatpak_create_dockerfile import (
     FLATPAK_CLEANUPSCRIPT_FILENAME,
     FLATPAK_INCLUDEPKGS_FILENAME,
 )
-from atomic_reactor.util import is_flatpak_build, map_to_user_params
+from atomic_reactor.util import is_flatpak_build
 from atomic_reactor.utils.flatpak_util import FlatpakUtil
 
 
 class FlatpakUpdateDockerfilePlugin(Plugin):
     key = "flatpak_update_dockerfile"
     is_allowed_to_fail = False
-
-    args_from_user_params = map_to_user_params("compose_ids")
 
     def __init__(self, workflow):
         """


### PR DESCRIPTION
The plugin no longer takes compose_ids from user params, instead it
takes compose info from the resolve_composes result.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
