### PR TITLE
Ignore whitespace-only lines for build error msg

### DIFF
--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -261,14 +261,14 @@ class PodmanRemote:
         while True:
             if line := build_process.stdout.readline():
                 yield line
-                last_line = line
+                # keep the last non-empty, non-whitespace line for an eventual error message
+                last_line = line.rstrip() or last_line
 
             if (rc := build_process.poll()) is not None:
                 break
 
         if rc != 0:
-            # the last line of output likely contains the error message
-            error = last_line.rstrip() if last_line else "<no output!>"
+            error = last_line if last_line else "<no output!>"
             raise BuildProcessError(f"Build failed (rc={rc}): {error}")
 
     def get_image_size(self, dest_tag: ImageName) -> int:

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -491,7 +491,9 @@ class TestPodmanRemote:
         "output_lines, expect_err_line",
         [
             (["starting the build\n", "failed :(\n"], "failed :("),
+            (["failed and printed an empty line\n", "\n"], "failed and printed an empty line"),
             ([], "<no output!>"),
+            (["\n"], "<no output!>"),
         ]
     )
     def test_build_container_fails(


### PR DESCRIPTION
Podman (or maybe the command that fails the build) often outputs
something like

```
Error: error building at STEP "RUN foo": error while running runtime...
\n
```

Make sure the empty line does not become the error message.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
