### PR TITLE
cachi2: fix pkg_managers opts

### DIFF
--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -40,7 +40,12 @@ def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     )
     cachi2_packages = []
 
-    for pkg_manager in remote_source["pkg_managers"]:
+    pkg_managers = remote_source.get("pkg_managers")
+    if pkg_managers is None:
+        # Cachito behavior, missing pkg_managers means to use gomod
+        pkg_managers = ["gomod"]
+
+    for pkg_manager in pkg_managers:
         if pkg_manager in removed_pkg_managers:
             continue
 

--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -28,6 +28,10 @@ def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     * git-submodule
 
     """
+    pkg_managers_map = {
+        "rubygems": "bundler"  # renamed in cachi2
+    }
+
     removed_flags = {"include-git-dir", "remove-unsafe-symlinks"}
     removed_pkg_managers = {"git-submodule"}
 
@@ -39,6 +43,9 @@ def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     for pkg_manager in remote_source["pkg_managers"]:
         if pkg_manager in removed_pkg_managers:
             continue
+
+        # if pkg manager has different name in cachi2 update it
+        pkg_manager = pkg_managers_map.get(pkg_manager, pkg_manager)
 
         packages = remote_source.get("packages", {}).get(pkg_manager, [])
         packages = packages or [{"path": "."}]

--- a/tests/utils/test_cachi2.py
+++ b/tests/utils/test_cachi2.py
@@ -23,6 +23,11 @@ import pytest
         id="pkg_manager_plain",
     ),
     pytest.param(
+        {"pkg_managers": ["rubygems"]},
+        {"flags": [], "packages": [{"path": ".", "type": "bundler"}]},
+        id="pkg_rubygems_to_bundler",
+    ),
+    pytest.param(
         {"pkg_managers": ["gomod"], "packages": {"gomod": [{"path": "operator"}]}},
         {"flags": [], "packages": [{"path": "operator", "type": "gomod"}]},
         id="pkg_manager_single_path"

--- a/tests/utils/test_cachi2.py
+++ b/tests/utils/test_cachi2.py
@@ -28,6 +28,11 @@ import pytest
         id="pkg_rubygems_to_bundler",
     ),
     pytest.param(
+        {},
+        {"flags": [], "packages": [{"path": ".", "type": "gomod"}]},
+        id="pkg_manager_missing",
+    ),
+    pytest.param(
         {"pkg_managers": ["gomod"], "packages": {"gomod": [{"path": "operator"}]}},
         {"flags": [], "packages": [{"path": "operator", "type": "gomod"}]},
         id="pkg_manager_single_path"


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
