### PR TITLE
overwrite contents of destination of `oc image extract`

### DIFF
--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -138,7 +138,8 @@ class ImageUtil:
         if any(Path(dst_path).iterdir()):
             raise NonEmptyDestinationError(f'the destination directory {dst_path} must be empty')
 
-        cmd = ['oc', 'image', 'extract', f'{image}', '--path', f'{src_path}:{dst_path}']
+        cmd = ['oc', 'image', 'extract', f'{image}', '--confirm', '--path',
+               f'{src_path}:{dst_path}']
 
         try:
             retries.run_cmd(cmd)

--- a/tests/utils/test_imageutil.py
+++ b/tests/utils/test_imageutil.py
@@ -194,7 +194,8 @@ class TestImageUtil:
         (
             flexmock(retries)
             .should_receive("run_cmd")
-            .with_args(['oc', 'image', 'extract', image, '--path', f'{src_path}:{dst_path}'])
+            .with_args(['oc', 'image', 'extract', image, '--confirm', '--path',
+                        f'{src_path}:{dst_path}'])
             .once()
         )
         with pytest.raises(
@@ -215,7 +216,8 @@ class TestImageUtil:
         (
             flexmock(retries)
             .should_receive("run_cmd")
-            .with_args(['oc', 'image', 'extract', image, '--path', f'{src_path}:{dst_path}'])
+            .with_args(['oc', 'image', 'extract', image, '--confirm', '--path',
+                        f'{src_path}:{dst_path}'])
             .and_raise(
                 subprocess.CalledProcessError(1, ["oc", "..."], output=b'something went wrong')
             )
@@ -244,7 +246,8 @@ class TestImageUtil:
         (
             flexmock(retries)
             .should_receive("run_cmd")
-            .with_args(['oc', 'image', 'extract', image, '--path', f'{src_path}:{dst_path}'])
+            .with_args(['oc', 'image', 'extract', image, '--confirm', '--path',
+                        f'{src_path}:{dst_path}'])
             .replace_with(mock_extract_file).once()
         )
         image_util.extract_file_from_image(image=image, src_path=src_path, dst_path=dst_path)


### PR DESCRIPTION
Otherwise retry won't work.

* CLOUDBLD-10668

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
