### PR TITLE
bump osbs version

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -62,7 +62,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@a640824c5710cd4514f738e30fc85d5f5263452b
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ jsonschema
 paramiko>=2.10.1
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@a640824c5710cd4514f738e30fc85d5f5263452b#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@a640824c5710cd4514f738e30fc85d5f5263452b
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216
     # via -r requirements.in
 paramiko==2.10.3
     # via -r requirements.in


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- n/a Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
