### PR TITLE
allowlist for source containers using lookaside cache

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -604,6 +604,10 @@
               "description": "Url with denylist yaml file, which will be used to exclude sources from cachito ",
               "type": "string"
           },
+          "lookaside_cache_allowlist": {
+              "description": "Url with allowlist yaml file, which allows usage of lookaside cache",
+              "type": "string"
+          },
           "cpu_request": {
               "description": "Openshift cpu request for build",
               "type": "string",


### PR DESCRIPTION
* CLOUDBLD-10079

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
