### PR TITLE
don't cache registry client

### DIFF
--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -108,7 +108,6 @@ class ImageUtil:
         client = self._get_registry_client(parsed_image.registry)
         return client.get_inspect_for_image(parsed_image, goarch)
 
-    @functools.lru_cache(maxsize=None)
     def _get_registry_client(self, registry: str) -> util.RegistryClient:
         session = util.RegistrySession.create_from_config(self._conf, registry)
         return util.RegistryClient(session)

--- a/tests/utils/test_imageutil.py
+++ b/tests/utils/test_imageutil.py
@@ -164,10 +164,13 @@ class TestImageUtil:
             .once()
             .and_return(registry_session)
         )
-        flexmock(util.RegistryClient).should_receive("__init__").with_args(registry_session).once()
+        (
+            flexmock(util.RegistryClient)
+            .should_receive("__init__")
+            .with_args(registry_session)
+            .once()
+        )
 
-        image_util._get_registry_client("registry.com")
-        # test caching (i.e. test that the create_from_config method is called only once)
         image_util._get_registry_client("registry.com")
 
     def test_extract_file_from_image_non_empty_dst_dir(self, tmpdir):


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
