### PR TITLE
force podman-remote to use Dockerfile,

### DIFF
--- a/atomic_reactor/tasks/binary_container_build.py
+++ b/atomic_reactor/tasks/binary_container_build.py
@@ -257,6 +257,8 @@ class PodmanRemote:
             f"--tag={dest_tag}",
             "--no-cache",  # make sure the build uses a clean environment
             "--pull-always",  # as above
+            # ensure that Dockerfile is always used even when Containerfile exists
+            "--file=Dockerfile",
         ]
         if memory_limit:
             # memory limit (format: <number>[<unit>], where unit = b, k, m or g)

--- a/tests/tasks/test_binary_container_build.py
+++ b/tests/tasks/test_binary_container_build.py
@@ -473,6 +473,7 @@ class TestPodmanRemote:
             f"--tag={X86_UNIQUE_IMAGE}",
             "--no-cache",
             "--pull-always",
+            "--file=Dockerfile",
         ]
         if memory_limit:
             options.append(f"--memory={memory_limit}")


### PR DESCRIPTION
because in case Containerfile exists as well, it will use that instead

* STONEBLD-1929

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
