### PR TITLE
pinning operator digest plugin now supports konflux images with oci.index

### DIFF
--- a/atomic_reactor/util.py
+++ b/atomic_reactor/util.py
@@ -785,6 +785,18 @@ class RegistryClient(object):
         digest_dict = get_checksums(io.BytesIO(response.content), ['sha256'])
         return 'sha256:{}'.format(digest_dict['sha256sum'])
 
+    def get_manifest_index_digest(self, image):
+        """Return manifest index digest for image
+
+        :param image:
+        :return:
+        """
+        response = self.get_manifest_index(image)
+        if response is None:
+            raise RuntimeError('Unable to fetch oci.index for {}'.format(image.to_str()))
+        digest_dict = get_checksums(io.BytesIO(response.content), ['sha256'])
+        return 'sha256:{}'.format(digest_dict['sha256sum'])
+
     def get_all_manifests(
         self, image: ImageName, versions: Sequence[str] = ('v1', 'v2', 'v2_list', 'oci_index')
     ) -> Dict[str, requests.Response]:


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
