### PR TITLE
Remove 'task_annotations_whitelist'

### DIFF
--- a/atomic_reactor/plugins/store_metadata.py
+++ b/atomic_reactor/plugins/store_metadata.py
@@ -84,18 +84,6 @@ class StoreMetadataPlugin(Plugin):
 
         return data
 
-    def set_koji_task_annotations_whitelist(self, annotations):
-        """Whitelist annotations to be included in koji task output
-
-        Allow annotations whose names are listed in task_annotations_whitelist
-        koji's configuration to be included in the build_annotations.json file,
-        which will be attached in the koji task output.
-        """
-        koji_config = self.workflow.conf.koji
-        whitelist = koji_config.get('task_annotations_whitelist')
-        if whitelist:
-            annotations['koji_task_annotations_whitelist'] = json.dumps(whitelist)
-
     def _update_annotations(self, annotations, updates):
         if updates:
             updates = {key: json.dumps(value) for key, value in updates.items()}
@@ -157,7 +145,6 @@ class StoreMetadataPlugin(Plugin):
             annotations['media-types'] = json.dumps(sorted(list(set(media_types))))
 
         self.apply_plugin_annotations(annotations)
-        self.set_koji_task_annotations_whitelist(annotations)
 
         try:
             self.workflow.osbs.update_annotations_on_build(pipeline_run_name, annotations)

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -79,13 +79,6 @@
                 "description": "Download data from koji insecurely",
                 "type": "boolean",
                 "default": false
-            },
-            "task_annotations_whitelist": {
-                "description": "Annotations to be included in the build_annotations.json task output file. If empty or not described, the file will not be generated",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
             }
         },
         "additionalProperties": false,

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -379,41 +379,6 @@ def test_store_metadata_fail_update_annotations(workflow, source_dir, caplog):
     assert 'annotations:' in caplog.text
 
 
-@pytest.mark.parametrize('koji_conf', (
-    {},
-    {'task_annotations_whitelist': []},
-    {'task_annotations_whitelist': ['foo']},
-    ))
-def test_set_koji_annotations_whitelist(workflow, source_dir, koji_conf):
-    env = (MockEnv(workflow)
-           .for_plugin(StoreMetadataPlugin.key)
-           .set_plugin_args({"url": "http://example.com/"}))
-    prepare(workflow)
-    if koji_conf is not None:
-        workflow.conf.conf['koji'] = koji_conf
-
-    df_content = dedent('''\
-        FROM nowhere
-        RUN nothing
-        CMD cowsay moo
-        ''')
-    mock_dockerfile(workflow, df_content)
-    output = env.create_runner().run()
-    assert StoreMetadataPlugin.key in output
-    annotations = output[StoreMetadataPlugin.key]["annotations"]
-    whitelist = None
-    if koji_conf:
-        whitelist = koji_conf.get('task_annotations_whitelist')
-
-    if whitelist:
-        assert 'koji_task_annotations_whitelist' in annotations
-        assert all(entry in whitelist for entry in koji_conf['task_annotations_whitelist'])
-        assert all(entry in whitelist for entry in json.loads(
-            annotations['koji_task_annotations_whitelist']))
-    else:
-        assert 'koji_task_annotations_whitelist' not in annotations
-
-
 def test_plugin_annotations(workflow):
     env = (MockEnv(workflow)
            .for_plugin(StoreMetadataPlugin.key)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
