### PR TITLE
tekton results aren't now always json

### DIFF
--- a/atomic_reactor/plugins/gather_builds_metadata.py
+++ b/atomic_reactor/plugins/gather_builds_metadata.py
@@ -6,7 +6,6 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 from typing import Any, Dict, Optional
-import json
 
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.constants import PLUGIN_GATHER_BUILDS_METADATA_KEY
@@ -68,7 +67,7 @@ class GatherBuildsMetadataPlugin(Plugin):
             if 'task_result' not in task_results[task_name]:
                 raise RuntimeError(f"task_results is missing from: {task_name}")
 
-            return json.loads(task_results[task_name]['task_result'])
+            return task_results[task_name]['task_result']
 
         except StopIteration:
             # pylint: disable=W0707

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -62,7 +62,7 @@ krb5==0.2.0
     # via pyspnego
 mccabe==0.6.1
     # via flake8
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@a183187d8858c816ba35dd451d0dc07f2da030a5
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3db33db62280d5b0d2f13993596d882c5deba54c
     # via -r requirements.in
 packaging==21.2
     # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ jsonschema
 paramiko>=2.10.1
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@a183187d8858c816ba35dd451d0dc07f2da030a5#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@3db33db62280d5b0d2f13993596d882c5deba54c#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ koji==1.26.1
     # via -r requirements.in
 krb5==0.2.0
     # via pyspnego
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@a183187d8858c816ba35dd451d0dc07f2da030a5
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@3db33db62280d5b0d2f13993596d882c5deba54c
     # via -r requirements.in
 paramiko==2.10.3
     # via -r requirements.in

--- a/tests/plugins/test_gather_builds_metadata.py
+++ b/tests/plugins/test_gather_builds_metadata.py
@@ -19,7 +19,6 @@ from atomic_reactor.utils.rpm import parse_rpm_output
 
 import pytest
 from flexmock import flexmock
-import json
 
 from tests.mock_env import MockEnv
 
@@ -148,8 +147,8 @@ def test_gather_builds_metadata(has_s390x_build_logs, workflow: DockerBuildWorkf
 
     flexmock(RemoteHost).should_receive('rpms_installed').and_return(package_list)
 
-    task_results = {'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)},
-                    'binary-container-build-s390x': {'task_result': json.dumps(S390X_HOST)}}
+    task_results = {'binary-container-build-x86-64': {'task_result': X86_64_HOST},
+                    'binary-container-build-s390x': {'task_result': S390X_HOST}}
     flexmock(workflow.osbs).should_receive('get_task_results').and_return(task_results)
 
     plugin = GatherBuildsMetadataPlugin(workflow)
@@ -201,19 +200,23 @@ def test_gather_builds_metadata(has_s390x_build_logs, workflow: DockerBuildWorkf
 
 
 @pytest.mark.parametrize(("task_results", "remote_hosts", "error_msg"), (
-    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+    ({'binary-container-build-x86-64': {'task_result': X86_64_HOST}},
      REMOTE_HOST_CONFIG,
      f"unable to obtain installed rpms on: {X86_64_HOST}"),
-    ({'binary-container-build-x86-64': {'some_result': json.dumps('some')}},
+
+    ({'binary-container-build-x86-64': {'some_result': 'some'}},
      REMOTE_HOST_CONFIG,
      "task_results is missing from: binary-container-build-x86-64"),
-    ({'some-container-build-x86-64': {'some_result': json.dumps('some')}},
+
+    ({'some-container-build-x86-64': {'some_result': 'some'}},
      REMOTE_HOST_CONFIG,
      "unable to find build host for platform: x86_64"),
-    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+
+    ({'binary-container-build-x86-64': {'task_result': X86_64_HOST}},
      REMOTE_HOST_CONFIG_MISSING_X86_64,
      "unable to find remote hosts for platform: x86_64"),
-    ({'binary-container-build-x86-64': {'task_result': json.dumps(X86_64_HOST)}},
+
+    ({'binary-container-build-x86-64': {'task_result': X86_64_HOST}},
      REMOTE_HOST_CONFIG_MISSING_SPECIFIC_X86_64,
      f"unable to get remote host instance: {X86_64_HOST}"),
 ))


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
