### PR TITLE
check_and_set_platforms sets platforms_results with final platforms, for

### DIFF
--- a/atomic_reactor/cli/parser.py
+++ b/atomic_reactor/cli/parser.py
@@ -82,6 +82,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> dict:
         description="Execute binary container pre-build steps.",
     )
     binary_container_prebuild.set_defaults(func=task.binary_container_prebuild)
+    binary_container_prebuild.add_argument("--platforms-result", metavar="FILE", default=None,
+                                           help="file to write final platforms result")
 
     binary_container_build = tasks.add_parser(
         "binary-container-build",

--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -5,7 +5,8 @@ All rights reserved.
 This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
-from atomic_reactor.tasks.binary import BinaryExitTask, BinaryPostBuildTask, BinaryPreBuildTask
+from atomic_reactor.tasks.binary import (BinaryExitTask, BinaryPostBuildTask, BinaryPreBuildTask,
+                                         PreBuildTaskParams)
 from atomic_reactor.tasks.binary_container_build import BinaryBuildTask, BinaryBuildTaskParams
 from atomic_reactor.tasks.clone import CloneTask
 from atomic_reactor.tasks.common import TaskParams
@@ -49,7 +50,7 @@ def binary_container_prebuild(task_args: dict):
 
     :param task_args: CLI arguments for a binary-container-prebuild task
     """
-    params = TaskParams.from_cli_args(task_args)
+    params = PreBuildTaskParams.from_cli_args(task_args)
     task = BinaryPreBuildTask(params)
     return task.run()
 

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -465,6 +465,7 @@ class DockerBuildWorkflow(object):
         plugins_conf: Optional[List[Dict[str, Any]]] = None,
         plugin_files: Optional[List[str]] = None,
         keep_plugins_running: bool = False,
+        platforms_result: Optional[str] = None,
     ):
         """
         :param context_dir: the directory passed to task --context-dir argument.
@@ -484,6 +485,7 @@ class DockerBuildWorkflow(object):
         :param client_version: osbs-client version used to render build json
         :param bool keep_plugins_running: keep plugins running even if error is
             raised from previous one. This is passed to ``PluginsRunner`` directly.
+        :param platforms_result: path to platform results for prebuild task
         """
         self.context_dir = context_dir
         self.build_dir = build_dir
@@ -492,6 +494,7 @@ class DockerBuildWorkflow(object):
         self.pipeline_run_name = pipeline_run_name
         self.source = source or DummySource(None, None)
         self.user_params = user_params or self._default_user_params.copy()
+        self.platforms_result = platforms_result
 
         self.keep_plugins_running = keep_plugins_running
         self.plugin_files = plugin_files

--- a/atomic_reactor/plugins/check_and_set_platforms.py
+++ b/atomic_reactor/plugins/check_and_set_platforms.py
@@ -9,6 +9,7 @@ of the BSD license. See the LICENSE file for details.
 Query the koji build target, if any, to find the enabled architectures. Remove any excluded
 architectures, and return the resulting list.
 """
+import json
 from typing import List, Optional
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import is_scratch_build, is_isolated_build, map_to_user_params
@@ -126,5 +127,9 @@ class CheckAndSetPlatformsPlugin(Plugin):
             raise RuntimeError("No platforms to build for")
 
         self.workflow.build_dir.init_build_dirs(final_defined, self.workflow.source)
+
+        if self.workflow.platforms_result:
+            with open(self.workflow.platforms_result, 'w') as f:
+                f.write(json.dumps(final_defined))
 
         return final_defined

--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -33,6 +33,8 @@ spec:
       value: $(tasks.binary-container-build-ppc64le.results.task_result)
     - name: task_build_result_aarch64
       value: $(tasks.binary-container-build-aarch64.results.task_result)
+    - name: platforms_result
+      value: $(tasks.binary-container-prebuild.results.platforms_result)
 
   tasks:
     - name: clone

--- a/tekton/tasks/binary-container-prebuild.yaml
+++ b/tekton/tasks/binary-container-prebuild.yaml
@@ -24,6 +24,9 @@ spec:
     - name: ws-koji-secret  # access with $(workspaces.ws-koji-secret.path)/token
     - name: ws-reactor-config-map
 
+  results:
+    - name: platforms_result
+
   stepTemplate:
     env:
       - name: HOME
@@ -49,3 +52,4 @@ spec:
         --namespace=$(context.taskRun.namespace)
         --pipeline-run-name="$(params.pipeline-run-name)"
         binary-container-prebuild
+        --platforms-result=$(results.platforms_result.path)

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -41,6 +41,10 @@ EXPECTED_ARGS_BINARY_CONTAINER_BUILD = {
     **EXPECTED_ARGS,
     "platform": "x86_64",
 }
+EXPECTED_ARGS_CONTAINER_PREBUILD = {
+    **EXPECTED_ARGS,
+    "platforms_result": None,
+}
 EXPECTED_ARGS_JOB = {
     "quiet": False,
     "verbose": False,
@@ -75,7 +79,7 @@ def test_parse_args_version(capsys):
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "binary-container-prebuild"],
-            {**EXPECTED_ARGS, "func": task.binary_container_prebuild},
+            {**EXPECTED_ARGS_CONTAINER_PREBUILD, "func": task.binary_container_prebuild},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "binary-container-build",
@@ -102,7 +106,8 @@ def test_parse_args_version(capsys):
         (
             ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml",
              "binary-container-prebuild"],
-            {**EXPECTED_ARGS, "config_file": "config.yaml", "func": task.binary_container_prebuild},
+            {**EXPECTED_ARGS_CONTAINER_PREBUILD, "config_file": "config.yaml",
+             "func": task.binary_container_prebuild},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml",
@@ -121,6 +126,12 @@ def test_parse_args_version(capsys):
              "binary-container-postbuild"],
             {**EXPECTED_ARGS, "task_result": "result_file",
              "func": task.binary_container_postbuild},
+        ),
+        (
+            ["task", *REQUIRED_COMMON_ARGS, "binary-container-prebuild",
+             "--platforms-result=platforms_file"],
+            {**EXPECTED_ARGS, "platforms_result": "platforms_file",
+             "func": task.binary_container_prebuild},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "binary-container-exit"],

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -28,17 +28,21 @@ TASK_ARGS = {
     "config_file": "reactor-config-map.yaml",
     "user_params": '{"some_param": "some_value"}',
 }
+PRE_TASK_ARGS = {
+    **TASK_ARGS,
+    "platforms_result": 'platform_result',
+}
 
 TASK_RESULT = object()
 
 
-def mock(task_cls, init_build_dirs=False):
+def mock(task_cls, init_build_dirs=False, task_args=TASK_ARGS):
     params = flexmock()
     (
         #  mock the common TaskParams because child classes do not override from_cli_args
         flexmock(common.TaskParams)
         .should_receive("from_cli_args")
-        .with_args(TASK_ARGS)
+        .with_args(task_args)
         .and_return(params)
     )
     flexmock(task_cls).should_receive("__init__").with_args(params)
@@ -57,8 +61,8 @@ def test_source_build():
 
 
 def test_binary_container_prebuild():
-    mock(binary.BinaryPreBuildTask)
-    assert task.binary_container_prebuild(TASK_ARGS) == TASK_RESULT
+    mock(binary.BinaryPreBuildTask, task_args=PRE_TASK_ARGS)
+    assert task.binary_container_prebuild(PRE_TASK_ARGS) == TASK_RESULT
 
 
 def test_binary_container_build():

--- a/tests/tasks/test_plugin_based.py
+++ b/tests/tasks/test_plugin_based.py
@@ -17,6 +17,7 @@ import pytest
 from atomic_reactor.inner import ImageBuildWorkflowData
 from atomic_reactor.plugin import TaskCanceledException, PluginFailedException
 from atomic_reactor.tasks.common import TaskParams
+from atomic_reactor.tasks.binary import PreBuildTaskParams, BinaryPreBuildTask
 from atomic_reactor.util import DockerfileImages
 
 from atomic_reactor import inner, dirs
@@ -182,6 +183,40 @@ def test_ensure_workflow_data_is_saved_in_various_conditions(
         time.sleep(0.3)
         proc.terminate()
 
+    time.sleep(1)
+    assert context_dir.join("workflow.json").exists()
+
+    wf_data = ImageBuildWorkflowData()
+    wf_data.load_from_dir(ContextDir(Path(context_dir)))
+    # As long as the data is loaded successfully, just check some
+    # attributes to check the data.
+    assert DockerfileImages() == wf_data.dockerfile_images
+    assert {} == wf_data.plugins_results
+
+
+def test_ensure_workflow_data_is_saved_prebuild_task(
+    build_dir, dummy_source, tmpdir
+):
+    context_dir = tmpdir.join("context_dir").mkdir()
+    params = PreBuildTaskParams(build_dir=str(build_dir),
+                                config_file="config.yaml",
+                                context_dir=str(context_dir),
+                                namespace="test-namespace",
+                                pipeline_run_name='test-pipeline-run',
+                                user_params={},
+                                task_result='results',
+                                platforms_result='platforms_result')
+    (flexmock(params)
+     .should_receive("source")
+     .and_return(dummy_source))
+
+    task = BinaryPreBuildTask(params)
+
+    (flexmock(plugin_based.inner.DockerBuildWorkflow)
+     .should_receive("build_docker_image")
+     .once())
+
+    task.run()
     time.sleep(1)
     assert context_dir.join("workflow.json").exists()
 


### PR DESCRIPTION
koji-container build to consume

* CLOUDBLD-10661

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
