### PR TITLE
bump new osbs-client version

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -62,7 +62,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@f60111429487ab36bd8aaf37b2e9f7d5eab331c8
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@7a0a7f17701f082ee01d202e8f8177d7aba637e2
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ jsonschema
 paramiko>=2.10.1
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@f60111429487ab36bd8aaf37b2e9f7d5eab331c8#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@7a0a7f17701f082ee01d202e8f8177d7aba637e2#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@f60111429487ab36bd8aaf37b2e9f7d5eab331c8
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@7a0a7f17701f082ee01d202e8f8177d7aba637e2
     # via -r requirements.in
 paramiko==2.10.3
     # via -r requirements.in


### PR DESCRIPTION
Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
