### PR TITLE
Don't inspect base image in check_user_settings plugin, as it can fail

### DIFF
--- a/atomic_reactor/plugins/check_user_settings.py
+++ b/atomic_reactor/plugins/check_user_settings.py
@@ -65,9 +65,7 @@ class CheckUserSettingsPlugin(Plugin):
         self.log.debug("Running check: %s", msg)
 
         # any_platform: the version label should be equal for all platforms
-        parser = self.workflow.build_dir.any_platform.dockerfile_with_parent_env(
-            self.workflow.imageutil.base_image_inspect()
-        )
+        parser = self.workflow.build_dir.any_platform.dockerfile
         dockerfile_labels = parser.labels
         labels = Labels(parser.labels)
 

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -1446,9 +1446,7 @@ def _has_label_flag(workflow, label) -> bool:
 
     Takes into account parent environment inheritance.
     """
-    dockerfile = workflow.build_dir.any_platform.dockerfile_with_parent_env(
-        workflow.imageutil.base_image_inspect()
-    )
+    dockerfile = workflow.build_dir.any_platform.dockerfile
     labels = Labels(dockerfile.labels)
     try:
         _, value = labels.get_name_and_value(label)


### PR DESCRIPTION
when base image in Dockerfile doesn't exist but koji_parent_build is used

* CLOUDBLD-11200

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
