### PR TITLE
dependabot: Ignore pytest-runner updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,6 @@ updates:
       - dependency-name: "setuptools"
         # We explicitly pin setuptools<54 to avoid issues when building with Cachito
         versions: [">=54.0.0"]
+      - dependency-name: "pytest-runner"
+        # pytest-runner>=5.3.2 requires setuptools>=56
+        versions: [">=5.3.2"]


### PR DESCRIPTION
Newer pytest-runner requires newer setuptools, newer setuptools breaks
Cachito.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
