### PR TITLE
Allow konflux images with oci index, be used in osbs

### DIFF
--- a/atomic_reactor/config.py
+++ b/atomic_reactor/config.py
@@ -483,7 +483,7 @@ class Configuration(object):
     @property
     def skip_koji_check_for_base_image(self):
         return self._get_value(ReactorConfigKeys.SKIP_KOJI_CHECK_FOR_BASE_IMAGE_KEY,
-                               fallback=False)
+                               fallback=True)
 
     @property
     def deep_manifest_list_inspection(self):

--- a/atomic_reactor/plugins/check_base_image.py
+++ b/atomic_reactor/plugins/check_base_image.py
@@ -143,6 +143,11 @@ class CheckBaseImagePlugin(Plugin):
         reg_client = self._get_registry_client(image.registry)
 
         manifest_list = reg_client.get_manifest_list(image)
+
+        if not manifest_list:
+            self.log.info('manifest list not found trying to get image index')
+            manifest_list = reg_client.get_manifest_index(image)
+
         if '@sha256:' in str(image) and not manifest_list:
             # we want to adjust the tag only for manifest list fetching
             image = image.copy()

--- a/atomic_reactor/plugins/fetch_sources.py
+++ b/atomic_reactor/plugins/fetch_sources.py
@@ -683,9 +683,11 @@ class FetchSourcesPlugin(Plugin):
             self.log.debug('Resolving SRPM for RPM ID: %s', rpm_id)
 
             if rpm['external_repo_name'] != 'INTERNAL':
-                msg = ('RPM comes from an external repo (RPM ID: {}). '
-                       'External RPMs are currently not supported.').format(rpm_id)
-                raise RuntimeError(msg)
+                msg = ('RPM comes from an external repo (RPM ID: {}; NVR: {}). '
+                       'External RPMs are currently not supported, '
+                       'skipping').format(rpm_id, rpm['nvr'])
+                self.log.warning(msg)
+                continue
 
             rpm_hdr = self.session.getRPMHeaders(rpm_id, headers=['SOURCERPM'])
             if 'SOURCERPM' not in rpm_hdr:

--- a/atomic_reactor/plugins/resolve_composes.py
+++ b/atomic_reactor/plugins/resolve_composes.py
@@ -148,7 +148,10 @@ class ResolveComposesPlugin(Plugin):
         if not self.plugin_result:
             return
 
-        build_info = self.plugin_result[BASE_IMAGE_KOJI_BUILD]
+        build_info = self.plugin_result.get(BASE_IMAGE_KOJI_BUILD)
+        if not build_info:
+            self.log.warning('Parent koji build does not exist can not inherit from the parent')
+            return
         parent_repourls = []
 
         try:
@@ -218,7 +221,11 @@ class ResolveComposesPlugin(Plugin):
                            PLUGIN_KOJI_PARENT_KEY)
             return
 
-        build_info = self.plugin_result[BASE_IMAGE_KOJI_BUILD]
+        build_info = self.plugin_result.get(BASE_IMAGE_KOJI_BUILD)
+        if not build_info:
+            self.log.warning('Parent koji build does not exist can not adjust '
+                             'signing intent from the parent')
+            return
 
         try:
             parent_signing_intent_name = build_info['extra']['image']['odcs']['signing_intent']

--- a/atomic_reactor/schemas/config.json
+++ b/atomic_reactor/schemas/config.json
@@ -497,9 +497,9 @@
         "type": "string"
     },
     "skip_koji_check_for_base_image": {
-        "description": "Allow base image without a related koji build (insecure) when there are no NVR labels set on the base image. If the NVR labels are set on the base image, the check is performed regardless",
+        "description": "Allow base image without a related koji build (insecure)",
         "type": "boolean",
-        "default": false
+        "default": true
     },
     "deep_manifest_list_inspection": {
         "description": "If manifest list digest check fails, inspect the manifest list contents",


### PR DESCRIPTION
* STONEBLD-2896

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
