### PR TITLE
Update requests and urllib3

### DIFF
--- a/otel-requirements.txt
+++ b/otel-requirements.txt
@@ -87,7 +87,7 @@ protobuf==4.24.2
     #   opentelemetry-proto
 pydantic==1.10.12
     # via otel-extensions
-requests==2.31.0
+requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 tomli==2.0.1
     # via hatchling
@@ -97,7 +97,7 @@ typing-extensions==4.7.1
     # via
     #   opentelemetry-sdk
     #   pydantic
-urllib3==1.26.16
+urllib3==1.26.19
     # via
     #   -r otel-requirements.in
     #   requests

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -200,7 +200,7 @@ pyyaml==6.0
     #   osbs-client
 reflink==0.2.1
     # via -r requirements.in
-requests==2.26.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   koji
@@ -244,7 +244,7 @@ typing-extensions==4.7.1
     # via
     #   opentelemetry-sdk
     #   pydantic
-urllib3==1.26.7
+urllib3==1.26.19
     # via
     #   -r otel-requirements.in
     #   -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ pyyaml==6.0
     #   osbs-client
 reflink==0.2.1
     # via -r requirements.in
-requests==2.26.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   koji
@@ -183,7 +183,7 @@ typing-extensions==4.7.1
     # via
     #   opentelemetry-sdk
     #   pydantic
-urllib3==1.26.7
+urllib3==1.26.19
     # via
     #   -r otel-requirements.in
     #   -r requirements.in

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -147,7 +147,7 @@ pytest-xdist==2.5.0 \
     --hash=sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf \
     --hash=sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65
     # via -r requirements.in
-requests==2.31.0 \
+requests==2.32.3 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
     --hash=sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1
     # via


### PR DESCRIPTION
Updating requests to 2.32.3 and urllib3 to 1.26.19, patches security vulnerabilites as reported by

https://github.com/containerbuildsystem/atomic-reactor/security/dependabot?q=is%3Aopen+package%3Aurllib3%2Crequests

STONEBLD-2636

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
