### PR TITLE
add build tools and rpms from build hosts to koji metadata, use build…

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -67,6 +67,7 @@ MANPAGE_SECTION = 1
 TOOLS_USED = (
     {"pkg_name": "atomic_reactor"},
     {"pkg_name": "osbs", "display_name": "osbs-client"},
+    {"pkg_name": "dockerfile_parse"},
 )
 
 DEFAULT_DOWNLOAD_BLOCK_SIZE = 10 * 1024 * 1024  # 10Mb

--- a/atomic_reactor/plugins/gather_builds_metadata.py
+++ b/atomic_reactor/plugins/gather_builds_metadata.py
@@ -6,12 +6,15 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 from typing import Any, Dict, Optional
+import json
 
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.constants import PLUGIN_GATHER_BUILDS_METADATA_KEY
 from atomic_reactor.util import Output, is_scratch_build, get_platforms
 from atomic_reactor.utils.koji import get_buildroot, get_output, get_output_metadata
 from osbs.utils import ImageName
+from atomic_reactor.utils.remote_host import RemoteHost
+from atomic_reactor.utils.rpm import parse_rpm_output
 
 
 class GatherBuildsMetadataPlugin(Plugin):
@@ -43,7 +46,7 @@ class GatherBuildsMetadataPlugin(Plugin):
             raise RuntimeError('Unable to determine pullspec_image')
         return unique_images[0]
 
-    def _generate_build_log_output(self, platform: str, buildroot_id: int) -> Optional[Output]:
+    def _generate_build_log_output(self, platform: str, buildroot_id: str) -> Optional[Output]:
         build_log_file = self.workflow.context_dir.get_platform_build_log(platform)
         if not build_log_file.exists():
             self.log.info("Build log file is not found: %s", str(build_log_file))
@@ -54,6 +57,52 @@ class GatherBuildsMetadataPlugin(Plugin):
         metadata['arch'] = platform
         return Output(metadata=metadata, filename=str(build_log_file))
 
+    def _get_hostname_for_platform(self, platform: str) -> str:
+        task_results = self.workflow.osbs.get_task_results(self.workflow.pipeline_run_name)
+        task_platform = platform.replace('_', '-')
+
+        try:
+            task_name = next(filter(lambda task_name:  # pylint: disable=W1639
+                                    task_name.startswith('binary-container-build') and
+                                    task_platform in task_name, task_results))
+            if 'task_result' not in task_results[task_name]:
+                raise RuntimeError(f"task_results is missing from: {task_name}")
+
+            return json.loads(task_results[task_name]['task_result'])
+
+        except StopIteration:
+            # pylint: disable=W0707
+            raise RuntimeError(f"unable to find build host for platform: {platform}")
+
+    def _get_build_rpms(self, platform: str, build_host: str):
+        remote_host = None
+
+        remote_host_pools = self.workflow.conf.remote_hosts.get("pools", {})
+        slots_dir = self.workflow.conf.remote_hosts.get("slots_dir")
+        platform_config = remote_host_pools.get(platform)
+
+        if not platform_config:
+            raise RuntimeError(f"unable to find remote hosts for platform: {platform}")
+
+        host_config = platform_config.get(build_host)
+        if host_config:
+            remote_host = RemoteHost(
+                hostname=build_host, username=host_config["username"],
+                ssh_keyfile=host_config["auth"], slots=host_config.get("slots", 1),
+                socket_path=host_config["socket_path"], slots_dir=slots_dir
+            )
+
+        if not remote_host:
+            raise RuntimeError(f"unable to get remote host instance: {build_host}")
+
+        rpms = remote_host.rpms_installed
+        if not rpms:
+            raise RuntimeError(f"unable to obtain installed rpms on: {build_host}")
+
+        all_rpms = [line for line in rpms.splitlines() if line]
+
+        return parse_rpm_output(all_rpms)
+
     def _get_build_metadata(self, platform: str):
         """
         Build the metadata needed for importing the build
@@ -62,11 +111,16 @@ class GatherBuildsMetadataPlugin(Plugin):
         """
         pullspec_image = self._determine_image_pullspec(platform)
         buildroot = get_buildroot(platform)
-        output_files, _ = get_output(workflow=self.workflow, buildroot_id=buildroot['id'],
+        build_host = self._get_hostname_for_platform(platform)
+        output_files, _ = get_output(workflow=self.workflow, buildroot_id=build_host,
                                      pullspec=pullspec_image, platform=platform,
                                      source_build=False)
-        if build_log_output := self._generate_build_log_output(platform, buildroot['id']):
+        if build_log_output := self._generate_build_log_output(platform, build_host):
             output_files.append(build_log_output)
+
+        buildroot['components'] = self._get_build_rpms(platform, build_host)
+        buildroot['id'] = build_host
+
         koji_metadata = {
             'metadata_version': 0,
             'buildroots': [buildroot],

--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -628,13 +628,10 @@ class KojiImportPlugin(KojiImportBase):
         result = wf_data.plugins_results.get(PLUGIN_FETCH_MAVEN_KEY) or {}
         maven_components = result.get('components', [])
 
-        platform: str
         output: Dict[str, Any]  # an output metadata of the build
         outputs: List[Dict[str, Any]] = []
 
-        for platform, output in self._iter_build_metadata_outputs():
-            buildroot_id = output['buildroot_id']
-            output['buildroot_id'] = f'{platform}-{buildroot_id}'
+        for _, output in self._iter_build_metadata_outputs():
             if maven_components and output['type'] == 'docker-image':
                 # add maven components alongside RPM components
                 output['components'] += maven_components
@@ -674,7 +671,6 @@ class KojiImportPlugin(KojiImportBase):
 
         for platform in sorted(self._builds_metadatas.keys()):
             for instance in self._builds_metadatas[platform]['buildroots']:
-                instance['id'] = '{}-{}'.format(platform, instance['id'])
                 buildroots.append(instance)
 
         return buildroots

--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -60,7 +60,7 @@ class BinaryBuildTask(Task[BinaryBuildTaskParams]):
     #   and inconsistencies. Luckily, this task does not make any context data updates.
     autosave_context_data = False
 
-    def execute(self) -> None:
+    def execute(self) -> Any:
         """Build a container image for the platform specified in the task parameters.
 
         The built image will be pushed to the unique tag for this platform, which can be found
@@ -126,6 +126,8 @@ class BinaryBuildTask(Task[BinaryBuildTaskParams]):
                 )
 
             podman_remote.push_container(dest_tag, insecure=config.registry.get("insecure", False))
+
+            return remote_resource.host.hostname
 
     def acquire_remote_resource(self, remote_hosts_config: dict) -> remote_host.LockedResource:
         """Lock a build slot on a remote host."""

--- a/atomic_reactor/utils/koji.py
+++ b/atomic_reactor/utils/koji.py
@@ -29,7 +29,7 @@ from atomic_reactor.types import RpmComponent
 from atomic_reactor.util import (Output, get_image_upload_filename,
                                  get_checksums, get_manifest_media_type,
                                  create_tar_gz_archive, get_config_from_registry,
-                                 get_manifest_digests)
+                                 get_manifest_digests, get_version_of_tools)
 from osbs.utils import ImageName
 
 logger = logging.getLogger(__name__)
@@ -323,7 +323,12 @@ def get_buildroot(arch: Optional[str] = None) -> Dict[str, Any]:
             'arch': host_arch,
         },
         'components': [],
-        'tools': [],
+        'tools': [
+            {
+                'name': tool['name'],
+                'version': tool['version'],
+            }
+            for tool in get_version_of_tools()]
     }
 
     return buildroot

--- a/atomic_reactor/utils/remote_host.py
+++ b/atomic_reactor/utils/remote_host.py
@@ -18,6 +18,7 @@ from functools import cached_property
 from shlex import quote
 from typing import List, Optional, Tuple, Set
 from paramiko.channel import ChannelFile  # just for type annotation
+from atomic_reactor.utils.rpm import rpm_qf_args
 
 SSH_COMMAND_TIMEOUT = 30
 SLOTS_RELATIVE_PATH = "osbs_slots"
@@ -343,6 +344,16 @@ class RemoteHost:
             logger.error("%s: cannot prepare slots directory:\n%s", self.hostname, stderr)
             return False
         return True
+
+    @property
+    def rpms_installed(self):
+        rpms = None
+        try:
+            rpms, _, _ = self._run(f"rpm {rpm_qf_args()}")
+        except Exception as e:
+            logger.info("can't get rpms from host: %s : %s", self.hostname, e)
+
+        return rpms
 
     def is_free(self, slot_id: int) -> bool:
         """ Check whether a slot is in free state

--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -245,6 +245,8 @@ spec:
           workspace: ws-koji-secret
         - name: ws-reactor-config-map
           workspace: ws-reactor-config-map
+        - name: ws-remote-host-auth
+          workspace: ws-remote-host-auth
       params:
         - name: osbs-image
           value: "$(params.osbs-image)"

--- a/tekton/tasks/binary-container-postbuild.yaml
+++ b/tekton/tasks/binary-container-postbuild.yaml
@@ -23,6 +23,7 @@ spec:
     - name: ws-registries-secret  # access with $(workspaces.ws-registries-secret.path)/token
     - name: ws-koji-secret  # access with $(workspaces.ws-koji-secret.path)/token
     - name: ws-reactor-config-map
+    - name: ws-remote-host-auth
 
   stepTemplate:
     env:

--- a/tests/plugins/test_gather_builds_metadata.py
+++ b/tests/plugins/test_gather_builds_metadata.py
@@ -14,16 +14,86 @@ from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.utils.koji import get_buildroot
 from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
 from atomic_reactor.plugins.gather_builds_metadata import GatherBuildsMetadataPlugin
+from atomic_reactor.utils.remote_host import RemoteHost
+from atomic_reactor.utils.rpm import parse_rpm_output
 
 import pytest
+from flexmock import flexmock
+import json
 
 from tests.mock_env import MockEnv
 
 
-def mock_reactor_config(workflow):
+X86_64_HOST = 'x86_64_host'
+S390X_HOST = 's390x_host'
+REMOTE_HOST_CONFIG = {
+    "slots_dir": 'slots_dir',
+    "pools": {
+        "x86_64": {
+            X86_64_HOST: {
+                "username": 'username',
+                "auth": 'keyfile',
+                "enabled": True,
+                "slots": 1,
+                "socket_path": 'socket',
+            },
+        },
+        "s390x": {
+            S390X_HOST: {
+                "username": 'username',
+                "auth": 'keyfile',
+                "enabled": True,
+                "slots": 1,
+                "socket_path": 'socket',
+            },
+        },
+    },
+}
+REMOTE_HOST_CONFIG_MISSING_X86_64 = {
+    "slots_dir": 'slots_dir',
+    "pools": {
+        "s390x": {
+            S390X_HOST: {
+                "username": 'username',
+                "auth": 'keyfile',
+                "enabled": True,
+                "slots": 1,
+                "socket_path": 'socket',
+            },
+        },
+    },
+}
+REMOTE_HOST_CONFIG_MISSING_SPECIFIC_X86_64 = {
+    "slots_dir": 'slots_dir',
+    "pools": {
+        "x86_64": {
+            'some_x86_64': {
+                "username": 'username',
+                "auth": 'keyfile',
+                "enabled": True,
+                "slots": 1,
+                "socket_path": 'socket',
+            },
+        },
+        "s390x": {
+            S390X_HOST: {
+                "username": 'username',
+                "auth": 'keyfile',
+                "enabled": True,
+                "slots": 1,
+                "socket_path": 'socket',
+            },
+        },
+    },
+}
+
+
+def mock_reactor_config(workflow, remote_hosts=None):
     config = {
         'version': 1,
+        'openshift': {'url': 'openshift_url'},
         'koji': {'hub_url': 'http://brew.host/', 'root_url': '', 'auth': {}},
+        'remote_hosts': remote_hosts if remote_hosts else REMOTE_HOST_CONFIG
     }
     workflow.conf.conf = config
 
@@ -47,8 +117,8 @@ def test_fail_if_no_platform_is_set(workflow):
         runner.run()
 
 
-def assert_log_file_metadata(metadata, expected_filename, expected_platform):
-    assert metadata["buildroot_id"] == 1
+def assert_log_file_metadata(metadata, expected_filename, expected_platform, buildroot_id):
+    assert metadata["buildroot_id"] == buildroot_id
     assert metadata["type"] == "log"
     assert metadata["arch"] == expected_platform
     assert metadata["filename"] == expected_filename
@@ -68,21 +138,43 @@ def test_gather_builds_metadata(has_s390x_build_logs, workflow: DockerBuildWorkf
     if has_s390x_build_logs:
         build_log_file.write_text("line 1\nline 2\nline 3\n", "utf-8")
 
+    package_list = 'python-docker-py;1.3.1;1.fc24;noarch;(none);191456;' \
+                   '7c1f60d8cde73e97a45e0c489f4a3b26;1438058212;(none);(none);(none);(none)\n' \
+                   'fedora-repos-rawhide;24;0.1;noarch;(none);2149;' \
+                   'd41df1e059544d906363605d47477e60;1436940126;(none);(none);(none);(none)\n' \
+                   'gpg-pubkey-doc;1.0;1;noarch;(none);1000;00000000000000000000000000000000;' \
+                   '1436940126;(none);(none);(none);(none)'
+    all_rpms = [line for line in package_list.splitlines() if line]
+    all_components = parse_rpm_output(all_rpms)
+
+    flexmock(RemoteHost).should_receive('rpms_installed').and_return(package_list)
+
+    task_results = {'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)},
+                    'binary-container-build-s390x': {'task_result': json.dumps(S390X_HOST)}}
+    flexmock(workflow.osbs).should_receive('get_task_results').and_return(task_results)
+
     plugin = GatherBuildsMetadataPlugin(workflow, koji_upload_dir="path/to/upload")
 
     with patch("atomic_reactor.plugins.gather_builds_metadata.get_output",
                return_value=([], None)):
         output = plugin.run()
 
+    buildroot_x86_64 = get_buildroot("x86_64")
+    buildroot_s390x = get_buildroot("s390x")
+    buildroot_x86_64['components'] = all_components
+    buildroot_x86_64['id'] = X86_64_HOST
+    buildroot_s390x['components'] = all_components
+    buildroot_s390x['id'] = S390X_HOST
+
     expected = {
         "x86_64": {
             "metadata_version": 0,
-            "buildroots": [get_buildroot("x86_64")],
+            "buildroots": [buildroot_x86_64],
             "output": [],
         },
         "s390x": {
             "metadata_version": 0,
-            "buildroots": [get_buildroot("s390x")],
+            "buildroots": [buildroot_s390x],
             "output": [],
         },
     }
@@ -93,6 +185,7 @@ def test_gather_builds_metadata(has_s390x_build_logs, workflow: DockerBuildWorkf
             log_file_metadata,
             expected_filename=build_log_file.name,
             expected_platform="s390x",
+            buildroot_id=S390X_HOST
         )
 
         upload_file_info = {
@@ -106,3 +199,38 @@ def test_gather_builds_metadata(has_s390x_build_logs, workflow: DockerBuildWorkf
     # There is always no build log for x86_64 in this test.
     assert re.search(r"not found: .+x86_64-build.log", caplog.text)
     assert expected == output
+
+
+@pytest.mark.parametrize(("task_results", "remote_hosts", "error_msg"), (
+    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+     REMOTE_HOST_CONFIG,
+     f"unable to obtain installed rpms on: {X86_64_HOST}"),
+    ({'binary-container-build-x86-64': {'some_result': json.dumps('some')}},
+     REMOTE_HOST_CONFIG,
+     "task_results is missing from: binary-container-build-x86-64"),
+    ({'some-container-build-x86-64': {'some_result': json.dumps('some')}},
+     REMOTE_HOST_CONFIG,
+     "unable to find build host for platform: x86_64"),
+    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+     REMOTE_HOST_CONFIG_MISSING_X86_64,
+     "unable to find remote hosts for platform: x86_64"),
+    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+     REMOTE_HOST_CONFIG_MISSING_SPECIFIC_X86_64,
+     f"unable to get remote host instance: {X86_64_HOST}"),
+))
+@patch("koji.ClientSession", new=MockedClientSession)
+def test_get_build_metadata_fails(task_results, remote_hosts, error_msg,
+                                  workflow: DockerBuildWorkflow):
+    mock_reactor_config(workflow, remote_hosts=remote_hosts)
+    workflow.data.plugins_results[PLUGIN_CHECK_AND_SET_PLATFORMS_KEY] = ["x86_64"]
+    workflow.data.tag_conf.add_unique_image("ns/img:1.0-1")
+
+    flexmock(RemoteHost).should_receive('rpms_installed').and_return(None)
+    flexmock(workflow.osbs).should_receive('get_task_results').and_return(task_results)
+
+    plugin = GatherBuildsMetadataPlugin(workflow, koji_upload_dir="path/to/upload")
+
+    with patch("atomic_reactor.plugins.gather_builds_metadata.get_output",
+               return_value=([], None)):
+        with pytest.raises(RuntimeError, match=error_msg):
+            plugin.run()

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -662,14 +662,14 @@ class TestKojiImport(object):
                     'arch': 'ppc64le',
                     'type': 'docker',
                 },
-                'id': 'ppc64le-1',
+                'id': 1,
             },
             {
                 'container': {
                     'arch': 'x86_64',
                     'type': 'docker',
                 },
-                'id': 'x86_64-1',
+                'id': 1,
             },
         ]
 

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -63,9 +63,10 @@ REGISTRY_CONFIG = {
 }
 
 X86_64 = 'x86_64'
+X86_64_HOSTNAME = "osbs-remote-host-x86-64-1.example.com"
 
 X86_REMOTE_HOST = remote_host.RemoteHost(
-    hostname="osbs-remote-host-x86-64-1.example.com",
+    hostname=X86_64_HOSTNAME,
     username="osbs-podman-dev",
     ssh_keyfile="/workspace/ws-remote-host-auth/remote-host-auth",
     slots=10,
@@ -295,7 +296,7 @@ class TestBinaryBuildTask:
             with pytest.raises(ExceedsImageSizeError, match=err_msg):
                 task.execute()
         else:
-            task.execute()
+            output = task.execute()
 
         assert (
             f"Building for the x86_64 platform from {x86_build_dir.dockerfile_path}" in caplog.text
@@ -308,6 +309,9 @@ class TestBinaryBuildTask:
         assert build_log_file.exists()
         build_logs = build_log_file.read_text().splitlines()
         assert ["output line 1", "output line 2"] == build_logs
+
+        if not fail_image_size_check:
+            assert output == X86_64_HOSTNAME
 
     def test_run_exit_steps_on_failure(
         self, x86_task_params, x86_build_dir, mock_podman_remote, mock_locked_resource, caplog


### PR DESCRIPTION
… hostname as buildroot_id

* CLOUDBLD-10926

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
