### PR TITLE
when using podman-remote paralel build tasks are writing and reading

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -13,6 +13,7 @@ spec:
 
   workspaces:
     - name: ws-container
+    - name: ws-home-dir
     - name: ws-registries-secret
     - name: ws-koji-secret
     - name: ws-reactor-config-map
@@ -50,8 +51,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -79,8 +79,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -108,8 +107,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -141,8 +139,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -174,8 +171,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -207,8 +203,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -243,8 +238,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret
@@ -284,8 +278,7 @@ spec:
           workspace: ws-container
           subPath: context-dir
         - name: ws-home-dir
-          subPath: home-dir
-          workspace: ws-container
+          workspace: ws-home-dir
         - name: ws-registries-secret
           workspace: ws-registries-secret
         - name: ws-koji-secret

--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -13,6 +13,7 @@ spec:
 
   workspaces:
     - name: ws-container
+    - name: ws-home-dir
     - name: ws-registries-secret
     - name: ws-koji-secret
     - name: ws-reactor-config-map
@@ -37,8 +38,7 @@ spec:
         workspace: ws-container
         subPath: context-dir
       - name: ws-home-dir
-        subPath: home-dir
-        workspace: ws-container
+        workspace: ws-home-dir
       - name: ws-registries-secret
         workspace: ws-registries-secret
       - name: ws-koji-secret
@@ -78,8 +78,7 @@ spec:
         workspace: ws-container
         subPath: context-dir
       - name: ws-home-dir
-        subPath: home-dir
-        workspace: ws-container
+        workspace: ws-home-dir
       - name: ws-registries-secret
         workspace: ws-registries-secret
       - name: ws-koji-secret


### PR DESCRIPTION
podman connections to ~/.config/containers/containers.conf, and race between read/write can happen, so instead of using shared pvc for homedir use just emptyDir, home directory contains only few config files but has to be isolated

* CLOUDBLD-10958

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
