### PR TITLE
add set -x to all tasks, to print executed command

### DIFF
--- a/tekton/tasks/binary-container-build.yaml
+++ b/tekton/tasks/binary-container-build.yaml
@@ -47,13 +47,6 @@ spec:
         limits:
           memory: 600Mi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        --task-result=$(results.task_result.path)
-        binary-container-build --platform="$(params.platform)"
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" --task-result=$(results.task_result.path) binary-container-build --platform="$(params.platform)"

--- a/tekton/tasks/binary-container-exit.yaml
+++ b/tekton/tasks/binary-container-exit.yaml
@@ -43,13 +43,6 @@ spec:
         limits:
           memory: 600Mi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        binary-container-exit
-        --annotations-result=$(results.annotations.path)
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" binary-container-exit --annotations-result=$(results.annotations.path)

--- a/tekton/tasks/binary-container-postbuild.yaml
+++ b/tekton/tasks/binary-container-postbuild.yaml
@@ -41,12 +41,6 @@ spec:
         limits:
           memory: 600Mi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        binary-container-postbuild
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" binary-container-postbuild

--- a/tekton/tasks/binary-container-prebuild.yaml
+++ b/tekton/tasks/binary-container-prebuild.yaml
@@ -43,13 +43,6 @@ spec:
         limits:
           memory: 1Gi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        binary-container-prebuild
-        --platforms-result=$(results.platforms_result.path)
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" binary-container-prebuild --platforms-result=$(results.platforms_result.path)

--- a/tekton/tasks/binary-container-set-results.yaml
+++ b/tekton/tasks/binary-container-set-results.yaml
@@ -28,5 +28,6 @@ spec:
           memory: 600Mi
           cpu: 395m
       script: |
+        set -x
         jq -c '.annotations.repositories' $(workspaces.ws-context-dir.path)/workflow.json >$(results.repositories.path)
         jq -c '.annotations["koji-build-id"]' $(workspaces.ws-context-dir.path)/workflow.json >$(results.koji-build-id.path)

--- a/tekton/tasks/clone.yaml
+++ b/tekton/tasks/clone.yaml
@@ -40,12 +40,6 @@ spec:
         limits:
           memory: 600Mi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        clone
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" clone

--- a/tekton/tasks/source-container-build.yaml
+++ b/tekton/tasks/source-container-build.yaml
@@ -40,12 +40,6 @@ spec:
         limits:
           memory: 8600Mi
           cpu: 1300m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        source-container-build
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" source-container-build

--- a/tekton/tasks/source-container-exit.yaml
+++ b/tekton/tasks/source-container-exit.yaml
@@ -43,13 +43,6 @@ spec:
         limits:
           memory: 600Mi
           cpu: 395m
-      script: >
-        atomic-reactor -v task
-        --user-params='$(params.user-params)'
-        --build-dir=$(workspaces.ws-build-dir.path)
-        --context-dir=$(workspaces.ws-context-dir.path)
-        --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml
-        --namespace=$(context.taskRun.namespace)
-        --pipeline-run-name="$(params.pipeline-run-name)"
-        source-container-exit
-        --annotations-result=$(results.annotations.path)
+      script: |
+        set -x
+        atomic-reactor -v task --user-params='$(params.user-params)' --build-dir=$(workspaces.ws-build-dir.path) --context-dir=$(workspaces.ws-context-dir.path) --config-file=$(workspaces.ws-reactor-config-map.path)/config.yaml --namespace=$(context.taskRun.namespace) --pipeline-run-name="$(params.pipeline-run-name)" source-container-exit --annotations-result=$(results.annotations.path)

--- a/tekton/tasks/source-container-set-results.yaml
+++ b/tekton/tasks/source-container-set-results.yaml
@@ -28,5 +28,6 @@ spec:
           memory: 600Mi
           cpu: 395m
       script: |
+        set -x
         jq -c '.annotations.repositories' $(workspaces.ws-context-dir.path)/workflow.json >$(results.repositories.path)
         jq -c '.annotations["koji-build-id"]' $(workspaces.ws-context-dir.path)/workflow.json >$(results.koji-build-id.path)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
