### PR TITLE
cachi2: conversion function to cachi2 params

### DIFF
--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2024 Red Hat, Inc
+# All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the BSD license. See the LICENSE file for details.
+
+"""
+Utils to help to integrate with cachi2 CLI tool
+"""
+
+from typing import Any, Dict
+
+
+def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
+    """Converts remote source into cachi2 expected params.
+
+    Remote sources were orignally designed for cachito. Cachi2 is not a direct
+    fork but has lot of similarities.
+    However, some parameters must be updated to be compatible with cachi2.
+
+    Removed flags (OSBS process them):
+    * include-git-dir
+    * remove-unsafe-symlinks
+
+    Removed pkg-managers (OSBS process them):
+    * git-submodule
+
+    """
+    removed_flags = {"include-git-dir", "remove-unsafe-symlinks"}
+    removed_pkg_managers = {"git-submodule"}
+
+    cachi2_flags = sorted(
+        set(remote_source.get("flags", [])) - removed_flags
+    )
+    cachi2_packages = []
+
+    for pkg_manager in remote_source["pkg_managers"]:
+        if pkg_manager in removed_pkg_managers:
+            continue
+
+        packages = remote_source.get("packages", {}).get(pkg_manager, [])
+        packages = packages or [{"path": "."}]
+        for pkg in packages:
+            cachi2_packages.append({"type": pkg_manager, **pkg})
+
+    return {"packages": cachi2_packages, "flags": cachi2_flags}

--- a/tests/utils/test_cachi2.py
+++ b/tests/utils/test_cachi2.py
@@ -1,0 +1,85 @@
+"""
+Copyright (c) 2024 Red Hat, Inc
+All rights reserved.
+
+This software may be modified and distributed under the terms
+of the BSD license. See the LICENSE file for details.
+"""
+
+from atomic_reactor.utils.cachi2 import remote_source_to_cachi2
+
+import pytest
+
+
+@pytest.mark.parametrize(('input_remote_source', 'expected_cachi2'), [
+    pytest.param(
+        {"pkg_managers": ["gomod"]},
+        {"flags": [], "packages": [{"path": ".", "type": "gomod"}]},
+        id="pkg_manager_plain",
+    ),
+    pytest.param(
+        {"pkg_managers": ["gomod"], "packages": {"gomod": [{"path": "operator"}]}},
+        {"flags": [], "packages": [{"path": "operator", "type": "gomod"}]},
+        id="pkg_manager_single_path"
+    ),
+    pytest.param(
+        {"pkg_managers": ["gomod"], "packages": {"gomod": [
+            {"path": "."}, {"path": "operator"}
+        ]}},
+        {"flags": [], "packages": [
+            {"path": ".", "type": "gomod"}, {"path": "operator", "type": "gomod"}
+        ]},
+        id="pkg_manager_multiple_paths"
+    ),
+    pytest.param(
+        {"pkg_managers": ["pip"], "packages": {
+            "pip": [{
+                "path": "src/web",
+                "requirements_files": ["requirements.txt", "requirements-extras.txt"],
+                "requirements_build_files": [
+                    "requirements-build.txt", "requirements-build-extras.txt"
+                ]
+            }, {
+                "path": "src/workers"
+            }]
+        }},
+        {"flags": [], "packages": [
+            {
+                "path": "src/web", "type": "pip",
+                "requirements_files": ["requirements.txt", "requirements-extras.txt"],
+                "requirements_build_files": [
+                    "requirements-build.txt", "requirements-build-extras.txt"
+                    ]
+            },
+            {"path": "src/workers", "type": "pip"}]},
+        id="pip_extra_options"
+    ),
+    pytest.param(
+        {"pkg_managers": ["gomod", "npm"], "packages": {"gomod": [{"path": "operator"}]}},
+        {"flags": [], "packages": [
+            {"path": "operator", "type": "gomod"}, {"path": ".", "type": "npm"}
+        ]},
+        id="mixed_pkg_managers"
+    ),
+    pytest.param(
+        {"pkg_managers": ["gomod"], "flags": ["gomod-vendor"]},
+        {"flags": ["gomod-vendor"], "packages": [{"path": ".", "type": "gomod"}]},
+        id="pkg_manager_with_flags",
+    ),
+    pytest.param(
+        {"pkg_managers": ["gomod"], "flags": [
+            "remove-unsafe-symlinks", "gomod-vendor", "include-git-dir"
+        ]},
+        {"flags": ["gomod-vendor"], "packages": [{"path": ".", "type": "gomod"}]},
+        id="unsupported_flags",
+    ),
+    pytest.param(
+        {"pkg_managers": ["git-submodule"]},
+        {"flags": [], "packages": []},
+        id="unsupported_git_submodule",
+    ),
+])
+def test_remote_source_to_cachi2_conversion(input_remote_source, expected_cachi2):
+    """Test conversion of remote_source (cachito) configuration from container yaml
+    into cachi2 params"""
+    assert remote_source_to_cachi2(input_remote_source) == expected_cachi2


### PR DESCRIPTION
Conversion function that transforms remote_source into cachi2 params

STONEBLD-2586

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [-] JSON/YAML configuration changes are updated in the relevant schema
- [-] Changes to metadata also update the documentation for the metadata
- [-] Pull request has a link to an osbs-docs PR for user documentation updates
- [-] New feature can be disabled from a configuration file
