### PR TITLE
don't store remote_sources in annotation because if there is too many

### DIFF
--- a/atomic_reactor/plugins/resolve_remote_source.py
+++ b/atomic_reactor/plugins/resolve_remote_source.py
@@ -25,7 +25,6 @@ from atomic_reactor.constants import (
     REMOTE_SOURCE_TARBALL_FILENAME,
 )
 from atomic_reactor.dirs import BuildDir
-from atomic_reactor.metadata import annotation_map
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import is_scratch_build, map_to_user_params
 from atomic_reactor.utils.cachito import CFG_TYPE_B64
@@ -64,16 +63,6 @@ class RemoteSource:
             return REMOTE_SOURCE_JSON_FILENAME
 
 
-def transform_results(results):
-    remote_sources_annotations = [
-        {"name": remote_source["name"], "url": remote_source["url"]}
-        for remote_source in results
-    ]
-
-    return remote_sources_annotations
-
-
-@annotation_map('remote_sources', transform_results)
 class ResolveRemoteSourcePlugin(Plugin):
     """Initiate a new Cachito request for sources
 

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -921,12 +921,6 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
     if expect_result:
         assert results == expected_plugin_results
 
-        remote_sources_annotations = [
-            {"name": remote_source["name"], "url": remote_source["url"]}
-            for remote_source in expected_plugin_results
-        ]
-        assert workflow.data.annotations['remote_sources'] == remote_sources_annotations
-
     return results
 
 


### PR DESCRIPTION
sources it will hit task results limit

* CLOUDBLD-11401

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
