### PR TITLE
Ignore empty layers in image history

### DIFF
--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -33,8 +33,6 @@ from atomic_reactor.source import get_source_instance_for, DummySource
 from atomic_reactor.constants import (
     CONTAINER_DEFAULT_BUILD_METHOD,
     DOCKER_STORAGE_TRANSPORT_NAME,
-    INSPECT_ROOTFS,
-    INSPECT_ROOTFS_LAYERS,
     PLUGIN_BUILD_ORCHESTRATE_KEY
 )
 from atomic_reactor.util import exception_message
@@ -380,7 +378,7 @@ class DockerBuildWorkflow(object):
 
         self.builder = None
         self.built_image_inspect = None
-        self.layer_sizes = []
+        self.built_image_history = []
         self.default_image_build_method = CONTAINER_DEFAULT_BUILD_METHOD
         self.storage_transport = DOCKER_STORAGE_TRANSPORT_NAME
 
@@ -541,13 +539,7 @@ class DockerBuildWorkflow(object):
             if self.build_result.is_image_available():
                 self.built_image_inspect = self.builder.inspect_built_image()
                 history = self.builder.tasker.get_image_history(self.builder.image_id)
-                diff_ids = self.built_image_inspect[INSPECT_ROOTFS][INSPECT_ROOTFS_LAYERS]
-
-                # diff_ids is ordered oldest first
-                # history is ordered newest first
-                # We want layer_sizes to be ordered oldest first
-                self.layer_sizes = [{"diff_id": diff_id, "size": layer['Size']}
-                                    for (diff_id, layer) in zip(diff_ids, reversed(history))]
+                self.built_image_history = history
 
             try:
                 postbuild_runner.run()

--- a/atomic_reactor/plugins/post_tag_and_push.py
+++ b/atomic_reactor/plugins/post_tag_and_push.py
@@ -172,7 +172,7 @@ class TagAndPushPlugin(PostBuildPlugin):
                     raise RuntimeError("Image name must not contain registry: %r" % image.registry)
 
                 if not source_docker_archive:
-                    image_size = sum(item['size'] for item in self.workflow.layer_sizes)
+                    image_size = sum(layer['Size'] for layer in self.workflow.built_image_history)
                     config_image_size = image_size_limit['binary_image']
                     # Only handle the case when size is set > 0 in config
                     if config_image_size and image_size > config_image_size:

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -485,7 +485,7 @@ def get_output(workflow, buildroot_id, pullspec, platform, source_build=False, l
     config = copy.deepcopy(registries[0].config)
 
     # We don't need container_config section
-    if config and 'container_config' in config:
+    if 'container_config' in config:
         del config['container_config']
 
     repositories, typed_digests = get_repositories_and_digests(workflow, pullspec)
@@ -511,9 +511,6 @@ def get_output(workflow, buildroot_id, pullspec, platform, source_build=False, l
             },
         },
     })
-
-    if not config:
-        del metadata['extra']['docker']['config']
 
     if not source_build:
         metadata['components'] = get_image_components(workflow)

--- a/tests/plugins/test_tag_and_push.py
+++ b/tests/plugins/test_tag_and_push.py
@@ -650,10 +650,10 @@ def test_exceed_binary_image_size(image_size_limit, workflow):
     workflow.builder = StubInsideBuilder()
     workflow.builder.image_id = INPUT_IMAGE
     # fake layer sizes of the test image
-    workflow.layer_sizes = [
-        {'diff_id': '12345', 'size': 1000},
-        {'diff_id': '23456', 'size': 2000},
-        {'diff_id': '34567', 'size': 3000},
+    workflow.built_image_history = [
+        {'Created': '2022-07-21T11:55:24Z', 'Size': 3000},
+        {'Created': '2022-07-21T11:55:23Z', 'Size': 2000},
+        {'Created': '2022-07-21T11:55:22Z', 'Size': 1000},
     ]
 
     mock_docker()

--- a/tests/test_inner.py
+++ b/tests/test_inner.py
@@ -1341,37 +1341,6 @@ def test_show_version(has_version, caplog):
     ) == has_version
 
 
-def test_layer_sizes():
-    flexmock(DockerfileParser, content='df_content')
-    this_file = inspect.getfile(PreRaises)
-    mock_docker()
-    fake_builder = MockInsideBuilder()
-    flexmock(InsideBuilder).new_instances(fake_builder)
-    watch_exit = Watcher()
-    watch_buildstep = Watcher()
-    workflow = DockerBuildWorkflow(source=SOURCE,
-                                   exit_plugins=[{'name': 'uses_source',
-                                                  'args': {
-                                                      'watcher': watch_exit,
-                                                  }}],
-                                   buildstep_plugins=[{'name': 'buildstep_watched',
-                                                       'args': {
-                                                           'watcher': watch_buildstep,
-                                                       }}],
-                                   plugin_files=[this_file])
-
-    workflow.build_docker_image()
-
-    expected = [
-        {'diff_id': u'sha256:diff_id1-oldest', 'size': 4},
-        {'diff_id': u'sha256:diff_id2', 'size': 3},
-        {'diff_id': u'sha256:diff_id3', 'size': 2},
-        {'diff_id': u'sha256:diff_id4-newest', 'size': 1}
-    ]
-
-    assert workflow.layer_sizes == expected
-
-
 @pytest.mark.parametrize('buildstep_plugins, is_orchestrator', [
     (None, False),
     ([], False),


### PR DESCRIPTION
CLOUDBLD-9968

When figuring out the sizes of layers corresponding to rootfs.diff_ids,
we use data from the image history. The diff_ids contain only non-empty
layers, history contains all layers including empty ones (created by
e.g. a LABEL or ENV instruction). Filter out empty layers from history
to get correct data.

To do that, we need to combine the .history attribute from the blob
config with the `docker history` output. The blob config history shows
which layers are empty but doesn't show layer sizes, docker history vice
versa. Note: Size == 0 does not necessarily mean the layer is empty (in
the sense of not creating a diff_id in the rootfs). See also
https://github.com/opencontainers/image-spec/blob/main/config.md

Previously, this was not an issue, because images built in OSBS 1 had
only non-empty layers in history. Those built in OSBS 2 also have empty
layers.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
