### PR TITLE
Make escaping of control chars in metadata more efficient

### DIFF
--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -85,12 +85,15 @@ def escape_non_printable_chars(koji_metadata: Dict[str, Any]) -> Dict[str, Any]:
     """
     Escapes non-printable chars in dictionary, except for \n, \t and \r.
     """
+    translation_table = {
+        i: chr(i).encode("unicode-escape").decode("utf-8")
+        for i in range(32)
+        if chr(i) not in ["\n", "\t", "\r"]
+    }
+
     def callback(value):
         if isinstance(value, str):
-            for char in value:
-                if not char.isprintable() and char not in ['\n', '\t', '\r']:
-                    escaped_char = char.encode('unicode-escape').decode('utf-8')
-                    value = value.replace(char, escaped_char)
+            value = value.translate(translation_table)
         return value
 
     walker = koji.util.DataWalker(koji_metadata, callback)


### PR DESCRIPTION
This was suggested by Michael McLean and I agree with him.

CLOUDBLD-11243

Signed-off-by: mkosiarc <mkosiarc@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
