### PR TITLE
retry commands on remote hosts also on connection and timeout errors

### DIFF
--- a/atomic_reactor/utils/remote_host.py
+++ b/atomic_reactor/utils/remote_host.py
@@ -23,9 +23,11 @@ from atomic_reactor.utils.rpm import rpm_qf_args
 SSH_COMMAND_TIMEOUT = 30
 SLOTS_RELATIVE_PATH = "osbs_slots"
 RETRY_ON_SSH_EXCEPTIONS = (paramiko.ssh_exception.NoValidConnectionsError,
-                           paramiko.ssh_exception.SSHException)
-BACKOFF_FACTOR = 3
-MAX_RETRIES = 3
+                           paramiko.ssh_exception.SSHException, ConnectionError, TimeoutError)
+# wait time is calculated for backoff.expo: factor * 2 ** n
+BACKOFF_FACTOR = 0.5
+# max last wait fime will be 128s
+MAX_RETRIES = 8
 
 logger = logging.getLogger(__name__)
 

--- a/tests/utils/test_remote_host.py
+++ b/tests/utils/test_remote_host.py
@@ -9,6 +9,7 @@ of the BSD license. See the LICENSE file for details.
 import backoff
 import pytest
 import re
+import time
 from flexmock import flexmock, Mock
 from functools import wraps
 from typing import Callable, Optional, Tuple
@@ -38,6 +39,8 @@ SOCKET_PATH = "/run/user/2022/podman/podman.sock"
 @pytest.fixture(autouse=True)
 def _mock_ssh_session(request):
     """ Mock the ssh session with things we don't want to test or change """
+    flexmock(time).should_receive('sleep')
+
     if "disable_autouse" in request.keywords:
         yield
     else:


### PR DESCRIPTION
* CLOUDBLD-11291

Signed-off-by: Robert Cerven <rcerven@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
