### PR TITLE
Pin pip version in unittest

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -69,7 +69,7 @@ function setup_osbs() {
   $RUN $PKG install -y $PIP_PKG
 
   # Upgrade pip to provide latest features for successful installation
-  $RUN "${PIP_INST[@]}" --upgrade pip
+  $RUN "${PIP_INST[@]}" --upgrade "pip<23.1"
 
   if [[ $OS == centos ]]; then
     # Pip install/upgrade setuptools. Older versions of setuptools don't understand


### PR DESCRIPTION
Otherwise the "Unittests / Python 3.8 tests on centos-8" part of the CI pipeline will be broken.

See https://github.com/junaruga/rpm-py-installer/issues/276 This is a temporary solution. Until it is resolved in better way, I don't think we can merge https://github.com/containerbuildsystem/atomic-reactor/pull/2061

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
