### PR TITLE
Create parent dirs when injecting config files

### DIFF
--- a/atomic_reactor/plugins/resolve_remote_source.py
+++ b/atomic_reactor/plugins/resolve_remote_source.py
@@ -355,6 +355,7 @@ class ResolveRemoteSourcePlugin(Plugin):
         """
         for config in config_files:
             config_path = dest_dir / config['path']
+            config_path.parent.mkdir(parents=True, exist_ok=True)
             if config['type'] == CFG_TYPE_B64:
                 data = base64.b64decode(config['content'])
                 config_path.write_bytes(data)

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -218,6 +218,11 @@ CACHITO_CONFIG_FILES = [
         "type": CFG_TYPE_B64,
         "content": base64.b64encode(b"gomod requests don't actually have configs").decode(),
     },
+    {
+        "path": "app/to-be-created-dir/config",
+        "type": CFG_TYPE_B64,
+        "content": base64.b64encode(b"Config file contents").decode()
+    }
 ]
 
 # The response from SECOND_CACHITO_REQUEST_CONFIG_URL
@@ -591,6 +596,7 @@ def test_resolve_remote_source(workflow, scratch, dr_strs, dependency_replacemen
                 "cachito.env": cachito_env_content,
                 "app/README.txt": "Content of remote-source.tar.gz",
                 "app/some-config.txt": "gomod requests don't actually have configs",
+                "app/to-be-created-dir/config": "Config file contents",
             },
         )
     )
@@ -844,6 +850,7 @@ def test_allow_multiple_remote_sources(workflow, allow_multiple_remote_sources):
                     "gomod/cachito.env": first_cachito_env,
                     "gomod/app/README.txt": "Content of remote-source-gomod.tar.gz",
                     "gomod/app/some-config.txt": "gomod requests don't actually have configs",
+                    "gomod/app/to-be-created-dir/config": "Config file contents",
                     "pip/cachito.env": second_cachito_env,
                     "pip/app/README.txt": "Content of remote-source-pip.tar.gz",
                     "pip/app/package-index-ca.pem": "-----BEGIN CERTIFICATE-----",


### PR DESCRIPTION
CLOUDBLD-11265

Cachito's RubyGems package manager creates config files in .bundle/config, expecting the parent directory to already exist. Atomic reactor should support that.

Signed-off-by: Milan Tichavský <mtichavs@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
