### PR TITLE
Output original Dockerfile when build fails

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -287,3 +287,20 @@ spec:
           value: "$(context.pipelineRun.name)"
         - name: user-params
           value: '$(params.user-params)'
+    - name: binary-container-output-dockerfile
+      when:
+        - input: "$(tasks.status)"
+          operator: in
+          values:
+            - Failed
+      taskRef:
+        name: binary-container-output-dockerfile-0-1
+      workspaces:
+        - name: ws-build-dir
+          workspace: ws-container
+          subPath: build-dir
+      params:
+        - name: osbs-image
+          value: "$(params.osbs-image)"
+        - name: user-params
+          value: '$(params.user-params)'

--- a/tekton/tasks/binary-container-output-dockerfile.yaml
+++ b/tekton/tasks/binary-container-output-dockerfile.yaml
@@ -1,0 +1,37 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: binary-container-output-dockerfile-0-1  # dot is not allowed in the name
+spec:
+  description: >-
+    Output the original image Dockerfile
+  params:
+    - name: osbs-image
+      description: The location of the OSBS builder image (FQDN pullspec)
+      type: string
+    - name: user-params
+      type: string
+      description: User parameters in JSON format. Use git_uri.
+
+  workspaces:
+    - name: ws-build-dir
+
+  steps:
+    - name: binary-container-output-dockerfile
+      image: $(params.osbs-image)
+      resources:
+        requests:
+          memory: 300Mi
+          cpu: 250m
+        limits:
+          memory: 600Mi
+          cpu: 395m
+      script: |
+        repo=$(basename $(echo '$(params.user-params)' | jq -r '.git_uri') .git)
+        dockerfile="$(workspaces.ws-build-dir.path)/${repo}/Dockerfile"
+        if [ -e "$dockerfile" ]; then
+          echo "Original Dockerfile:"
+          cat "$dockerfile"
+        else
+          echo "Dockerfile does not exit: ${dockerfile}"
+        fi


### PR DESCRIPTION
* CLOUDBLD-10133

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
