### PR TITLE
Fix conversion of config blob to inspect format

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -886,29 +886,23 @@ class RegistryClient(object):
             raise RuntimeError("Image {image_name} not found: No v2 schema 1 image, "
                                "or v2 schema 2 image or list, found".format(image_name=image))
 
-        # dictionary to convert config keys to inspect keys
-        config_2_inspect = {
-            'created': 'Created',
-            'os': 'Os',
-            'container_config': 'ContainerConfig',
-            'architecture': 'Architecture',
-            'docker_version': 'DockerVersion',
-            'config': 'Config',
-        }
-
         if not blob_config:
             raise RuntimeError("Image {image_name}: Couldn't get inspect data "
                                "from digest config".format(image_name=image))
 
-        # set Id, which isn't in config blob
-        # Won't be set for v1,as for that image has to be pulled
-        image_inspect['Id'] = config_digest
+        image_inspect = {
+            # set Id, which isn't in config blob
+            # Won't be set for v1,as for that image has to be pulled
+            'Id': config_digest,
+            'Architecture': blob_config['architecture'],
+            'Os': blob_config['os'],
+            # According to OCI spec, 'created' and 'config' are optional
+            'Created': blob_config.get('created'),
+            'Config': blob_config.get('config') or {},
+        }
         # only v2 has rootfs, not v1
         if 'rootfs' in blob_config:
             image_inspect['RootFS'] = blob_config['rootfs']
-
-        for old_key, new_key in config_2_inspect.items():
-            image_inspect[new_key] = blob_config[old_key]
 
         return image_inspect
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1608,9 +1608,7 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
     inspect_data = {
         'created': 'create_time',
         'os': 'os version',
-        'container_config': 'container config',
         'architecture': 'arch',
-        'docker_version': 'docker version',
         'config': 'conf',
         'rootfs': 'some roots'
     }
@@ -1619,9 +1617,7 @@ def test_get_inspect_for_image(insecure, found_versions, type_in_list, will_rais
     expect_inspect = {
         'Created': 'create_time',
         'Os': 'os version',
-        'ContainerConfig': 'container config',
         'Architecture': 'arch',
-        'DockerVersion': 'docker version',
         'Config': 'conf',
         'RootFS': 'some roots',
         'Id': config_digest


### PR DESCRIPTION
Cherry-picks b7b6dfec

CLOUDBLD-9968

The container_config and docker_version keys are docker-specific. OSBS2
builds with podman. OSBS1 needs to be forward-compatible with base
images built in OSBS 2 (until decommissioned).

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
