### PR TITLE
don't add remote sources to annotations

### DIFF
--- a/atomic_reactor/plugins/resolve_remote_source.py
+++ b/atomic_reactor/plugins/resolve_remote_source.py
@@ -25,7 +25,6 @@ from atomic_reactor.constants import (
     REMOTE_SOURCE_TARBALL_FILENAME,
 )
 from atomic_reactor.dirs import BuildDir
-from atomic_reactor.metadata import annotation_map
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import (is_scratch_build,
                                  map_to_user_params,
@@ -67,16 +66,6 @@ class RemoteSource:
             return REMOTE_SOURCE_JSON_FILENAME
 
 
-def transform_results(results):
-    remote_sources_annotations = [
-        {"name": remote_source["name"], "url": remote_source["url"]}
-        for remote_source in results
-    ]
-
-    return remote_sources_annotations
-
-
-@annotation_map('remote_sources', transform_results)
 class ResolveRemoteSourcePlugin(Plugin):
     """Initiate a new Cachito request for sources
 

--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -24,8 +24,6 @@ spec:
       value: $(tasks.binary-container-set-results.results.repositories)
     - name: koji-build-id
       value: $(tasks.binary-container-set-results.results.koji-build-id)
-    - name: remote_sources
-      value: $(tasks.binary-container-set-results.results.remote_sources)
     - name: task_build_result_x86_64
       value: $(tasks.binary-container-build-x86-64.results.task_result)
     - name: task_build_result_s390x

--- a/tekton/tasks/binary-container-set-results.yaml
+++ b/tekton/tasks/binary-container-set-results.yaml
@@ -16,7 +16,6 @@ spec:
   results:
     - name: repositories
     - name: koji-build-id
-    - name: remote_sources
 
   steps:
     - name: binary-container-set-results
@@ -30,5 +29,4 @@ spec:
           cpu: 395m
       script: |
         jq -c '.annotations.repositories' $(workspaces.ws-context-dir.path)/workflow.json >$(results.repositories.path)
-        jq -c '.annotations.remote_sources' $(workspaces.ws-context-dir.path)/workflow.json >$(results.remote_sources.path)
         jq -c '.annotations["koji-build-id"]' $(workspaces.ws-context-dir.path)/workflow.json >$(results.koji-build-id.path)

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -921,12 +921,6 @@ def run_plugin_with_args(workflow, dependency_replacements=None, expect_error=No
     if expect_result:
         assert results == expected_plugin_results
 
-        remote_sources_annotations = [
-            {"name": remote_source["name"], "url": remote_source["url"]}
-            for remote_source in expected_plugin_results
-        ]
-        assert workflow.data.annotations['remote_sources'] == remote_sources_annotations
-
     return results
 
 


### PR DESCRIPTION
* STONEBLD-1057

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
