### PR TITLE
fix(cachi2): single remote source name

### DIFF
--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -78,7 +78,7 @@ class Cachi2InitPlugin(Plugin):
         remote_sources = self.multiple_remote_sources_params
         if self.single_remote_source_params:
             remote_sources = [{
-                "name": "",  # name single remote source with generic name
+                "name": None,
                 "remote_source": self.single_remote_source_params}]
 
         processed_remote_sources = []

--- a/tests/plugins/test_cachi2_init.py
+++ b/tests/plugins/test_cachi2_init.py
@@ -133,7 +133,7 @@ def test_single_remote_source_initialization(workflow, mocked_cachi2_init):
         '/remote-source')
 
     assert result == [{
-        "name": "",
+        "name": None,
         "source_path": str(
             workflow.build_dir.path / CACHI2_BUILD_DIR / CACHI2_SINGLE_REMOTE_SOURCE_NAME),
         "remote_source": {


### PR DESCRIPTION
When single remote source is used, returned name should be None and not an empty string. This si compatible with Cachito behavior.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
