### PR TITLE
remove `workflow.data.exported_image_sequence`

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -301,15 +301,6 @@ class ImageBuildWorkflowData(ISerializer):
 
     buildargs: Dict[str, str] = field(default_factory=dict)  # --buildargs for container build
 
-    # When an image is exported into tarball, it can then be processed by various plugins.
-    #  Each plugin that transforms the image should save it as a new file and append it to
-    #  the end of exported_image_sequence. Other plugins should then operate with last
-    #  member of this structure. Example:
-    #  [{'path': '/tmp/foo.tar', 'size': 12345678, 'md5sum': '<md5>', 'sha256sum': '<sha256>'}]
-    #  You can use util.get_exported_image_metadata to create a dict to append to this list.
-    # OSBS2 TBD exported_image_sequence will not work for multiple platform
-    exported_image_sequence: List[Dict[str, Union[str, int]]] = field(default_factory=list)
-
     # mapping of downloaded files; DON'T PUT ANYTHING BIG HERE!
     # "path/to/file" -> "content"
     files: Dict[str, str] = field(default_factory=dict)

--- a/atomic_reactor/plugins/store_metadata.py
+++ b/atomic_reactor/plugins/store_metadata.py
@@ -6,7 +6,6 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 import json
-import os
 
 from osbs.exceptions import OsbsResponseException
 
@@ -156,24 +155,6 @@ class StoreMetadataPlugin(Plugin):
 
         if media_types:
             annotations['media-types'] = json.dumps(sorted(list(set(media_types))))
-
-        tar_path = tar_size = tar_md5sum = tar_sha256sum = None
-        if len(wf_data.exported_image_sequence) > 0:
-            # OSBS2 TBD exported_image_sequence will not work for multiple platform
-            info = wf_data.exported_image_sequence[-1]
-            tar_path = info.get("path")
-            tar_size = info.get("size")
-            tar_md5sum = info.get("md5sum")
-            tar_sha256sum = info.get("sha256sum")
-        # looks like that openshift can't handle value being None (null in json)
-        if tar_size is not None and tar_md5sum is not None and tar_sha256sum is not None and \
-                tar_path is not None:
-            annotations["tar_metadata"] = json.dumps({
-                "size": tar_size,
-                "md5sum": tar_md5sum,
-                "sha256sum": tar_sha256sum,
-                "filename": os.path.basename(tar_path),
-            })
 
         self.apply_plugin_annotations(annotations)
         self.set_koji_task_annotations_whitelist(annotations)

--- a/atomic_reactor/schemas/workflow_data.json
+++ b/atomic_reactor/schemas/workflow_data.json
@@ -28,11 +28,6 @@
 
     "buildargs": {"type": "object"},
 
-    "exported_image_sequence": {
-      "type": "array",
-      "items": {"$ref": "#/definitions/exported_image_info"}
-    },
-
     "files": {"type": "object"},
     "image_components": {
       "type": ["object", "null"],
@@ -70,9 +65,8 @@
     "plugins_results",
     "plugins_timestamps", "plugins_durations", "plugins_errors", "build_canceled",
     "reserved_build_id", "reserved_token", "koji_source_nvr", "koji_source_source_url", "koji_source_manifest",
-    "buildargs", "exported_image_sequence", "files", "image_components", "all_yum_repourls",
-    "annotations", "parent_images_digests",
-    "koji_upload_files"
+    "buildargs", "files", "image_components", "all_yum_repourls", "annotations",
+    "parent_images_digests", "koji_upload_files"
   ],
   "additionalProperties": false,
   "definitions": {

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -339,7 +339,6 @@ def get_image_output(image_type, image_id, arch, pullspec):
     :return: tuple, (metadata dict, Output instance)
 
     """
-    # OSBS2 TBD exported_image_sequence will not work for multiple platform
     image_name = get_image_upload_filename(image_type, image_id, arch)
 
     readme_content = ('Archive is just a placeholder for the koji archive, if you need the '

--- a/docs/api.md
+++ b/docs/api.md
@@ -469,7 +469,6 @@ This class defines a workflow for building images
 - builder
 - built_image_inspect
 - exit_plugins_conf
-- exported_image_sequence
 - files
 - image
 - kwargs


### PR DESCRIPTION
it's not used any more with pipelines

* CLOUDBLD-10182

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
