### PR TITLE
cachi2: bump osbs-client

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ jsonschema
 paramiko>=3.4.0
 PyYAML
 ruamel.yaml
-git+https://github.com/containerbuildsystem/osbs-client@541387019135f2bb6fc8054a453641f0e9feb3d7#egg=osbs-client
+git+https://github.com/containerbuildsystem/osbs-client@b59210140d04060640e660c7cdee0ba56648e372#egg=osbs-client
 # cannot build cryptography with rust for version >= 3.5
 cryptography < 3.5
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,7 +111,7 @@ opentelemetry-semantic-conventions==0.41b0
     #   opentelemetry-sdk
 opentelemetry-util-http==0.41b0
     # via opentelemetry-instrumentation-requests
-osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@541387019135f2bb6fc8054a453641f0e9feb3d7
+osbs-client @ git+https://github.com/containerbuildsystem/osbs-client@b59210140d04060640e660c7cdee0ba56648e372
     # via -r requirements.in
 otel-extensions==0.2.5
     # via -r otel-requirements.in


### PR DESCRIPTION
This bump is required to validate allowed pkg_managers also on atomic-reactor side.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
