### PR TITLE
don't add arch to logs

### DIFF
--- a/atomic_reactor/__init__.py
+++ b/atomic_reactor/__init__.py
@@ -20,14 +20,6 @@ from osbs.constants import ATOMIC_REACTOR_LOGGING_FMT, USER_WARNING_LEVEL
 from osbs.utils import user_warning_log_handler
 
 
-class ArchFormatter(logging.Formatter):
-    def format(self, record):
-        if not hasattr(record, 'arch'):
-            record.arch = '-'
-
-        return super(ArchFormatter, self).format(record)
-
-
 class EncodedStream(object):
     # The point of this class is to force python to enocde UTF-8
     # over stderr.  Normal techniques were not working, so we dup
@@ -78,7 +70,7 @@ def set_logging(name="atomic_reactor", level=logging.DEBUG, handler=None):
         handler.setLevel(logging.DEBUG)
 
         # create formatter
-        formatter = ArchFormatter(ATOMIC_REACTOR_LOGGING_FMT)
+        formatter = logging.Formatter(ATOMIC_REACTOR_LOGGING_FMT)
 
         # add formatter to ch
         handler.setFormatter(formatter)

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -62,7 +62,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3d68328c5c906b4b54805694ae5ed9f2d6abd2fd
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ jsonschema
 paramiko>=2.10.1
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@3d68328c5c906b4b54805694ae5ed9f2d6abd2fd#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@2c9ed368e21e9e8ec310241d507457d2bc896216
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3d68328c5c906b4b54805694ae5ed9f2d6abd2fd
     # via -r requirements.in
 paramiko==2.10.3
     # via -r requirements.in


### PR DESCRIPTION
Arch can be distinguished by task names.

* CLOUDBLD-10132

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
