### PR TITLE
add annotation_results parameter for exit tasks, and save annotations

### DIFF
--- a/atomic_reactor/cli/parser.py
+++ b/atomic_reactor/cli/parser.py
@@ -68,6 +68,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> dict:
         description="Execute source container exit steps.",
     )
     source_container_exit.set_defaults(func=task.source_container_exit)
+    source_container_exit.add_argument("--annotations-result", metavar="FILE", default=None,
+                                       help="file to write annotations result")
 
     clone = tasks.add_parser(
         "clone",
@@ -107,6 +109,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> dict:
         description="Execute binary container exit steps.",
     )
     binary_container_exit.set_defaults(func=task.binary_container_exit)
+    binary_container_exit.add_argument("--annotations-result", metavar="FILE", default=None,
+                                       help="file to write annotations result")
 
     remote_hosts_unlocking_recovery = jobs.add_parser(
         "remote-hosts-unlocking-recovery",

--- a/atomic_reactor/cli/task.py
+++ b/atomic_reactor/cli/task.py
@@ -6,13 +6,12 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 from atomic_reactor.tasks.binary import (BinaryExitTask, BinaryPostBuildTask, BinaryPreBuildTask,
-                                         PreBuildTaskParams)
+                                         PreBuildTaskParams, BinaryExitTaskParams)
 from atomic_reactor.tasks.binary_container_build import BinaryBuildTask, BinaryBuildTaskParams
 from atomic_reactor.tasks.clone import CloneTask
 from atomic_reactor.tasks.common import TaskParams
-from atomic_reactor.tasks.sources import (
-    SourceExitTask, SourceBuildTask, SourceBuildTaskParams
-)
+from atomic_reactor.tasks.sources import (SourceExitTask, SourceBuildTask, SourceBuildTaskParams,
+                                          SourceExitTaskParams)
 
 
 def source_container_build(task_args: dict):
@@ -30,7 +29,7 @@ def source_container_exit(task_args: dict):
 
     :param task_args: CLI arguments for a source-container-exit task
     """
-    params = SourceBuildTaskParams.from_cli_args(task_args)
+    params = SourceExitTaskParams.from_cli_args(task_args)
     task = SourceExitTask(params)
     return task.run()
 
@@ -80,6 +79,6 @@ def binary_container_exit(task_args: dict):
 
     :param task_args: CLI arguments for a binary-container-exit task
     """
-    params = TaskParams.from_cli_args(task_args)
+    params = BinaryExitTaskParams.from_cli_args(task_args)
     task = BinaryExitTask(params)
     return task.run(init_build_dirs=True)

--- a/atomic_reactor/inner.py
+++ b/atomic_reactor/inner.py
@@ -466,6 +466,7 @@ class DockerBuildWorkflow(object):
         plugin_files: Optional[List[str]] = None,
         keep_plugins_running: bool = False,
         platforms_result: Optional[str] = None,
+        annotations_result: Optional[str] = None,
     ):
         """
         :param context_dir: the directory passed to task --context-dir argument.
@@ -486,6 +487,7 @@ class DockerBuildWorkflow(object):
         :param bool keep_plugins_running: keep plugins running even if error is
             raised from previous one. This is passed to ``PluginsRunner`` directly.
         :param platforms_result: path to platform results for prebuild task
+        :param annotations_result: path to annotations result for exit task
         """
         self.context_dir = context_dir
         self.build_dir = build_dir
@@ -495,6 +497,7 @@ class DockerBuildWorkflow(object):
         self.source = source or DummySource(None, None)
         self.user_params = user_params or self._default_user_params.copy()
         self.platforms_result = platforms_result
+        self.annotations_result = annotations_result
 
         self.keep_plugins_running = keep_plugins_running
         self.plugin_files = plugin_files

--- a/atomic_reactor/plugins/sendmail.py
+++ b/atomic_reactor/plugins/sendmail.py
@@ -13,7 +13,6 @@ from email.mime.base import MIMEBase
 from email import encoders
 import smtplib
 import socket
-import json
 
 from atomic_reactor.plugin import Plugin, PluginFailedException
 from atomic_reactor.plugins.koji_import import KojiImportPlugin
@@ -167,7 +166,7 @@ class SendMailPlugin(Plugin):
         if (annotation_repos := stored_data['annotations'].get('repositories')) is None:
             self.log.debug('repositories is not included in annotations.')
         else:
-            repo_data = json.loads(annotation_repos)
+            repo_data = annotation_repos
             repos.extend(repo_data.get('unique', []))
             repos.extend(repo_data.get('primary', []))
             repos.extend(repo_data.get('floating', []))

--- a/atomic_reactor/tasks/binary.py
+++ b/atomic_reactor/tasks/binary.py
@@ -25,6 +25,12 @@ class PreBuildTaskParams(TaskParams):
     platforms_result: Optional[str]
 
 
+@dataclass(frozen=True)
+class BinaryExitTaskParams(TaskParams):
+    """Binary container exit task parameters"""
+    annotations_result: Optional[str]
+
+
 class BinaryPreBuildTask(plugin_based.PluginBasedTask[PreBuildTaskParams]):
     """Binary container pre-build task."""
 
@@ -95,7 +101,7 @@ class BinaryPostBuildTask(plugin_based.PluginBasedTask[TaskParams]):
     ]
 
 
-class BinaryExitTask(plugin_based.PluginBasedTask[TaskParams]):
+class BinaryExitTask(plugin_based.PluginBasedTask[BinaryExitTaskParams]):
     """Binary container exit-build task."""
 
     keep_plugins_running = True
@@ -105,6 +111,12 @@ class BinaryExitTask(plugin_based.PluginBasedTask[TaskParams]):
         {"name": "store_metadata"},
         {"name": "sendmail"},
     ]
+
+    def prepare_workflow(self) -> inner.DockerBuildWorkflow:
+        """Fully initialize the workflow instance to be used for running the list of plugins."""
+        workflow = super().prepare_workflow()
+        workflow.annotations_result = self._params.annotations_result
+        return workflow
 
     def _output_dockerfile(self):
         dockerfile = Path(os.path.join(self._params.source.path, DOCKERFILE_FILENAME))

--- a/atomic_reactor/tasks/sources.py
+++ b/atomic_reactor/tasks/sources.py
@@ -7,7 +7,7 @@ of the BSD license. See the LICENSE file for details.
 """
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, Optional
 
 from atomic_reactor import inner
 from atomic_reactor import source
@@ -28,7 +28,13 @@ class SourceBuildTaskParams(common.TaskParams):
         return source.DummySource(None, None, workdir=self.build_dir)
 
 
-class SourceBuildBaseTask(plugin_based.PluginBasedTask[SourceBuildTaskParams]):
+@dataclass(frozen=True)
+class SourceExitTaskParams(SourceBuildTaskParams):
+    """Source exit task parameters"""
+    annotations_result: Optional[str]
+
+
+class SourceBuildBaseTask(plugin_based.PluginBasedTask[common.ParamsT]):
     """Base task for defining different build phases for source container build."""
 
     def prepare_workflow(self) -> inner.DockerBuildWorkflow:
@@ -65,3 +71,8 @@ class SourceExitTask(SourceBuildBaseTask):
         {"name": "cancel_build_reservation"},
         {"name": "store_metadata"},
     ]
+
+    def prepare_workflow(self) -> inner.DockerBuildWorkflow:
+        workflow = super().prepare_workflow()
+        workflow.annotations_result = self._params.annotations_result
+        return workflow

--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -35,6 +35,8 @@ spec:
       value: $(tasks.binary-container-build-aarch64.results.task_result)
     - name: platforms_result
       value: $(tasks.binary-container-prebuild.results.platforms_result)
+    - name: annotations
+      value: $(tasks.binary-container-exit.results.annotations)
 
   tasks:
     - name: clone

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -22,6 +22,8 @@ spec:
       value: $(tasks.source-container-set-results.results.repositories)
     - name: koji-build-id
       value: $(tasks.source-container-set-results.results.koji-build-id)
+    - name: annotations
+      value: $(tasks.source-container-exit.results.annotations)
 
   tasks:
     - name: source-container-build

--- a/tekton/tasks/binary-container-exit.yaml
+++ b/tekton/tasks/binary-container-exit.yaml
@@ -16,6 +16,9 @@ spec:
       type: string
       description: User parameters in JSON format
 
+  results:
+    - name: annotations
+
   workspaces:
     - name: ws-build-dir
     - name: ws-context-dir
@@ -49,3 +52,4 @@ spec:
         --namespace=$(context.taskRun.namespace)
         --pipeline-run-name="$(params.pipeline-run-name)"
         binary-container-exit
+        --annotations-result=$(results.annotations.path)

--- a/tekton/tasks/source-container-exit.yaml
+++ b/tekton/tasks/source-container-exit.yaml
@@ -16,6 +16,9 @@ spec:
       type: string
       description: User parameters in JSON format
 
+  results:
+    - name: annotations
+
   workspaces:
     - name: ws-build-dir
     - name: ws-context-dir
@@ -49,3 +52,4 @@ spec:
         --namespace=$(context.taskRun.namespace)
         --pipeline-run-name="$(params.pipeline-run-name)"
         source-container-exit
+        --annotations-result=$(results.annotations.path)

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -70,8 +70,10 @@ def test_parse_args_version(capsys):
             {**EXPECTED_ARGS, "func": task.source_container_build},
         ),
         (
-            ["task", *REQUIRED_COMMON_ARGS, "source-container-exit"],
-            {**EXPECTED_ARGS, "func": task.source_container_exit},
+            ["task", *REQUIRED_COMMON_ARGS, "source-container-exit",
+             "--annotations-result=annotations_file"],
+            {**EXPECTED_ARGS, "annotations_result": "annotations_file",
+             "func": task.source_container_exit},
         ),
         (
             ["task", *REQUIRED_COMMON_ARGS, "clone"],
@@ -91,8 +93,10 @@ def test_parse_args_version(capsys):
             {**EXPECTED_ARGS, "func": task.binary_container_postbuild},
         ),
         (
-            ["task", *REQUIRED_COMMON_ARGS, "binary-container-exit"],
-            {**EXPECTED_ARGS, "func": task.binary_container_exit},
+            ["task", *REQUIRED_COMMON_ARGS, "binary-container-exit",
+             "--annotations-result=annotations_file"],
+            {**EXPECTED_ARGS, "annotations_result": "annotations_file",
+             "func": task.binary_container_exit},
         ),
         # all common task args
         (
@@ -134,8 +138,10 @@ def test_parse_args_version(capsys):
              "func": task.binary_container_prebuild},
         ),
         (
-            ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "binary-container-exit"],
-            {**EXPECTED_ARGS, "config_file": "config.yaml", "func": task.binary_container_exit},
+            ["task", *REQUIRED_COMMON_ARGS, "--config-file=config.yaml", "binary-container-exit",
+             "--annotations-result=annotations_file"],
+            {**EXPECTED_ARGS, "annotations_result": "annotations_file",
+             "config_file": "config.yaml", "func": task.binary_container_exit},
         ),
         (
             ["job", *REQUIRED_JOB_ARGS, "remote-hosts-unlocking-recovery"],

--- a/tests/cli/test_task.py
+++ b/tests/cli/test_task.py
@@ -93,6 +93,7 @@ def test_binary_container_exit(has_dockerfile, build_dir, context_dir, caplog):
      .and_return(TASK_RESULT))
 
     task_args = TASK_ARGS.copy()
+    task_args["annotations_result"] = "annotations"
     task_args["context_dir"] = str(context_dir)
     task_args["build_dir"] = str(build_dir)
     task_args["namespace"] = "test"

--- a/tests/plugins/test_sendmail.py
+++ b/tests/plugins/test_sendmail.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from flexmock import flexmock
 import koji
 import pytest
-import json
 
 from atomic_reactor.inner import DockerBuildWorkflow
 from atomic_reactor.plugin import PluginFailedException
@@ -136,7 +135,7 @@ def mock_store_metadata_results(workflow, annotations=None):
     annotations = DEFAULT_ANNOTATIONS if annotations is None else annotations
     result = {}
     if annotations:
-        result['annotations'] = {key: json.dumps(value) for key, value in annotations.items()}
+        result['annotations'] = {key: value for key, value in annotations.items()}
     workflow.data.plugins_results[StoreMetadataPlugin.key] = result
 
 


### PR DESCRIPTION
in exit task results instead of pipelinerun annotations

* CLOUDBLD-10949

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
