### PR TITLE
CI: Replace centos with rockylinux

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: centos
+          - name: rockylinux
             version: 8
             python: "3.8"
             engine: docker


### PR DESCRIPTION
Centos 8 is deprecated and mirrors have been shutdown. The closest distro is rockylinux 8, let's use that one.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
