### PR TITLE
retry locking remote host resources

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -1,5 +1,5 @@
 """
-Copyright (c) 2015, 2019 Red Hat, Inc
+Copyright (c) 2022 Red Hat, Inc
 All rights reserved.
 
 This software may be modified and distributed under the terms
@@ -148,6 +148,9 @@ KOJI_RESERVE_RETRY_DELAY = 2
 KOJI_MAX_RETRIES = 120
 KOJI_RETRY_INTERVAL = 60
 KOJI_OFFLINE_RETRY_INTERVAL = 120
+# max retries for locking remote host slots
+REMOTE_HOST_MAX_RETRIES = 10
+REMOTE_HOST_RETRY_INTERVAL = 5
 # max retries for subprocesses (see utils.retries.run_cmd())
 SUBPROCESS_MAX_RETRIES = 5
 # the factor for the exponential backoff series - 5, 10, 20, 40, 80 seconds of waiting

--- a/atomic_reactor/utils/remote_host.py
+++ b/atomic_reactor/utils/remote_host.py
@@ -654,7 +654,7 @@ class RemoteHostsPool:
 
         platform_config = config.get("pools", {}).get(platform, {})
         if not platform_config:
-            logger.warning("No remote hosts found in config for platform %s", platform)
+            raise RuntimeError("No remote hosts found in config for platform %s" % platform)
 
         hosts = []
         for hostname, attr in platform_config.items():
@@ -674,11 +674,6 @@ class RemoteHostsPool:
 
         :param prid: str, pipelinerun ID
         """
-
-        if not self.hosts:
-            logger.error("There is no available remote host in pool")
-            return None
-
         resources = []
         random.shuffle(self.hosts)
         for host in self.hosts:

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -11,6 +11,7 @@ import json
 import re
 import shutil
 import subprocess
+import time
 from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
@@ -27,7 +28,7 @@ from atomic_reactor import dirs
 from atomic_reactor import inner
 from atomic_reactor import util
 from atomic_reactor.config import ReactorConfigKeys
-from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY
+from atomic_reactor.constants import PLUGIN_CHECK_AND_SET_PLATFORMS_KEY, REMOTE_HOST_MAX_RETRIES
 from atomic_reactor.tasks.binary_container_build import (
     BinaryBuildTask,
     BinaryBuildTaskParams,
@@ -346,11 +347,12 @@ class TestBinaryBuildTask:
             .once()
             .and_return(pool)
         )
+        (flexmock(time).should_receive('sleep'))
         (
             flexmock(pool)
             .should_receive("lock_resource")
             .with_args(PIPELINE_RUN_NAME)
-            .once()
+            .times(REMOTE_HOST_MAX_RETRIES + 1)
             .and_return(None)
         )
 


### PR DESCRIPTION
* CLOUDBLD-10703

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
