### PR TITLE
verify digest for cachito archive

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -218,3 +218,8 @@ KOJI_METADATA_FILENAME = "metadata.json"
 
 # https://raw.githubusercontent.com/CycloneDX/specification/1.4/schema/bom-1.4.schema.json
 SBOM_SCHEMA_PATH = 'schemas/sbom-1.4.schema.json'
+
+# algorithm used for hash of cachito archive
+CACHITO_HASH_ALG = 'sha256'
+# string used in response header in Digest
+CACHITO_ALG_STR = 'sha-256'

--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -183,7 +183,7 @@ class CachitoAPI(object):
         url = self.assemble_download_url(request_id)
         dest_path = download_url(
             url, dest_dir=dest_dir, insecure=not self.session.verify, session=self.session,
-            dest_filename=dest_filename)
+            dest_filename=dest_filename, verify_cachito_digest=True)
         logger.debug('Sources bundle for request %d downloaded to %s', request_id, dest_path)
         return dest_path
 


### PR DESCRIPTION
* STONEBLD-509

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
