### PR TITLE
cachito: add url poiting to logs in emsg

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -116,6 +116,7 @@ class CachitoAPI(object):
         """
         request_id = self._get_request_id(request)
         url = '{}/api/v1/requests/{}'.format(self.api_url, request_id)
+        log_url = f'{url}/logs'
         logger.info('Waiting for request %s to complete...', request_id)
 
         last_updated_value = None
@@ -135,7 +136,7 @@ class CachitoAPI(object):
                 raise CachitoAPIUnsuccessfulRequest(
                     "Cachito request is in \"{}\" state, reason: {}. "
                     "Request {} ({}) tried to get repo '{}' at reference '{}'.".format(
-                        state, state_reason, request_id, url,
+                        state, state_reason, request_id, log_url,
                         response_json['repo'], response_json['ref']
                     )
                 )

--- a/tests/utils/test_cachito.py
+++ b/tests/utils/test_cachito.py
@@ -240,7 +240,7 @@ def test_check_CachitoAPIUnsuccessfulRequest_text(error_state, error_reason, cap
     updated = datetime.utcnow().isoformat()
     expected_total_responses_calls = len(states)
 
-    cachito_request_url = '{}/api/v1/requests/{}'.format(CACHITO_URL, CACHITO_REQUEST_ID)
+    cachito_req_url_logs = '{}/api/v1/requests/{}/logs'.format(CACHITO_URL, CACHITO_REQUEST_ID)
 
     def handle_wait_for_request(http_request):
         state = states.pop(0)
@@ -263,7 +263,7 @@ def test_check_CachitoAPIUnsuccessfulRequest_text(error_state, error_reason, cap
         "Cachito request is in \"{}\" state, reason: {}. "
         "Request {} ({}) tried to get repo '{}' at reference '{}'.".format(
             error_state, error_reason, CACHITO_REQUEST_ID,
-            cachito_request_url, CACHITO_REQUEST_REPO,
+            cachito_req_url_logs, CACHITO_REQUEST_REPO,
             CACHITO_REQUEST_REF)
     )
     with pytest.raises(CachitoAPIUnsuccessfulRequest) as excinfo:


### PR DESCRIPTION
Users may not know URL to get detailed info about cachito request failure. This should make their life easier.

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
