### PR TITLE
fix(imp module): replace deprecated module

### DIFF
--- a/atomic_reactor/plugin.py
+++ b/atomic_reactor/plugin.py
@@ -15,7 +15,7 @@ import logging
 import os
 import sys
 import traceback
-import imp  # pylint: disable=deprecated-module
+import importlib
 import inspect
 import time
 from abc import ABC, abstractmethod
@@ -185,7 +185,9 @@ class PluginsRunner(object):
                 f_module = sys.modules[module_name]
             else:
                 try:
-                    f_module = imp.load_source(module_name, f)
+                    spec = importlib.util.spec_from_file_location(module_name, f)
+                    f_module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(f_module)
                 except (IOError, OSError, ImportError, SyntaxError) as ex:
                     logger.warning("can't load module '%s': %s", f, ex)
                     continue


### PR DESCRIPTION
imp module has been replaced by importlib in python 3.12 and is not available anymore

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
