### PR TITLE
task results are even more limited, so add there only plugins errors

### DIFF
--- a/atomic_reactor/plugins/store_metadata.py
+++ b/atomic_reactor/plugins/store_metadata.py
@@ -153,7 +153,8 @@ class StoreMetadataPlugin(Plugin):
         self.apply_plugin_annotations(annotations)
 
         if self.workflow.annotations_result:
-            annotations_result = {'plugins-metadata': annotations['plugins-metadata']}
+            annotations_result = \
+                {'plugins-metadata': {'errors': annotations['plugins-metadata']['errors']}}
             with open(self.workflow.annotations_result, 'w') as f:
                 f.write(json.dumps(annotations_result))
 

--- a/tests/plugins/test_store_metadata.py
+++ b/tests/plugins/test_store_metadata.py
@@ -273,8 +273,9 @@ def test_metadata_plugin(workflow, source_dir, tmpdir, failed, init_dirs,
     with open(workflow.annotations_result) as f:
         annotations_result = json.loads(f.read())
 
-    # remove store_metadata duration as it isn't there yet when it is writing to result
-    annotations['plugins-metadata']['durations'].pop('store_metadata')
+    # in annotations result are only errors
+    annotations['plugins-metadata'].pop('durations')
+    annotations['plugins-metadata'].pop('timestamps')
     assert annotations['plugins-metadata'] == annotations_result['plugins-metadata']
 
 
@@ -373,8 +374,9 @@ def test_metadata_plugin_source(failed, verify_media_results, expected_media_res
     with open(workflow.annotations_result) as f:
         annotations_result = json.loads(f.read())
 
-    # remove store_metadata duration as it isn't there yet when it is writing to result
-    annotations['plugins-metadata']['durations'].pop('store_metadata')
+    # in annotations result are only errors
+    annotations['plugins-metadata'].pop('durations')
+    annotations['plugins-metadata'].pop('timestamps')
     assert annotations['plugins-metadata'] == annotations_result['plugins-metadata']
 
 


### PR DESCRIPTION
* CLOUDBLD-10949

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
