### PR TITLE
CI: fix missing bandit git

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -107,7 +107,7 @@ case ${ACTION} in
   ;;
 "bandit")
   setup_osbs
-  $RUN "${PIP_INST[@]}" bandit
+  $RUN "${PIP_INST[@]}" bandit[baseline]
   TEST_CMD="bandit-baseline -r atomic_reactor -ll -ii"
   ;;
 *)


### PR DESCRIPTION
We have to install badit[baseline] as upstream removed support for git in basic installation.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
