### PR TITLE
Set include_koji_repo correctly when plugin is aborted

### DIFF
--- a/atomic_reactor/plugins/inject_yum_repos.py
+++ b/atomic_reactor/plugins/inject_yum_repos.py
@@ -148,7 +148,7 @@ class InjectYumReposPlugin(Plugin):
         self.log.info("baseurl = '%s'", baseurl)
 
         repo = {
-            'name': 'atomic-reactor-koji-target-%s' % self.target,
+            'name': 'atomic-reactor-koji-plugin-%s' % self.target,
             'baseurl': baseurl,
             'enabled': 1,
             'gpgcheck': 0,

--- a/atomic_reactor/plugins/resolve_composes.py
+++ b/atomic_reactor/plugins/resolve_composes.py
@@ -88,7 +88,6 @@ class ResolveComposesPlugin(Plugin):
         self.all_compose_ids = list(self.compose_ids)
         self.new_compose_ids = []
         self.parent_compose_ids = []
-        self.include_koji_repo = False
         self.yum_repourls = defaultdict(list)
         self.architectures = get_platforms(self.workflow.data)
 
@@ -357,13 +356,6 @@ class ResolveComposesPlugin(Plugin):
             for arch in self.yum_repourls:
                 self.yum_repourls[arch].extend(noarch_repos)
 
-        # If we don't think the set of packages available from the user-supplied repourls,
-        # inherited repourls, and composed repositories is complete, set the 'include_koji_repo'
-        # kwarg so that the so that the 'yum_repourls' kwarg that we just set doesn't
-        # result in the 'koji' plugin being omitted.
-        if not self.has_complete_repos:
-            self.include_koji_repo = True
-
     def make_result(self) -> ResolveComposesResult:
         signing_intent = None
         signing_intent_overridden = False
@@ -374,7 +366,11 @@ class ResolveComposesPlugin(Plugin):
         result: ResolveComposesResult = {
             'composes': self.composes_info,
             'yum_repourls': self.yum_repourls,
-            'include_koji_repo': self.include_koji_repo,
+            # If we don't think the set of packages available from the user-supplied repourls,
+            # inherited repourls, and composed repositories is complete,
+            # set the 'include_koji_repo' to True, so it can be
+            # properly processed in inject_yum_repos plugin
+            'include_koji_repo': not self.has_complete_repos,
             'signing_intent': signing_intent,
             'signing_intent_overridden': signing_intent_overridden,
         }

--- a/tests/plugins/test_inject_yum_repos.py
+++ b/tests/plugins/test_inject_yum_repos.py
@@ -874,10 +874,10 @@ def test_include_koji(workflow, build_dir, caplog, parent_images, base_from_scra
     assert fnmatch(next(iter(files)), repofile)
     with open(repos_path / files[0], 'r') as f:
         content = f.read()
-    assert content.startswith("[atomic-reactor-koji-target-target]\n")
+    assert content.startswith("[atomic-reactor-koji-plugin-target]\n")
     assert "gpgcheck=0\n" in content
     assert "enabled=1\n" in content
-    assert "name=atomic-reactor-koji-target-target\n" in content
+    assert "name=atomic-reactor-koji-plugin-target\n" in content
     assert "baseurl=%s/repos/tag/2/$basearch\n" % root in content
 
     if proxy:


### PR DESCRIPTION
This fixes bug that was introduced in
https://github.com/containerbuildsystem/atomic-reactor/pull/1764/

When plugin is aborted and no yum_repourls are present,
include_koji_repo should be set to True

CLOUDBLD-10020

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
