### PR TITLE
Write downloaded filesystem to binary file

### DIFF
--- a/atomic_reactor/plugins/add_filesystem.py
+++ b/atomic_reactor/plugins/add_filesystem.py
@@ -274,7 +274,7 @@ class AddFilesystemPlugin(Plugin):
         if file_path.exists():
             raise RuntimeError(f'Filesystem {file_name} already exists at {file_path}')
 
-        with open(file_path, 'w') as f:
+        with open(file_path, 'wb') as f:
             for chunk in stream_task_output(self.session, task_id, file_name, self.blocksize):
                 f.write(chunk)
 

--- a/tests/plugins/test_add_filesystem.py
+++ b/tests/plugins/test_add_filesystem.py
@@ -111,7 +111,7 @@ def mock_koji_session(scratch=False, image_task_fail=False,
     session.should_receive('getTaskChildren').and_return([
         {'id': 1234568},
     ])
-    contents = 'tarball-contents'
+    contents = [b'tarball', b'content']
     expectation = session.should_receive('downloadTaskOutput')
     for chunk in contents:
         expectation = expectation.and_return(chunk)


### PR DESCRIPTION
The content downloaded from Koji is binary, can't write it to text file.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
