### PR TITLE
Revert "flatpak_create_dockerfile: create a skeleton /dev in the inst…

### DIFF
--- a/atomic_reactor/plugins/flatpak_create_dockerfile.py
+++ b/atomic_reactor/plugins/flatpak_create_dockerfile.py
@@ -46,9 +46,6 @@ ADD {relative_repos_path}* {yum_repos_dir}
 
 ADD {includepkgs} /tmp/
 
-RUN mkdir -p /var/tmp/flatpak-build/dev && \
-    for i in null zero random urandom ; do cp -a /dev/$i /var/tmp/flatpak-build/dev ; done
-
 RUN cat /tmp/atomic-reactor-includepkgs >> /etc/dnf/dnf.conf && \\
     INSTALLDIR=/var/tmp/flatpak-build && \\
     DNF='\\


### PR DESCRIPTION
…allroot"

This isn't supported in rootless podman. We'll need to
find a different workaround.

This reverts commit 9411751f1a9d000147c907a5cecc573683976a68.

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
