### PR TITLE
raise a specific error when image is not available in registry

### DIFF
--- a/atomic_reactor/plugins/check_base_image.py
+++ b/atomic_reactor/plugins/check_base_image.py
@@ -105,8 +105,8 @@ class CheckBaseImagePlugin(Plugin):
                 manifest_digest_response = digests_dict['v2']
             except KeyError as exc:
                 raise RuntimeError(
-                    'Unable to fetch manifest list or '
-                    'v2 schema 2 digest for {} (Does image exist?)'.format(image_str)
+                    'Unable to fetch manifest list or v2 schema 2 digest for'
+                    ' image: "{}" (Does the tag "{}" exist?)'.format(image_str, image.tag)
                 ) from exc
 
             digest_dict = get_checksums(BytesIO(manifest_digest_response.content), ['sha256'])

--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -666,6 +666,10 @@ class RegistryClient(object):
         except (HTTPError, RetryError) as ex:
             if ex.response is None:
                 raise
+            if ex.response.status_code == requests.codes.unauthorized:
+                logger.warning('Requested parent/base image "%s" not found', image.to_str())
+                raise RuntimeError('Unable to fetch image: "{}"'
+                                   ' (Does the image exist?)'.format(image.to_str())) from ex
             if ex.response.status_code == requests.codes.not_found:
                 saved_not_found = ex
             # If the registry has a v2 manifest that can't be converted into a v1

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -845,6 +845,19 @@ def test_get_manifest_timeout_error(tmpdir, body):
         get_manifest(image, session, 'v2')
 
 
+@responses.activate
+def test_get_manifest_non_existent_image_error(tmpdir):
+    image = ImageName.parse('example.com/spam:latest')
+    registry = 'https://example.com'
+    session = RegistrySession(registry)
+
+    url = 'https://example.com/v2/spam/manifests/latest'
+    responses.add(responses.GET, url, body='', status=401)
+    msg = 'Does the image exist'
+    with pytest.raises(RuntimeError, match=msg):
+        get_manifest(image, session, 'v2')
+
+
 @pytest.mark.parametrize('namespace,repo,explicit,expected', [
     ('foo', 'bar', False, 'foo/bar'),
     ('foo', 'bar', True, 'foo/bar'),


### PR DESCRIPTION
Otherwise an UNAUTHORIZED error is raised that
causes confusion for the user.

* CLOUDBLD-7086

Signed-off-by: Harsh Modi <hmodi@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
