### PR TITLE
feat(remote_source): upload all metadata

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -193,6 +193,8 @@ REMOTE_SOURCE_DIR = '/remote-source'
 # Name of downloaded remote sources tarball
 REMOTE_SOURCE_TARBALL_FILENAME = 'remote-source.tar.gz'
 REMOTE_SOURCE_JSON_FILENAME = 'remote-source.json'
+REMOTE_SOURCE_JSON_CONFIG_FILENAME = 'remote-source.config.json'
+REMOTE_SOURCE_JSON_ENV_FILENAME = 'remote-source.env.json'
 ICM_JSON_FILENAME = 'icm-{}.json'
 
 # koji osbs_build metadata

--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -322,6 +322,8 @@ class KojiImportBase(Plugin):
                         "archives": [
                             remote_source["remote_source_json"]["filename"],
                             remote_source["remote_source_tarball"]["filename"],
+                            remote_source["remote_source_json_env"]["filename"],
+                            remote_source["remote_source_json_config"]["filename"],
                         ],
                     }
                     for remote_source in remote_source_result
@@ -622,15 +624,18 @@ class KojiImportPlugin(KojiImportBase):
             dest_filename = remote_source_tarball['filename']
             yield local_filename, dest_filename, KOJI_BTYPE_REMOTE_SOURCES, None
 
-            remote_source_json = remote_source['remote_source_json']
-            remote_source_json_filename = remote_source_json['filename']
-            file_path = os.path.join(tmpdir, remote_source_json_filename)
-            with open(file_path, 'w') as f:
-                json.dump(remote_source_json['json'], f, indent=4, sort_keys=True)
-            yield (file_path,
-                   remote_source_json_filename,
-                   KOJI_BTYPE_REMOTE_SOURCES,
-                   None)
+            for source_key in (
+                "remote_source_json", "remote_source_json_env", "remote_source_json_config",
+            ):
+                data_json = remote_source[source_key]
+                data_json_filename = data_json['filename']
+                file_path = os.path.join(tmpdir, data_json_filename)
+                with open(file_path, 'w') as f:
+                    json.dump(data_json['json'], f, indent=4, sort_keys=True)
+                yield (file_path,
+                       data_json_filename,
+                       KOJI_BTYPE_REMOTE_SOURCES,
+                       None)
 
     def _collect_exported_operator_manifests(self) -> Iterable[ArtifactOutputInfo]:
         wf_data = self.workflow.data

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -49,6 +49,8 @@ from atomic_reactor.constants import (IMAGE_TYPE_DOCKER_ARCHIVE, KOJI_BTYPE_OPER
                                       PARENT_IMAGES_KEY, OPERATOR_MANIFESTS_ARCHIVE,
                                       REMOTE_SOURCE_TARBALL_FILENAME,
                                       REMOTE_SOURCE_JSON_FILENAME,
+                                      REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+                                      REMOTE_SOURCE_JSON_ENV_FILENAME,
                                       MEDIA_TYPE_DOCKER_V2_SCHEMA2,
                                       MEDIA_TYPE_DOCKER_V2_MANIFEST_LIST,
                                       KOJI_BTYPE_REMOTE_SOURCE_FILE,
@@ -532,6 +534,14 @@ def mock_environment(workflow: DockerBuildWorkflow, source_dir: Path,
                 "remote_source_json": {
                     "filename": REMOTE_SOURCE_JSON_FILENAME,
                     "json": {"stub": "data"},
+                },
+                "remote_source_json_config": {
+                    "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+                    "json": [{"stub": "data"}],
+                },
+                "remote_source_json_env": {
+                    "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
+                    "json": {"var": {"stub": "data"}},
                 },
                 "remote_source_tarball": {
                     "filename": REMOTE_SOURCE_TARBALL_FILENAME,
@@ -2003,7 +2013,10 @@ class TestKojiImport(object):
                     {
                         'name': None,
                         'url': 'https://cachito.com/api/v1/requests/21048',
-                        'archives': ['remote-source.json', 'remote-source.tar.gz'],
+                        'archives': [
+                            'remote-source.json', 'remote-source.tar.gz',
+                            'remote-source.env.json', 'remote-source.config.json'
+                        ],
                     }
                 ]
                 assert REMOTE_SOURCE_TARBALL_FILENAME in session.uploaded_files.keys()

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -29,6 +29,8 @@ from atomic_reactor.constants import (
     REMOTE_SOURCE_DIR,
     REMOTE_SOURCE_TARBALL_FILENAME,
     REMOTE_SOURCE_JSON_FILENAME,
+    REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+    REMOTE_SOURCE_JSON_ENV_FILENAME,
 )
 from atomic_reactor.plugin import PluginFailedException
 from atomic_reactor.plugins.resolve_remote_source import (
@@ -393,6 +395,14 @@ def mock_cachito_api_multiple_remote_sources(workflow, user=KOJI_TASK_OWNER):
 
     (
         flexmock(CachitoAPI)
+        .should_receive("get_request_config_files")
+        .with_args(CACHITO_SOURCE_REQUEST["id"])
+        .and_return(CACHITO_CONFIG_FILES)
+        .ordered()
+    )
+
+    (
+        flexmock(CachitoAPI)
         .should_receive("download_sources")
         .with_args(
             SECOND_CACHITO_SOURCE_REQUEST,
@@ -408,14 +418,6 @@ def mock_cachito_api_multiple_remote_sources(workflow, user=KOJI_TASK_OWNER):
         .should_receive("get_request_env_vars")
         .with_args(SECOND_CACHITO_SOURCE_REQUEST["id"])
         .and_return(SECOND_CACHITO_ENV_VARS_JSON)
-        .ordered()
-    )
-
-    (
-        flexmock(CachitoAPI)
-        .should_receive("get_request_config_files")
-        .with_args(CACHITO_SOURCE_REQUEST["id"])
-        .and_return(CACHITO_CONFIG_FILES)
         .ordered()
     )
 
@@ -564,6 +566,14 @@ def test_resolve_remote_source(workflow, scratch, dr_strs, dependency_replacemen
                 "json": REMOTE_SOURCE_JSON,
                 "filename": REMOTE_SOURCE_JSON_FILENAME,
             },
+            "remote_source_json_config": {
+                "json": CACHITO_CONFIG_FILES,
+                "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+            },
+            "remote_source_json_env": {
+                "json": CACHITO_ENV_VARS_JSON,
+                "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
+            },
             "remote_source_tarball": {
                 "filename": REMOTE_SOURCE_TARBALL_FILENAME,
                 "path": expected_dowload_path(workflow),
@@ -653,6 +663,14 @@ def test_no_koji_user(workflow, caplog):
                 "json": REMOTE_SOURCE_JSON,
                 "filename": REMOTE_SOURCE_JSON_FILENAME,
             },
+            "remote_source_json_config": {
+                "json": CACHITO_CONFIG_FILES,
+                "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+            },
+            "remote_source_json_env": {
+                "json": CACHITO_ENV_VARS_JSON,
+                "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
+            },
             "remote_source_tarball": {
                 "filename": REMOTE_SOURCE_TARBALL_FILENAME,
                 "path": expected_dowload_path(workflow),
@@ -732,6 +750,14 @@ def test_bad_build_metadata(workflow, task_id, log_entry, caplog):
                 "json": REMOTE_SOURCE_JSON,
                 "filename": REMOTE_SOURCE_JSON_FILENAME,
             },
+            "remote_source_json_config": {
+                "json": CACHITO_CONFIG_FILES,
+                "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+            },
+            "remote_source_json_env": {
+                "json": CACHITO_ENV_VARS_JSON,
+                "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
+            },
             "remote_source_tarball": {
                 "filename": REMOTE_SOURCE_TARBALL_FILENAME,
                 "path": expected_dowload_path(workflow),
@@ -749,9 +775,13 @@ def test_allow_multiple_remote_sources(workflow, allow_multiple_remote_sources):
     first_remote_source_name = 'gomod'
     first_remote_tarball_filename = 'remote-source-gomod.tar.gz'
     first_remote_json_filename = 'remote-source-gomod.json'
+    first_remote_json_config_filename = 'remote-source-gomod.config.json'
+    first_remote_json_env_filename = 'remote-source-gomod.env.json'
     second_remote_source_name = 'pip'
     second_remote_tarball_filename = 'remote-source-pip.tar.gz'
     second_remote_json_filename = 'remote-source-pip.json'
+    second_remote_json_config_filename = 'remote-source-pip.config.json'
+    second_remote_json_env_filename = 'remote-source-pip.env.json'
 
     container_yaml_config = dedent(
         """\
@@ -806,6 +836,14 @@ def test_allow_multiple_remote_sources(workflow, allow_multiple_remote_sources):
                     "json": REMOTE_SOURCE_JSON,
                     "filename": first_remote_json_filename,
                 },
+                "remote_source_json_config": {
+                    "json": CACHITO_CONFIG_FILES,
+                    "filename": first_remote_json_config_filename,
+                },
+                "remote_source_json_env": {
+                    "json": CACHITO_ENV_VARS_JSON,
+                    "filename": first_remote_json_env_filename,
+                },
                 "remote_source_tarball": {
                     "filename": first_remote_tarball_filename,
                     "path": expected_dowload_path(workflow, "gomod"),
@@ -818,6 +856,14 @@ def test_allow_multiple_remote_sources(workflow, allow_multiple_remote_sources):
                 "remote_source_json": {
                     "json": SECOND_REMOTE_SOURCE_JSON,
                     "filename": second_remote_json_filename,
+                },
+                "remote_source_json_config": {
+                    "json": SECOND_CACHITO_CONFIG_FILES,
+                    "filename": second_remote_json_config_filename,
+                },
+                "remote_source_json_env": {
+                    "json": SECOND_CACHITO_ENV_VARS_JSON,
+                    "filename": second_remote_json_env_filename,
                 },
                 "remote_source_tarball": {
                     "filename": second_remote_tarball_filename,
@@ -932,6 +978,8 @@ def test_inject_remote_sources_dest_already_exists(workflow):
             id=CACHITO_REQUEST_ID,
             name=None,
             json_data={},
+            json_env_data={},
+            json_config_data={},
             build_args={},
             tarball_path=Path("/does/not/matter"),
         ),

--- a/tests/plugins/test_resolve_remote_source.py
+++ b/tests/plugins/test_resolve_remote_source.py
@@ -980,7 +980,6 @@ def test_inject_remote_sources_dest_already_exists(workflow):
             json_data={},
             json_env_data={},
             json_config_data={},
-            build_args={},
             tarball_path=Path("/does/not/matter"),
         ),
     ]


### PR DESCRIPTION
Upload all metadata from cachito, se we can avoid having extra queries for cachito endpoints and keep all data in koji

STONEBLD-2655

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
