### PR TITLE
fix(cachi2): copy all files generated by cachi2

### DIFF
--- a/atomic_reactor/plugins/cachi2_postprocess.py
+++ b/atomic_reactor/plugins/cachi2_postprocess.py
@@ -186,11 +186,8 @@ class Cachi2PostprocessPlugin(Plugin):
                 "copy method used for cachi2 build_dir_injecting: %s", copy_method.__name__)
 
             copytree(
-                remote_source.sources_path/'app', dest_dir/'app',
-                symlinks=True, copy_function=copy_method)
-            copytree(
-                remote_source.sources_path/'deps', dest_dir/'deps',
-                symlinks=True, copy_function=copy_method)
+                remote_source.sources_path, dest_dir,
+                symlinks=True, copy_function=copy_method, dirs_exist_ok=True)
 
             # Create cachito.env file with environment variables received from cachito request
             self.generate_cachito_env_file(dest_dir, remote_source.build_args)


### PR DESCRIPTION
Rubygems package manager contains data also out of deps/ and app/ directory. The whole remote dir must be copied.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
