### PR TITLE
New registries_cfg_path config

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -456,23 +456,38 @@
         }
     },
     "registries_organization": {"$ref": "#/definitions/organization"},
+    "registries_cfg_path": {
+      "description": "Path to directory containing .dockercfg for registries auth",
+      "type": "string"
+    },
     "registry": {
-        "description": "Container registry to output images",
-        "type": "object",
-        "properties": {
-            "url": {
-                "description": "Registry URI including version",
-                "type": "string"
-            },
-            "insecure": {
-                "description": "Don't check SSL certificate for url",
-                "type": "boolean"
-            },
-            "auth": {"$ref": "#/definitions/registry_auth"},
-            "expected_media_types": {"$ref": "#/definitions/media_types"}
+      "description": "Container registry to output images",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Registry URI including version",
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": ["url"]
+        "insecure": {
+          "description": "Don't check SSL certificate for url",
+          "type": "boolean"
+        },
+        "expected_media_types": {"$ref": "#/definitions/media_types"}
+      },
+      "additionalProperties": false,
+      "required": ["url"]
+    },
+    "source_registry": {
+      "description": "Default container registry to use for pulling images",
+      "$ref": "#/definitions/source_registry"
+    },
+    "pull_registries": {
+      "description": "Other container registries that may be used for pulling images",
+      "type": "array",
+      "items": {
+        "description": "Any container registry other than the default one",
+        "$ref": "#/definitions/source_registry"
+      }
     },
     "yum_proxy": {
         "description": "Proxy to access yum repositories",
@@ -515,18 +530,6 @@
         },
         "additionalProperties": false,
         "required": ["tmpdir", "files"]
-    },
-    "source_registry": {
-        "description": "Default container registry to use for pulling images",
-        "$ref": "#/definitions/source_registry"
-    },
-    "pull_registries": {
-        "description": "Other container registries that may be used for pulling images",
-        "type": "array",
-        "items": {
-            "description": "Any container registry other than the default one",
-            "$ref": "#/definitions/source_registry"
-        }
     },
     "sources_command": {
         "description": "Command to retrieve artifacts in lookaside cache",
@@ -756,33 +759,20 @@
                    "application/vnd.oci.image.index.v1+json"]
         }
     },
-    "registry_auth": {
-        "description": "Registry authentication information",
-        "type": "object",
-        "properties": {
-            "cfg_path": {
-                "description": "Path to directory containing .dockercfg for registry auth",
-                "type": "string"
-            }
-        },
-        "additionalProperties": false,
-        "required": ["cfg_path"]
-    },
     "source_registry": {
-        "type": "object",
-        "properties": {
-            "url": {
-                "description": "Registry url",
-                "type": "string"
-            },
-            "insecure": {
-                "description": "Don't check SSL certificate for url",
-                "type": "boolean"
-            },
-            "auth": {"$ref": "#/definitions/registry_auth"}
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "Registry url",
+          "type": "string"
         },
-        "additionalProperties": false,
-        "required": ["url"]
+        "insecure": {
+          "description": "Don't check SSL certificate for url",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["url"]
     },
     "builder_ca_bundle": {
         "description": "An absolute path to the custom ca-bundle certificate inside the buildroot.",

--- a/docs/config.md
+++ b/docs/config.md
@@ -6,6 +6,9 @@ YAML file describing atomic-reactor's configuration.
 It has the following keys
 
 - **version**: Must be 1.
+- **registries_cfg_path**: A directory path where holds a docker
+  configuration file for registry authentication. Either `.dockercfg`
+  or `.dockerconfigjson` is supported.
 - **remote_hosts**: Contains 'pools' which is a map of platform names,
   with each value being a list. Each list item describes host which can handle
   builds for that platform.

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -129,15 +129,12 @@ content_versions:
 
 registry:
   url: https://container-registry.example.com/v2
-  auth:
-      cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
 
 source_registry:
     url: https://registry.private.example.com
     insecure: True
-    auth:
-        cfg_path: /var/run/secrets/atomic-reactor/private-registry-dockercfg
 
+registries_cfg_path: /var/run/secrets/atomic-reactor/v2-registry-dockercfg
 
 sources_command: "fedpkg sources"
 

--- a/tests/plugins/test_group_manifests.py
+++ b/tests/plugins/test_group_manifests.py
@@ -408,12 +408,6 @@ def test_group_manifests(workflow, source_dir, schema_version, test_name, group,
     noarch_image, *_ = some_per_platform_image.rsplit("-", 1)
     mock_environment(workflow, unique_image=noarch_image, primary_images=test_images)
 
-    reg_info = registry_conf[REGISTRY_V2]
-    registry = {
-        'url': f'https://{REGISTRY_V2}/{reg_info["version"]}',
-        'auth': {'cfg_path': reg_info.get('secret', str(temp_dir))},
-    }
-
     platform_descriptors_list = []
     for platform, arch in goarch.items():
         new_plat = {
@@ -430,7 +424,11 @@ def test_group_manifests(workflow, source_dir, schema_version, test_name, group,
             {
                 'version': 1,
                 'group_manifests': group,
-                'registry': registry,
+                'registry': {
+                    'url': f'https://{REGISTRY_V2}/{registry_conf[REGISTRY_V2]["version"]}',
+                    'auth': True,
+                },
+                'registries_cfg_path': str(temp_dir),
                 'platform_descriptors': platform_descriptors_list,
             }
         )

--- a/tests/plugins/test_push_floating_tags.py
+++ b/tests/plugins/test_push_floating_tags.py
@@ -381,12 +381,6 @@ def test_floating_tags_push(workflow, tmpdir, test_name, manifest_results,
                            floating_images=floating_tags,
                            manifest_results=manifest_results)
 
-    reg_info = registry_conf[REGISTRY_V2]
-    registry = {
-        'url': f'https://{REGISTRY_V2}/{reg_info["version"]}',
-        'auth': {'cfg_path': reg_info.get('secret', str(temp_dir))},
-    }
-
     platform_descriptors_list = []
     for platform, arch in goarch.items():
         new_plat = {
@@ -395,8 +389,15 @@ def test_floating_tags_push(workflow, tmpdir, test_name, manifest_results,
         }
         platform_descriptors_list.append(new_plat)
 
-    rcm = {'version': 1, 'registry': registry,
-           'platform_descriptors': platform_descriptors_list}
+    rcm = {
+        'version': 1,
+        'registry': {
+            'url': f'https://{REGISTRY_V2}/{registry_conf[REGISTRY_V2]["version"]}',
+            'auth': True,
+        },
+        'platform_descriptors': platform_descriptors_list,
+        'registries_cfg_path': str(temp_dir),
+    }
     env.set_reactor_config(rcm)
 
     runner = env.create_runner()

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -199,9 +199,11 @@ def test_tag_and_push_plugin(
         'registry': {
             'url': LOCALHOST_REGISTRY,
             'insecure': True,
-            'auth': {'cfg_path': secret_path},
-        }
+            'auth': use_secret,
+        },
     }
+    if use_secret:
+        reactor_config['registries_cfg_path'] = secret_path
     runner = (MockEnv(workflow)
               .for_plugin(TagAndPushPlugin.key)
               .set_reactor_config(reactor_config)
@@ -270,9 +272,11 @@ def test_tag_and_push_plugin_oci(workflow, monkeypatch, is_source_build, v2s2,
         'registry': {
             'url': LOCALHOST_REGISTRY,
             'insecure': True,
-            'auth': {'cfg_path': secret_path},
+            'auth': use_secret,
         },
     }
+    if use_secret:
+        reactor_config['registries_cfg_path'] = secret_path
     env = (MockEnv(workflow)
            .for_plugin(TagAndPushPlugin.key)
            .set_plugin_args({'koji_target': sources_koji_target})

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -362,10 +362,8 @@ def test_registry_session(tmpdir, registry, insecure, method, responses_method, 
      {
          'source_registry': {
             'url': "default_registry.io",
-            'auth': {
-                'cfg_path': '/not/important'
-            }
-         }
+         },
+         'registries_cfg_path': '/not/important',
      },
      {
          'uri': "default_registry.io",
@@ -377,16 +375,14 @@ def test_registry_session(tmpdir, registry, insecure, method, responses_method, 
      {
          'source_registry': {
             'url': "default_registry.io",
-            'auth': {
-                'cfg_path': '/not/important'
-            }
          },
          'pull_registries': [
              {
                  'url': "some_registry.io",
                  'insecure': True
              }
-         ]
+         ],
+         'registries_cfg_path': '/not/important',
      },
      {
          'uri': "default_registry.io",
@@ -415,11 +411,9 @@ def test_registry_session(tmpdir, registry, insecure, method, responses_method, 
              {
                  'url': "https://some_registry.io",
                  'insecure': False,
-                 'auth': {
-                     'cfg_path': '/not/important'
-                 }
              }
-         ]
+         ],
+         'registries_cfg_path': '/not/important',
      },
      {
          'uri': "https://some_registry.io",
@@ -427,30 +421,27 @@ def test_registry_session(tmpdir, registry, insecure, method, responses_method, 
          'dockercfg_path': '/not/important'
      }),
     # Have both source_registry and pull_registries, matches pull_registries
-    ('some_registry.io',
-     {
-         'source_registry': {
-             'url': "default_registry.io",
-             'insecure': False,
-             'auth': {
-                 'cfg_path': '/not/important'
-             }
-         },
-         'pull_registries': [
-             {
-                 'url': "some_registry.io",
-                 'insecure': False,
-                 'auth': {
-                     'cfg_path': '/also/not/important'
-                 }
-             }
-         ]
-     },
-     {
-         'uri': "some_registry.io",
-         'insecure': False,
-         'dockercfg_path': '/also/not/important'
-     }),
+    (
+        'some_registry.io',
+        {
+            'source_registry': {
+                'url': "default_registry.io",
+                'insecure': False,
+            },
+            'pull_registries': [
+                {
+                    'url': "some_registry.io",
+                    'insecure': False,
+                }
+            ],
+            'registries_cfg_path': '/not/important'
+        },
+        {
+            'uri': "some_registry.io",
+            'insecure': False,
+            'dockercfg_path': '/not/important'
+        },
+    ),
 ])
 @pytest.mark.parametrize('access', [None, ('pull', 'push')])
 def test_registry_create_from_config(workflow, registry, reactor_config, matched_registry, access):


### PR DESCRIPTION
* CLOUDBLD-9346

The auth.cfg_path configs under registry, pull_registries and
source_registry are moved outside and are replaced by the top level
config registries_cfg_path.

To keep the ability of indicating whether a registry requires
authentication, every kind of registry config has auth config in boolean
type. The final dockercfg_path is read from the registries_cfg_path only
when auth is True.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
