### PR TITLE
Do not log error responses from retries as errors

### DIFF
--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -50,7 +50,10 @@ def hook_log_error_response_content(response, *args, **kwargs):
     :type response: requests.Response
     """
     if 400 <= response.status_code <= 599:
-        logger.error('Error response from %s: %s', response.url, response.content)
+        logger.debug(
+            'HTTP %d response from %s: %s',
+            response.status_code, response.url, response.content
+        )
 
 
 def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,

--- a/tests/utils/test_retries.py
+++ b/tests/utils/test_retries.py
@@ -84,7 +84,7 @@ def test_log_error_response(http_code, caplog):
     session.get(api_url)
 
     content = json.dumps(json_data).encode()
-    expected = f"Error response from {api_url}: {content}"
+    expected = f"HTTP {http_code} response from {api_url}: {content}"
     if 400 <= http_code <= 599:
         assert expected in caplog.text
     else:


### PR DESCRIPTION
Sometimes error code is ecpected and shouldn't be treated as error. In
fact everything logged from retries should be just DEBUG.

Many errors in logs scary users.

Removing "Error" from log string and replacing it with http status code.

CLOUDBLD-10533

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
