### PR TITLE
store_metadata should check images only if build was successfull,

### DIFF
--- a/atomic_reactor/plugins/sendmail.py
+++ b/atomic_reactor/plugins/sendmail.py
@@ -150,6 +150,8 @@ class SendMailPlugin(Plugin):
         return should_send
 
     def _get_image_name_and_repos(self):
+        if not self.workflow.build_dir.has_sources:
+            return '', []
 
         dockerfile = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
             self.workflow.imageutil.base_image_inspect()

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -736,9 +736,6 @@ class TestSendMailPlugin(object):
         (flexmock(p).should_receive('_should_send')
             .with_args(False, False).and_return(True))
         flexmock(p).should_receive('_get_receivers_list').and_return(receivers)
-        flexmock(p).should_receive('_get_image_name_and_repos').and_return(('foobar',
-                                                                           ['foo/bar:baz',
-                                                                            'foo/bar:spam']))
 
         smtp_inst = SMTP()
         flexmock(smtplib).should_receive('SMTP').and_return(smtp_inst)


### PR DESCRIPTION
store_metadata and sendmail shouldn't check build_dir if
check_and_set_platforms didn't run

* CLOUDBLD-10441

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
