### PR TITLE
Update setuptools and packaging version

### DIFF
--- a/requirements-build.in
+++ b/requirements-build.in
@@ -2,14 +2,14 @@
 Cython
 cffi>=1.12
 flit_core<4,>=3.2.0
-packaging>=20.0
+packaging>=22.0
 poetry-core
 pycairo
 pycparser
 pyparsing<3,>=2.0.2
 semantic-version>=2.6.0
 setuptools-rust>=0.11.4
-setuptools
+setuptools>=70.0.0
 setuptools_scm
 setuptools_scm[toml]>=3.4
 # pin tomli to avoid issue when building with cachito

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -103,9 +103,9 @@ flit-core==3.9.0 \
     --hash=sha256:72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba \
     --hash=sha256:7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
     # via -r requirements-build.in
-packaging==21.2 \
-    --hash=sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966 \
-    --hash=sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0
+packaging==24.1 \
+    --hash=sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002 \
+    --hash=sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124
     # via
     #   -r requirements-build.in
     #   setuptools-scm
@@ -135,9 +135,7 @@ pycparser==2.20 \
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
-    # via
-    #   -r requirements-build.in
-    #   packaging
+    # via -r requirements-build.in
 pytest-runner==5.3.1 \
     --hash=sha256:0fce5b8dc68760f353979d99fdd6b3ad46330b6b1837e2077a89ebcf204aac91 \
     --hash=sha256:85f93af814438ee322b4ea08fe3f5c2ad53b253577f3bd84b2ad451fee450ac5
@@ -159,7 +157,9 @@ setuptools-scm[toml]==7.1.0 \
 tomli==1.0.1 \
     --hash=sha256:597db31e0350ef52f55595244ab74915daf8c03c8bda7bfb61a4297ab01f98fe \
     --hash=sha256:dce66410edbec030792fc81653d8658ff675998076f31c45c0aafb1da824e9c7
-    # via -r requirements-build.in
+    # via
+    #   -r requirements-build.in
+    #   setuptools-scm
 typing-extensions==4.0.1 \
     --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e \
     --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
@@ -172,9 +172,9 @@ wheel==0.40.0 \
     # via -r requirements-build.in
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==67.6.1 \
-    --hash=sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a \
-    --hash=sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078
+setuptools==72.1.0 \
+    --hash=sha256:5a03e1860cf56bb6ef48ce186b0e557fdba433237481a9a625176c2831be15d1 \
+    --hash=sha256:8d243eff56d095e5817f796ede6ae32941278f542e0f941867cc05ae52b162ec
     # via
     #   -r requirements-build.in
     #   setuptools-rust


### PR DESCRIPTION
The setuptools update addresses a vulnerability alert by dependabot:
A vulnerability in the package_index module of pypa/setuptools versions up to 69.1.1 allows for remote code execution via its download functions.
These functions, which are used to download packages from URLs provided by users or retrieved from package index servers, are susceptible to code injection.
If these functions are exposed to user-controlled inputs, such as package URLs, they can execute arbitrary commands on the system. The issue is fixed in version 70.0.

The packaging update is necessary for the setuptools update (or we could
freeze it to version 70.x). But if version > 71 is used, we have to update the
packaging version to 22 or higher. Otherwise the build process fails
with

TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
More information in https://github.com/pypa/setuptools/issues/4483

STONEBLD-2636

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
