### PR TITLE
finally results are referenced differently, source pipeline

### DIFF
--- a/tekton/pipelines/source-container.yaml
+++ b/tekton/pipelines/source-container.yaml
@@ -24,7 +24,7 @@ spec:
     - name: koji-build-id
       value: $(tasks.source-container-set-results.results.koji-build-id)
     - name: annotations
-      value: $(tasks.source-container-exit.results.annotations)
+      value: $(finally.source-container-exit.results.annotations)
 
   tasks:
     - name: source-container-build


### PR DESCRIPTION
* STONEBLD-2192

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
