### PR TITLE
new cachito_session method for getting sbom from cachito

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -270,6 +270,27 @@ class CachitoAPI(object):
                    f'but the response contains: {resp.content}.')
             raise ValueError(msg) from exc
 
+    def get_sbom(self, request_ids: List[int]) -> dict:
+        """
+        Get the sbom from endpoint /sbom
+        :param list[int] request_ids: cachito request ids
+        :return: sbom data
+        :rtype: dict
+        :raises: ValueError if the server does not response a JSON data to be
+            parsed.
+        :raises: HTTP error raised from the underlying requests library in any
+            case of the request cannot be completed.
+        """
+        endpoint = f'{self.api_url}/api/v1/sbom'
+        resp = self.session.get(endpoint, params={'requests': ','.join(map(str, request_ids))})
+        resp.raise_for_status()
+        try:
+            return resp.json()
+        except Exception as exc:
+            msg = (f'JSON data is expected from Cachito endpoint {endpoint}, '
+                   f'but the response contains: {resp.content}.')
+            raise ValueError(msg) from exc
+
 
 if __name__ == '__main__':
     logging.basicConfig()


### PR DESCRIPTION
* STONEBLD-523

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
