### PR TITLE
Do not autosave context data in build tasks

### DIFF
--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -56,6 +56,10 @@ class BinaryBuildTaskParams(TaskParams):
 class BinaryBuildTask(Task[BinaryBuildTaskParams]):
     """Binary container build task."""
 
+    # Build tasks run in parallel, saving context data would lead to race conditions
+    #   and inconsistencies. Luckily, this task does not make any context data updates.
+    autosave_context_data = False
+
     def execute(self) -> None:
         """Build a container image for the platform specified in the task parameters.
 

--- a/atomic_reactor/tasks/common.py
+++ b/atomic_reactor/tasks/common.py
@@ -91,6 +91,8 @@ class Task(abc.ABC, Generic[ParamsT]):
     """Task; the main execution unit in atomic-reactor."""
 
     ignore_sigterm: ClassVar[bool] = False
+    # Automatically save context data before exiting? (Note: do not use for parallel tasks)
+    autosave_context_data: ClassVar[bool] = True
 
     def __init__(self, params: ParamsT):
         """Initialize a Task."""
@@ -129,6 +131,5 @@ class Task(abc.ABC, Generic[ParamsT]):
 
         finally:
             signal.signal(signal.SIGTERM, signal.SIG_DFL)
-            # For whatever the reason a task fails, always write the workflow
-            # data into the data file.
-            self.workflow_data.save(self.get_context_dir())
+            if self.autosave_context_data:
+                self.workflow_data.save(self.get_context_dir())

--- a/tests/tasks/test_common.py
+++ b/tests/tasks/test_common.py
@@ -212,3 +212,16 @@ class TestTask:
         signal_mock.should_receive("signal").with_args(signal.SIGTERM, signal.SIG_DFL).once()
 
         task.run()
+
+    @pytest.mark.parametrize("autosave", [True, False])
+    def test_autosave_context_data(self, autosave, params):
+
+        class SomeTask(common.Task):
+            autosave_context_data = autosave
+
+            def execute(self):
+                return None
+
+        task = SomeTask(params)
+        flexmock(task.workflow_data).should_receive("save").times(1 if autosave else 0)
+        task.run()


### PR DESCRIPTION
CLOUDBLD-10570

Build tasks run in parallel, which means there can be races between one
task reading the data and another one writing it.

Even without races, saving data could cause inconsistencies; the changes
made by one task could be overwritten by another one.

Luckily, the build task does not update anything in the context data and
so does not need to save it.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
