### PR TITLE
replace our custom makrdowlint with DavidAnson/markdownlint-cli2-action

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run markdownlint
-        uses: containerbuildsystem/actions/markdownlint@master
+        uses: DavidAnson/markdownlint-cli2-action@v16
 
   mypy:
     name: mypy

--- a/README.md
+++ b/README.md
@@ -124,6 +124,3 @@ You can either get the build image from Dockerhub or create it yourself.
 [unittests status link]: https://github.com/containerbuildsystem/atomic-reactor/actions?query=event%3Apush+branch%3Amaster+workflow%3A%22Unittests%22
 [koji]: https://github.com/containerbuildsystem/atomic-reactor/blob/master/docs/koji.md
 [fedora packaging system]: http://fedoraproject.org/wiki/Package_maintenance_guide
-[docker-py]: https://github.com/docker/docker-py
-[koji plugin]: https://github.com/containerbuildsystem/atomic-reactor/blob/master/atomic_reactor/plugins/pre_koji.py
-[images]: https://github.com/containerbuildsystem/atomic-reactor/tree/master/images


### PR DESCRIPTION
Contanerbuild markdown action is outdated and not working, instead of fixing and duplicating work, use existing action.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
