### PR TITLE
Use the configured path for manifests instead of default

### DIFF
--- a/atomic_reactor/plugins/export_operator_manifests.py
+++ b/atomic_reactor/plugins/export_operator_manifests.py
@@ -100,7 +100,11 @@ class ExportOperatorManifestsPlugin(Plugin):
             raise ValueError(f'Operator manifests check in built image failed: {e}') from e
 
         repo_csv: OperatorCSV = OperatorManifest.from_directory(
-            os.path.join(self.workflow.build_dir.any_platform.path, MANIFESTS_DIR_NAME)).csv
+            os.path.join(
+                self.workflow.build_dir.any_platform.path,
+                self.workflow.source.config.operator_manifests["manifests_dir"],
+            )
+        ).csv
 
         if image_csv.checksum != repo_csv.checksum:
             image_csv_filename = os.path.basename(image_csv.path)

--- a/tests/plugins/test_export_operator_manifests.py
+++ b/tests/plugins/test_export_operator_manifests.py
@@ -125,6 +125,7 @@ def mock_env(workflow, has_appregistry_label=False, appregistry_label=False,
 
     env.workflow.build_dir.init_build_dirs(PLATFORMS, env.workflow.source)
     env.workflow.data.tag_conf.add_unique_image(TEST_IMAGE)
+    env.workflow.source.config.operator_manifests = {"manifests_dir": "manifests"}
 
     mock_oc_image_extract = functools.partial(extract_manifests_dir, empty=empty_archive,
                                               multiple_csv=multiple_csv, has_archive=has_archive,


### PR DESCRIPTION
CLOUDBLD-10685

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
