### PR TITLE
Mark custom parent image as scratch

### DIFF
--- a/atomic_reactor/plugins/add_filesystem.py
+++ b/atomic_reactor/plugins/add_filesystem.py
@@ -344,10 +344,13 @@ class AddFilesystemPlugin(Plugin):
 
         build_dir.dockerfile.lines = lines
         new_parents = []
+        df_images = self.workflow.data.dockerfile_images
 
         for image in build_dir.dockerfile.parent_images:
             if base_image_is_custom(image):
                 new_parents.append('scratch')
+                # To make change_from_in_df happy and nothing will change due to this.
+                df_images[image] = 'scratch'
             else:
                 new_parents.append(image)
 


### PR DESCRIPTION
* CLOUDBLD-10237

Signed-off-by: Chenxiong Qi <cqi@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
