### PR TITLE
remote hosts corrupted slots should be treated as free,

### DIFF
--- a/atomic_reactor/cli/job.py
+++ b/atomic_reactor/cli/job.py
@@ -27,6 +27,10 @@ def remote_hosts_unlocking_recovery(job_args: dict) -> None:
             logger.info("Checking occupied slots for platform: %s on host: %s",
                         platform, host.hostname)
 
+            # create slots dir if doesn't exist yet
+            if not host.is_operational:
+                continue
+
             for slot in range(host.slots):
                 prid = host.prid_in_slot(slot)
 


### PR DESCRIPTION
also call is_operational in unlocking job to create slots dir if doesn't exist

* CLOUDBLD-11117

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
