### PR TITLE
Update certifi package

### DIFF
--- a/otel-requirements.txt
+++ b/otel-requirements.txt
@@ -10,7 +10,7 @@ backoff==2.2.1
     #   opentelemetry-exporter-otlp-proto-http
 calver==2022.6.26
     # via -r otel-requirements.in
-certifi==2023.7.22
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.2.0
     # via requests

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -17,7 +17,7 @@ bcrypt==3.2.0
     # via paramiko
 calver==2022.6.26
     # via -r otel-requirements.in
-certifi==2022.12.7
+certifi==2024.7.4
     # via requests
 cffi==1.15.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ bcrypt==3.2.0
     # via paramiko
 calver==2022.6.26
     # via -r otel-requirements.in
-certifi==2022.12.7
+certifi==2024.7.4
     # via requests
 cffi==1.15.0
     # via


### PR DESCRIPTION
This deals with dependabot security alerts related to old version of
certifi.

See https://github.com/containerbuildsystem/atomic-reactor/security/dependabot?q=is%3Aopen+package%3Acertifi

STONEBLD-2636

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
