### PR TITLE
Don't follow symlinks when copying files

### DIFF
--- a/atomic_reactor/dirs.py
+++ b/atomic_reactor/dirs.py
@@ -172,7 +172,7 @@ class RootBuildDir(object):
         logger.debug("copy method used for copy sources: %s", copy_method.__name__)
 
         for platform in self.platforms:
-            copytree(src_path, self.path / platform, copy_function=copy_method)
+            copytree(src_path, self.path / platform, symlinks=True, copy_function=copy_method)
 
     @property
     def has_sources(self) -> bool:
@@ -301,10 +301,10 @@ class RootBuildDir(object):
                 dest = self.path / platform / src_file.relative_to(build_dir.path)
 
                 if src_file.is_dir():
-                    copytree(src_file, dest, copy_function=copy_method)
+                    copytree(src_file, dest, symlinks=True, copy_function=copy_method)
                 else:
                     dest.parent.mkdir(parents=True, exist_ok=True)
-                    copy_method(src_file, dest)
+                    copy_method(src_file, dest, follow_symlinks=False)
 
         return the_new_files
 


### PR DESCRIPTION
CLOUDBLD-10684

https://docs.python.org/3/library/shutil.html#shutil.copytree

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
