### PR TITLE
allow isolated build for FROM scratch base image in Dockerfile

### DIFF
--- a/atomic_reactor/plugins/check_user_settings.py
+++ b/atomic_reactor/plugins/check_user_settings.py
@@ -11,7 +11,6 @@ from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import (
     has_operator_appregistry_manifest,
     has_operator_bundle_manifest,
-    is_isolated_build,
     read_content_sets,
     read_fetch_artifacts_koji,
     read_fetch_artifacts_pnc,
@@ -110,27 +109,9 @@ class CheckUserSettingsPlugin(Plugin):
         read_fetch_artifacts_url(self.workflow)
         read_content_sets(self.workflow)
 
-    def isolated_from_scratch_build(self):
-        """Isolated builds for FROM scratch builds are prohibited
-         except operator bundle images"""
-        if (
-            self.workflow.data.dockerfile_images.base_from_scratch and
-            is_isolated_build(self.workflow) and
-            not has_operator_bundle_manifest(self.workflow)
-        ):
-            raise RuntimeError(
-                '"FROM scratch" image build cannot be isolated '
-                '(except operator bundle images)'
-            )
-
-    def isolated_builds_checks(self):
-        """Validate if isolated build was used correctly"""
-        self.isolated_from_scratch_build()
-
     def run(self):
         """
         run the plugin
         """
         self.dockerfile_checks()
         self.validate_user_config_files()
-        self.isolated_builds_checks()

--- a/atomic_reactor/plugins/inject_parent_image.py
+++ b/atomic_reactor/plugins/inject_parent_image.py
@@ -61,8 +61,8 @@ class InjectParentImage(Plugin):
             return
 
         if self.workflow.data.dockerfile_images.base_from_scratch:
-            self.log.info("from scratch can't inject parent image")
-            return
+            raise RuntimeError("from scratch can't inject parent image")
+
         if self.workflow.data.dockerfile_images.custom_base_image:
             self.log.info("custom base image builds can't inject parent image")
             return

--- a/tests/plugins/test_check_user_settings.py
+++ b/tests/plugins/test_check_user_settings.py
@@ -278,39 +278,3 @@ class TestValidateUserConfigFiles(object):
         runner = mock_env(workflow, source_dir)
         with pytest.raises(PluginFailedException, match="validating 'pattern' has failed"):
             runner.run()
-
-
-class TestIsolatedBuildChecks(object):
-    """Test isolated_build_checks"""
-
-    @pytest.mark.parametrize(
-        'isolated,bundle,from_scratch,expected_fail',
-        [
-            (True, True, True, False),
-            # (True, True, False, True),  # invalid, bundle must be FROM scratch
-            (True, False, True, True),
-            (True, False, False, False),
-            (False, True, True, False),
-            # (False, True, False, False), # invalid, bundle must be FROM scratch
-            (False, False, True, False),
-            (False, False, False, False),
-        ]
-    )
-    def test_isolated_from_scratch_build(
-        self, workflow, source_dir, isolated, bundle, from_scratch, expected_fail
-    ):
-        """Test if isolated FROM scratch builds are prohibited except
-        operator bundle builds"""
-        labels = ['com.redhat.delivery.operator.bundle=true'] if bundle else []
-
-        dockerfile_f = partial(mock_dockerfile, from_scratch=from_scratch)
-
-        runner = mock_env(workflow, source_dir,
-                          dockerfile_f=dockerfile_f, labels=labels, isolated=isolated)
-        if expected_fail:
-            with pytest.raises(PluginFailedException) as exc_info:
-                runner.run()
-
-            assert '"FROM scratch" image build cannot be isolated ' in str(exc_info.value)
-        else:
-            runner.run()

--- a/tests/plugins/test_inject_parent_image.py
+++ b/tests/plugins/test_inject_parent_image.py
@@ -92,13 +92,19 @@ class TestKojiParent(object):
 
         previous_parent_image = wf_data.dockerfile_images.base_image
 
-        self.run_plugin_with_args(workflow, base_from_scratch=base_from_scratch,
-                                  custom_base_image=custom_base_image)
+        if base_from_scratch:
+            with pytest.raises(PluginFailedException) as exc_info:
+                self.run_plugin_with_args(workflow, base_from_scratch=base_from_scratch,
+                                          custom_base_image=custom_base_image)
+        else:
+            self.run_plugin_with_args(workflow, base_from_scratch=base_from_scratch,
+                                      custom_base_image=custom_base_image)
+
         if base_from_scratch:
             assert str(previous_parent_image) == str(wf_data.dockerfile_images.base_image)
 
             log_msg = "from scratch can't inject parent image"
-            assert log_msg in caplog.text
+            assert log_msg in str(exc_info.value)
         elif custom_base_image:
             assert str(previous_parent_image) == str(wf_data.dockerfile_images.base_image)
 


### PR DESCRIPTION
* STONEBLD-1070

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
