### PR TITLE
Raise memory request and limit for prebuild task

### DIFF
--- a/tekton/tasks/binary-container-prebuild.yaml
+++ b/tekton/tasks/binary-container-prebuild.yaml
@@ -38,10 +38,10 @@ spec:
       workingDir: $(workspaces.ws-home-dir.path)
       resources:
         requests:
-          memory: 300Mi
+          memory: 512Mi
           cpu: 250m
         limits:
-          memory: 600Mi
+          memory: 1Gi
           cpu: 395m
       script: >
         atomic-reactor -v task


### PR DESCRIPTION
CLOUDBLD-10932

Some prebuild tasks were getting OOMKilled while generating content
manifests. The improvements to add_image_content_manifest code should
help with that, but based on the investigation, the tasks were still
approaching the 600 Mi limit even after the changes.

Bump the limit to 1Gi, which should be safe even for builds with very
large ICMs. The pipeline should still fit within the same memory quota,
since the quota is calculated based on parallel build task requirements
=> 4x 600 Mi = 2400 Mi.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
