### PR TITLE
fix: shellcheck report

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -96,7 +96,7 @@ case ${ACTION} in
   ;;
 "bandit")
   setup_osbs
-  $RUN "${PIP_INST[@]}" bandit[baseline]
+  $RUN "${PIP_INST[@]}" 'bandit[baseline]'
   TEST_CMD="bandit-baseline -r atomic_reactor -ll -ii"
   ;;
 *)


### PR DESCRIPTION
```
In ./test.sh line 99:
  $RUN "${PIP_INST[@]}" bandit[baseline]
                              ^--------^ SC2102: Ranges can only
 match single chars (mentioned due to duplicates).
```

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
