### PR TITLE
allow limiting memory for binary builds on remote hosts

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -92,6 +92,11 @@
                 "description": "Remote-host slots directory",
                 "type": "string"
             },
+            "memory_limit": {
+                "description": "Memory limit for podman-remote build",
+                "type": "string",
+                "examples": ["1g", "10m"]
+            },
             "pools": {
                 "description": "Pool of Remote-hosts",
                 "type": "object",


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
