### PR TITLE
cachi2: generate remote-source.json

### DIFF
--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -8,7 +8,9 @@
 Utils to help to integrate with cachi2 CLI tool
 """
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from packageurl import PackageURL
 
 
 def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
@@ -68,3 +70,82 @@ def convert_SBOM_to_ICM(sbom: Dict[str, Any]) -> Dict[str, Any]:
         {"purl": comp["purl"]} for comp in sbom["components"]  # type: ignore
     ]
     return icm
+
+
+def gen_dependency_from_sbom_component(sbom_dep: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """Generate a single request.json dependency from a SBOM component
+
+    Dependency type is derived from purl.
+    Version is decided on how Cachito would do it.
+    """
+    # we need to detect type from purl, this is just heuristics,
+    # we cannot reliably construct type from purl
+    purl = PackageURL.from_string(sbom_dep["purl"])
+    heuristic_type = purl.type or "unknown"  # for unknown types, reuse what's in purl type
+    # types supported by cachito/cachi2
+    purl_type_matchers: Tuple[Tuple[Callable[[PackageURL], bool], str], ...] = (
+        (lambda p: p.type == "golang" and p.qualifiers.get("type", "") == "module", "gomod"),
+        (lambda p: p.type == "golang", "go-package"),
+        (lambda p: p.type == "npm", "npm"),
+        (lambda p: p.type == "pypi", "pip"),
+        (lambda p: p.type == "rpm", "rpm"),
+        (lambda p: p.type == "gem", "rubygems"),
+        (lambda p: p.type == "cargo", "cargo"),
+    )
+
+    for matcher, request_type in purl_type_matchers:
+        if matcher(purl):
+            heuristic_type = request_type
+            break
+
+    version = (
+        # for non-registry dependencies cachito uses URL as version
+        purl.qualifiers.get("vcs_url") or
+        purl.qualifiers.get("download_url") or
+        # for local dependencies Cachito uses path as version
+        (f"./{purl.subpath}" if purl.subpath and purl.type == "golang" else None) or
+        (f"file:{purl.subpath}" if purl.subpath and purl.type != "golang" else None) or
+        # version is mainly for dependencies from pkg registries
+        sbom_dep.get("version")
+        # returns None if version cannot be determined
+    )
+
+    res = {
+        "name": sbom_dep["name"],
+        "replaces": None,  # it's always None, replacements aren't supported by cachi2
+        "type": heuristic_type,
+        "version": version,
+    }
+
+    # dev package definition
+    # currently only NPM
+    if any(p["name"] == "cdx:npm:package:development" and p["value"] == "true"
+           for p in sbom_dep.get("properties", [])):
+        res["dev"] = True
+
+    return res
+
+
+def generate_request_json(
+    remote_source: Dict[str, Any], remote_source_sbom: Dict[str, Any],
+    remote_source_env_json: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
+    """Generates Cachito like request.json
+
+    Cachito does provide request.json, for backward compatibility
+    as some tools are depending on it, we have to generate also request.json from cachi2
+    """
+
+    res = {
+        "dependencies": [
+            gen_dependency_from_sbom_component(dep)
+            for dep in remote_source_sbom["components"]
+        ],
+        "pkg_managers": remote_source.get("pkg_managers", []),
+        "ref": remote_source["ref"],
+        "repo": remote_source["repo"],
+        "environment_variables": {key: val["value"] for key, val in remote_source_env_json.items()},
+        "flags": remote_source.get("flags", []),
+        "packages": [],  # this will be always empty cachi2 doesn't provide nested deps
+    }
+    return res

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -128,6 +128,8 @@ osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@d0e1e394fe
     # via -r requirements.in
 otel-extensions==0.2.5
     # via -r otel-requirements.in
+packageurl-python==0.15.6
+    # via -r requirements.in
 packaging==23.1
     # via
     #   hatchling

--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ PyGObject
 reflink
 urllib3 < 2.0
 setuptools<=70.3.0
+packageurl-python >= 0.15.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -115,6 +115,8 @@ osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@d0e1e394fe
     # via -r requirements.in
 otel-extensions==0.2.5
     # via -r otel-requirements.in
+packageurl-python==0.15.6
+    # via -r requirements.in
 packaging==23.1
     # via hatchling
 paramiko==2.10.3


### PR DESCRIPTION
Cachi2 doesn't provide remote-source.json but for backward compatibility OSBS must provide it.

STONEBLD-2585

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
