### PR TITLE
Fix build failure and cancellation handling

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -635,7 +635,10 @@ class DockerBuildWorkflow(object):
 
         :return: Tuple of (failed, cancelled). Note that a cancelled build also counts as failed.
         """
-        cancelled = self.osbs.build_has_any_cancelled_tasks(self.pipeline_run_name)
+        cancelled = (
+            self.osbs.build_has_any_cancelled_tasks(self.pipeline_run_name)  # prev. task cancelled
+            or self.data.build_canceled  # this task cancelled
+        )
         failed = (
             cancelled  # cancelled counts as failed
             or self.osbs.build_has_any_failed_tasks(self.pipeline_run_name)  # prev. task failed

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -291,7 +291,6 @@ class ImageBuildWorkflowData(ISerializer):
     # Plugin name -> a string containing error message
     plugins_errors: Dict[str, str] = field(default_factory=dict)
     build_canceled: bool = False
-    plugin_failed: bool = False
 
     # info about pre-declared build, build-id and token
     reserved_build_id: Optional[int] = None

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -33,10 +33,11 @@ from atomic_reactor.constants import (
 from atomic_reactor.types import ISerializer, RpmComponent
 from atomic_reactor.util import (DockerfileImages,
                                  base_image_is_custom, print_version_of_tools, validate_with_schema)
-from atomic_reactor.config import Configuration
+from atomic_reactor.config import Configuration, get_openshift_session
 from atomic_reactor.source import Source, DummySource
 from atomic_reactor.utils import imageutil
 # from atomic_reactor import get_logging_encoding
+from osbs.api import OSBS
 from osbs.utils import ImageName
 
 
@@ -625,6 +626,10 @@ class DockerBuildWorkflow(object):
     @property
     def image(self):
         return self.user_params['image_tag']
+
+    @functools.cached_property
+    def osbs(self) -> OSBS:
+        return get_openshift_session(self.conf, self.namespace)
 
     @property
     def build_process_failed(self):

--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -251,7 +251,6 @@ class PluginsRunner(object):
             plugin: Optional[str] = None,
             exception: Optional[Exception] = None,
     ):
-        self.workflow.data.plugin_failed = True
         if plugin and exception:
             self.workflow.data.plugins_errors[plugin] = str(exception)
 

--- a/atomic_reactor/plugins/cancel_build_reservation.py
+++ b/atomic_reactor/plugins/cancel_build_reservation.py
@@ -49,7 +49,9 @@ class CancelBuildReservation(Plugin):
                            reserved_build_id, cur_state_name)
             return
 
-        if not self.workflow.build_process_failed and cur_state == state_building:
+        failed, cancelled = self.workflow.check_build_outcome()
+
+        if not failed and cur_state == state_building:
             session.CGRefundBuild(PROG, reserved_build_id, reserved_token, state_failed)
             err_msg = (
                 f"Build process succeeds, but the reserved build {reserved_build_id} "
@@ -58,7 +60,7 @@ class CancelBuildReservation(Plugin):
             )
             raise RuntimeError(err_msg)
 
-        if self.workflow.data.build_canceled:
+        if cancelled:
             state = koji.BUILD_STATES["CANCELED"]
         else:
             state = state_failed

--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Iterable
 
 import koji_cli.lib
 
-from atomic_reactor.config import get_koji_session, get_openshift_session
+from atomic_reactor.config import get_koji_session
 from atomic_reactor import start_time as atomic_reactor_start_time
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.plugins.add_help import AddHelpPlugin
@@ -125,8 +125,6 @@ class KojiImportBase(Plugin):
         self.blocksize = blocksize
         self.poll_interval = poll_interval
 
-        self.osbs = get_openshift_session(self.workflow.conf,
-                                          self.workflow.namespace)
         self.build_id = None
         self.session = None
         self.userdata = userdata
@@ -185,7 +183,7 @@ class KojiImportBase(Plugin):
         koji_upload_files = self.workflow.data.koji_upload_files
         osbs_logs = OSBSLogs(self.log, get_platforms(self.workflow.data))
         log_files_outputs = osbs_logs.get_log_files(
-            self.osbs, self.workflow.pipeline_run_name
+            self.workflow.osbs, self.workflow.pipeline_run_name
         )
         for output in log_files_outputs:
             metadata = output.metadata

--- a/atomic_reactor/plugins/sendmail.py
+++ b/atomic_reactor/plugins/sendmail.py
@@ -362,8 +362,8 @@ class SendMailPlugin(Plugin):
             self.log.info('no smtp configuration, skipping plugin')
             return
 
-        success = not self.workflow.build_process_failed
-        manual_canceled = self.workflow.data.build_canceled
+        failed, manual_canceled = self.workflow.check_build_outcome()
+        success = not failed
 
         self.log.info('checking conditions for sending notification ...')
         if self._should_send(success, manual_canceled):

--- a/atomic_reactor/plugins/store_metadata.py
+++ b/atomic_reactor/plugins/store_metadata.py
@@ -12,7 +12,6 @@ from osbs.exceptions import OsbsResponseException
 
 from atomic_reactor.plugins.fetch_sources import PLUGIN_FETCH_SOURCES_KEY
 from atomic_reactor.constants import PLUGIN_VERIFY_MEDIA_KEY, SCRATCH_FROM
-from atomic_reactor.config import get_openshift_session
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import get_manifest_digests
 
@@ -109,8 +108,6 @@ class StoreMetadataPlugin(Plugin):
     def run(self):
         pipeline_run_name = self.workflow.pipeline_run_name
         self.log.info("pipelineRun name = %s", pipeline_run_name)
-        osbs = get_openshift_session(self.workflow.conf,
-                                     self.workflow.namespace)
 
         wf_data = self.workflow.data
 
@@ -195,7 +192,7 @@ class StoreMetadataPlugin(Plugin):
         self.set_koji_task_annotations_whitelist(annotations)
 
         try:
-            osbs.update_annotations_on_build(pipeline_run_name, annotations)
+            self.workflow.osbs.update_annotations_on_build(pipeline_run_name, annotations)
         except OsbsResponseException:
             self.log.debug("annotations: %r", annotations)
             raise

--- a/atomic_reactor/schemas/workflow_data.json
+++ b/atomic_reactor/schemas/workflow_data.json
@@ -12,7 +12,6 @@
     "plugins_durations": {"type": "object"},
     "plugins_errors": {"type": "object"},
     "build_canceled": {"type": "boolean"},
-    "plugin_failed": {"type": "boolean"},
 
     "reserved_build_id": {"type": ["integer", "null"], "minimum": 1},
     "reserved_token": {"type": ["string", "null"]},
@@ -70,7 +69,7 @@
   "required": [
     "dockerfile_images", "tag_conf",
     "plugins_results",
-    "plugins_timestamps", "plugins_durations", "plugins_errors", "build_canceled", "plugin_failed",
+    "plugins_timestamps", "plugins_durations", "plugins_errors", "build_canceled",
     "reserved_build_id", "reserved_token", "koji_source_nvr", "koji_source_source_url", "koji_source_manifest",
     "buildargs", "exported_image_sequence", "files", "image_components", "all_yum_repourls",
     "annotations", "image_id", "parent_images_digests",

--- a/tests/mock_env.py
+++ b/tests/mock_env.py
@@ -7,6 +7,8 @@ of the BSD license. See the LICENSE file for details.
 """
 from typing import Any, List, Union, Dict, Optional
 
+from flexmock import flexmock
+
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 from atomic_reactor.plugin import PluginsRunner
 from atomic_reactor.inner import DockerBuildWorkflow
@@ -157,6 +159,17 @@ class MockEnv(object):
         if not isinstance(images, DockerfileImages):
             images = DockerfileImages(images)
         self.workflow.data.dockerfile_images = images
+        return self
+
+    def mock_build_outcome(self, *, failed: bool, cancelled: bool = False):
+        """Make the check_build_outcome method return the specified values."""
+        if cancelled and not failed:
+            raise ValueError(
+                "Cannot set build outcome (failed=False, cancelled=True), "
+                "cancelled=True implies failed=True"
+            )
+        outcome = (failed, cancelled)
+        flexmock(self.workflow).should_receive("check_build_outcome").and_return(outcome)
         return self
 
     def _get_plugin_conf(self, plugin_key: str) -> Dict[str, Any]:

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -183,7 +183,6 @@ def test_running_build(workflow, caplog,
         err_msg += f"\nNo Maven source directory '{maven_dir_path}' available"
         # Since Python 3.7 logger adds additional whitespaces by default -> checking without them
         assert re.sub(r'\s+', " ", err_msg) in re.sub(r'\s+', " ", caplog.text)
-        assert workflow.build_process_failed
 
     elif export_failed:
         with pytest.raises(PluginFailedException):
@@ -258,6 +257,5 @@ def test_failed_build(workflow, source_dir, caplog, user_params):
 
     with pytest.raises(PluginFailedException, match="BSI utility failed"):
         runner.run()
-    assert workflow.build_process_failed
     assert 'BSI failed with output:' in caplog.text
     assert 'stub stdout' in caplog.text

--- a/tests/plugins/test_cancel_build_reservation.py
+++ b/tests/plugins/test_cancel_build_reservation.py
@@ -13,6 +13,8 @@ from flexmock import flexmock
 from atomic_reactor.constants import PROG
 from atomic_reactor.plugins.cancel_build_reservation import CancelBuildReservation
 
+from tests.mock_env import MockEnv
+
 
 def test_build_reservation_is_not_enabled(workflow, caplog):
     """Skip cancelation if build reservation feature is not enabled."""
@@ -94,8 +96,7 @@ def test_reserved_build_has_been_released_already(build_state, workflow, caplog)
 def test_cancel_a_reserved_build(is_canceled, expected_dest_state, workflow):
     """A reserved build is canceled with a proper destination state."""
     mock_reactor_config(workflow)
-    workflow.data.plugin_failed = True
-    workflow.data.build_canceled = is_canceled
+    MockEnv(workflow).mock_build_outcome(failed=True, cancelled=is_canceled)
     workflow.data.reserved_token = "1234"
     workflow.data.reserved_build_id = 1
 
@@ -119,7 +120,7 @@ def test_mark_reserved_build_fail_if_koji_import_does_not_run(workflow):
     reserved_build_id = 1
     mock_reactor_config(workflow)
     # Mark the build is successful.
-    workflow.data.plugin_failed = False
+    MockEnv(workflow).mock_build_outcome(failed=False)
     workflow.data.reserved_token = "1234"
     workflow.data.reserved_build_id = reserved_build_id
 

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -13,6 +13,7 @@ from atomic_reactor.plugins.store_metadata import StoreMetadataPlugin
 from atomic_reactor.plugins.koji_import import KojiImportPlugin
 from atomic_reactor.utils.koji import get_koji_task_owner
 from atomic_reactor.config import Configuration
+from tests.mock_env import MockEnv
 from tests.util import add_koji_map_in_workflow
 from osbs.exceptions import OsbsException
 from smtplib import SMTPException
@@ -356,7 +357,7 @@ class TestSendMailPlugin(object):
                                                        vcs_url=git_source_url,
                                                        vcs_ref=git_source_ref))
 
-        workflow.data.build_canceled = manual_cancel
+        MockEnv(workflow).mock_build_outcome(failed=True, cancelled=manual_cancel)
 
         if has_store_metadata_results:
             if annotations:
@@ -681,7 +682,7 @@ class TestSendMailPlugin(object):
             p._send_mail(['spam@spam.com'], 'subject', 'body')
 
     def test_run_ok(self, tmpdir, workflow, source_dir):
-        workflow.data.plugin_failed = True
+        MockEnv(workflow).mock_build_outcome(failed=True)
         receivers = ['foo@bar.com', 'x@y.com']
 
         mock_dockerfile(workflow)
@@ -709,7 +710,7 @@ class TestSendMailPlugin(object):
         p.run()
 
     def test_run_ok_and_send(self, workflow):
-        workflow.data.plugin_failed = True
+        MockEnv(workflow).mock_build_outcome(failed=True)
 
         class SMTP(object):
             def sendmail(self, from_addr, to, msg):
@@ -744,7 +745,7 @@ class TestSendMailPlugin(object):
         p.run()
 
     def test_run_fails_to_obtain_receivers(self, workflow):
-        workflow.data.plugin_failed = True
+        MockEnv(workflow).mock_build_outcome(failed=True)
         error_addresses = ['error@address.com']
         mock_store_metadata_results(workflow)
 
@@ -773,7 +774,7 @@ class TestSendMailPlugin(object):
         p.run()
 
     def test_run_invalid_receivers(self, caplog, workflow):
-        workflow.data.plugin_failed = True
+        MockEnv(workflow).mock_build_outcome(failed=True)
         error_addresses = ['error@address.com']
 
         mock_store_metadata_results(workflow)
@@ -802,7 +803,7 @@ class TestSendMailPlugin(object):
         assert 'no valid addresses in requested addresses. Doing nothing' in caplog.text
 
     def test_run_does_nothing_if_conditions_not_met(self, workflow):
-        workflow.data.plugin_failed = True
+        MockEnv(workflow).mock_build_outcome(failed=True)
         smtp_map = {
             'from_address': 'foo@bar.com',
             'host': 'smtp.spam.com',


### PR DESCRIPTION
CLOUDBLD-10117

Instead of relying on the plugin_failed property, check the status of
the Tekton pipeline to find out if any task failed.

Get rid of the plugin_failed property.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
