### PR TITLE
since we removed platforms from logs, koji-container can't find metadata

### DIFF
--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -13,7 +13,6 @@ from itertools import chain
 import koji
 import os
 import time
-import logging
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Iterable
 
@@ -487,8 +486,7 @@ class KojiImportBase(Plugin):
         local_filename = metadata_file.name
         try:
             uploaded_filename = self.upload_file(local_filename, "metadata.json", koji_upload_dir)
-            log = logging.LoggerAdapter(self.log, {'arch': METADATA_TAG})
-            log.info(uploaded_filename)
+            self.log.info("platform:%s %s", METADATA_TAG, uploaded_filename)
         finally:
             os.unlink(local_filename)
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -1516,14 +1516,18 @@ class TestKojiImport(object):
         runner.run()
 
         if is_scratch:
-            medata_tag = '_metadata_'
+            medata_tag = 'platform:_metadata_'
             metadata_file = 'metadata.json'
             assert metadata_file in session.uploaded_files
             data = json.loads(session.uploaded_files[metadata_file])
-            meta_rec = {x.arch: x.message for x in caplog.records if hasattr(x, 'arch')
-                        and x.arch == medata_tag}
-            assert medata_tag in meta_rec
-            assert os.path.join('upload-dir', metadata_file) == meta_rec[medata_tag]
+
+            meta_record = ''
+            for rec in caplog.records:
+                if medata_tag in rec.message:
+                    _, meta_record = rec.message.rsplit(' ', 1)
+                    break
+
+            assert os.path.join('upload-dir', metadata_file) == meta_record
         else:
             data = session.metadata
 

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -160,7 +160,7 @@ def test_ensure_workflow_data_is_saved_in_various_conditions(
         # Start the task.run in a separate process and terminate it.
         # This simulates the Cancel behavior by TERM signal.
 
-        def _build_docker_image(self, *args, **kwargs):
+        def _build_docker_image(*args, **kwargs):
 
             def _cancel_build(*args, **kwargs):
                 raise TaskCanceledException()
@@ -180,6 +180,7 @@ def test_ensure_workflow_data_is_saved_in_various_conditions(
         time.sleep(0.3)
         proc.terminate()
 
+    time.sleep(1)
     assert context_dir.join("workflow.json").exists()
 
     wf_data = ImageBuildWorkflowData()


### PR DESCRIPTION
info for scratch build, so log platform:_metadata_ in log message

* CLOUDBLD-10586

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
