### PR TITLE
Cleanup on retry

### DIFF
--- a/atomic_reactor/plugins/build_source_container.py
+++ b/atomic_reactor/plugins/build_source_container.py
@@ -37,9 +37,10 @@ class SourceContainerPlugin(Plugin):
         source_img = 'oci:{}'.format(image_output_dir)
         dest_img = 'docker-archive:{}'.format(output_path)
         cmd += [source_img, dest_img]
+        cleanup_cmd = ['rm', str(output_path)]
 
         try:
-            retries.run_cmd(cmd)
+            retries.run_cmd(cmd, cleanup_cmd)
         except subprocess.CalledProcessError as e:
             self.log.error("failed to save docker-archive :\n%s", e.output)
             raise

--- a/atomic_reactor/plugins/flatpak_create_oci.py
+++ b/atomic_reactor/plugins/flatpak_create_oci.py
@@ -85,9 +85,10 @@ class FlatpakCreateOciPlugin(Plugin):
 
         cmd = ['skopeo', 'copy', 'oci:{path}:{ref_name}'.format(**metadata), '--format=v2s2',
                'docker-archive:{}'.format(str(build_dir.exported_squashed_image))]
+        cleanup_cmd = ['rm', str(build_dir.exported_squashed_image)]
 
         try:
-            retries.run_cmd(cmd)
+            retries.run_cmd(cmd, cleanup_cmd)
         except subprocess.CalledProcessError as e:
             self.log.error("skopeo copy failed with output:\n%s", e.output)
             raise RuntimeError("skopeo copy failed with output:\n{}".format(e.output)) from e

--- a/atomic_reactor/utils/imageutil.py
+++ b/atomic_reactor/utils/imageutil.py
@@ -158,8 +158,9 @@ class ImageUtil:
         :param path: str, path including the filename of the tarball
         """
         cmd = ['skopeo', 'copy', f'docker://{image}', f'docker-archive:{path}']
+        cleanup_cmd = ['rm', path]
         try:
-            retries.run_cmd(cmd)
+            retries.run_cmd(cmd, cleanup_cmd)
         except subprocess.CalledProcessError as e:
             logger.error("Image archive download failed:\n%s", e.output)
             raise

--- a/tests/plugins/test_build_source_container.py
+++ b/tests/plugins/test_build_source_container.py
@@ -92,12 +92,14 @@ def test_running_build(workflow, caplog,
     temp_bsi_dir = workflow.build_dir.path / 'SrcImg'
     temp_bsi_dir.mkdir()
 
-    def check_run_skopeo(args):
+    def check_run_skopeo(args, cleanup_args):
         """Mocked call to skopeo"""
         assert args[0] == 'skopeo'
         assert args[1] == 'copy'
         assert args[2] == 'oci:%s' % temp_image_output_dir
         assert args[3] == f'docker-archive:{exported_image_file}'
+        assert cleanup_args[0] == 'rm'
+        assert cleanup_args[1] == str(exported_image_file)
 
         if export_failed:
             raise subprocess.CalledProcessError(returncode=1, cmd=args, output="Failed")

--- a/tests/plugins/test_flatpak_create_oci.py
+++ b/tests/plugins/test_flatpak_create_oci.py
@@ -558,8 +558,11 @@ def test_flatpak_create_oci(workflow, config_name, flatpak_metadata, breakage):
             skopeo_cmd = ['skopeo', 'copy', f'oci:{str(platform_dir.path)}'
                                             f'/flatpak-oci-image:app/org.gnome.eog/x86_64/stable',
                           '--format=v2s2', f'docker-archive:{platform_dir.exported_squashed_image}']
-            flexmock(retries).should_receive('run_cmd').with_args(skopeo_cmd).and_raise(
-                subprocess.CalledProcessError(1, ["skopeo", "..."], output=b'something went wrong'))
+            cleanup_cmd = ['rm', str(platform_dir.exported_squashed_image)]
+            (flexmock(retries).should_receive('run_cmd')
+                .with_args(skopeo_cmd, cleanup_cmd)
+                .and_raise(subprocess.CalledProcessError(1, ["skopeo", "..."],
+                                                         output=b'something went wrong')))
         expected_exception = 'skopeo copy failed with output:'
     else:
         assert breakage is None

--- a/tests/utils/test_imageutil.py
+++ b/tests/utils/test_imageutil.py
@@ -262,7 +262,8 @@ class TestImageUtil:
         (
             flexmock(retries)
             .should_receive("run_cmd")
-            .with_args(['skopeo', 'copy', f'docker://{image}', f'docker-archive:{path}'])
+            .with_args(['skopeo', 'copy', f'docker://{image}', f'docker-archive:{path}'],
+                       ['rm', path])
             .once()
         )
         image_util.download_image_archive_tarball(image=image, path=path)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
