### PR TITLE
check check_user_settings in sendmail and store metadata, and inspect

### DIFF
--- a/atomic_reactor/plugins/sendmail.py
+++ b/atomic_reactor/plugins/sendmail.py
@@ -18,7 +18,7 @@ from atomic_reactor.plugin import Plugin, PluginFailedException
 from atomic_reactor.plugins.koji_import import KojiImportPlugin
 from atomic_reactor.plugins.store_metadata import StoreMetadataPlugin
 from atomic_reactor.utils.koji import get_koji_task_owner
-from atomic_reactor.constants import PLUGIN_SENDMAIL_KEY
+from atomic_reactor.constants import PLUGIN_SENDMAIL_KEY, PLUGIN_CHECK_USER_SETTINGS
 from atomic_reactor.config import get_koji_session, get_smtp_session
 from osbs.utils import Labels, ImageName
 
@@ -135,6 +135,8 @@ class SendMailPlugin(Plugin):
             else:
                 self.log.info("Koji connection established")
 
+        self.baseimage_exists = self.workflow.data.plugins_results.get(PLUGIN_CHECK_USER_SETTINGS)
+
     def _should_send(self, success, manual_canceled):
         """Return True if any state in `self.send_on` meets given conditions, thus meaning
         that a notification mail should be sent.
@@ -149,7 +151,7 @@ class SendMailPlugin(Plugin):
         return should_send
 
     def _get_image_name_and_repos(self):
-        if not self.workflow.build_dir.has_sources:
+        if not self.workflow.build_dir.has_sources or not self.baseimage_exists:
             return '', []
 
         dockerfile = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(

--- a/atomic_reactor/plugins/store_metadata.py
+++ b/atomic_reactor/plugins/store_metadata.py
@@ -8,7 +8,8 @@ of the BSD license. See the LICENSE file for details.
 import json
 
 from atomic_reactor.plugins.fetch_sources import PLUGIN_FETCH_SOURCES_KEY
-from atomic_reactor.constants import PLUGIN_VERIFY_MEDIA_KEY, SCRATCH_FROM
+from atomic_reactor.constants import (PLUGIN_VERIFY_MEDIA_KEY, SCRATCH_FROM,
+                                      PLUGIN_CHECK_USER_SETTINGS)
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import get_manifest_digests
 
@@ -95,6 +96,7 @@ class StoreMetadataPlugin(Plugin):
 
         wf_data = self.workflow.data
 
+        baseimage_exists = self.workflow.data.plugins_results.get(PLUGIN_CHECK_USER_SETTINGS)
         failed, cancelled = self.workflow.check_build_outcome()
         success = not failed and not cancelled
         build_dir_initialized = self.workflow.build_dir.has_sources
@@ -117,7 +119,7 @@ class StoreMetadataPlugin(Plugin):
 
             dockerfile_contents = ""
 
-            if build_dir_initialized:
+            if build_dir_initialized and baseimage_exists:
                 try:
                     dockerfile = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
                         self.workflow.imageutil.base_image_inspect()


### PR DESCRIPTION
base image based on that,

when check user settings plugin fails because of non existent base image, store metadata and sendmail will fail as well because they are still inspecting base image

* CLOUDBLD-11076

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a New feature can be disabled from a configuration file
