### PR TITLE
Import koji metadata from file

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -206,3 +206,5 @@ USER_CONFIG_FILES = {
     REPO_FETCH_ARTIFACTS_KOJI: 'schemas/fetch-artifacts-nvr.json',
     REPO_CONTENT_SETS_CONFIG: 'schemas/content_sets.json',
 }
+
+KOJI_METADATA_FILENAME = "metadata.json"


### PR DESCRIPTION
Upload koji metadata file and use its filename in CGImport call This allows handling files containing control characters

CLOUDBLD-11191

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
