### PR TITLE
convert binary build git url to https url with 'git' in path based on a option

### DIFF
--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -606,6 +606,11 @@
               "description": "Openshift memory request for build",
               "type": "string",
               "examples": ["1Gi", "3Gi"]
+          },
+          "rh_git_url": {
+              "description": "Convert binary build git url to RH one",
+              "type": "boolean",
+              "default": false
           }
         },
         "additionalProperties": false


### PR DESCRIPTION
…git url to https url with 'git' in path

* STONEBLD-1497

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
