### PR TITLE
fix(Retry): replace method_whitelist

### DIFF
--- a/atomic_reactor/utils/cachito.py
+++ b/atomic_reactor/utils/cachito.py
@@ -47,8 +47,8 @@ class CachitoAPI(object):
         self.timeout = 3600 if timeout is None else timeout
 
     def _make_session(self, insecure, cert):
-        # method_whitelist=False allows retrying non-idempotent methods like POST
-        session = get_retrying_requests_session(method_whitelist=False)
+        # allowed_methods=False allows retrying non-idempotent methods like POST
+        session = get_retrying_requests_session(allowed_methods=False)
         session.verify = not insecure
         if cert:
             session.cert = cert

--- a/atomic_reactor/utils/odcs.py
+++ b/atomic_reactor/utils/odcs.py
@@ -55,8 +55,8 @@ class ODCSClient(object):
         self._setup_session(insecure=insecure, token=token, cert=cert, kerberos_auth=kerberos_auth)
 
     def _setup_session(self, insecure, token, cert, kerberos_auth):
-        # method_whitelist=False allows retrying non-idempotent methods like POST
-        session = get_retrying_requests_session(method_whitelist=False)
+        # allowed_methods=False allows retrying non-idempotent methods like POST
+        session = get_retrying_requests_session(allowed_methods=False)
 
         session.verify = not insecure
 

--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -58,7 +58,7 @@ def hook_log_error_response_content(response, *args, **kwargs):
 
 def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
                                   times=HTTP_MAX_RETRIES, delay=HTTP_BACKOFF_FACTOR,
-                                  method_whitelist=None, raise_on_status=True):
+                                  allowed_methods=None, raise_on_status=True):
     if _http_retries_disabled():
         times = 0
 
@@ -66,7 +66,7 @@ def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
         total=int(times),
         backoff_factor=delay,
         status_forcelist=client_statuses,
-        method_whitelist=method_whitelist
+        allowed_methods=allowed_methods
     )
 
     # raise_on_status was added later to Retry, adding compatibility to work


### PR DESCRIPTION
This parameter has been deprecated and allowed_methods param should be used instead

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
