### PR TITLE
cachi2: allow only relative paths

### DIFF
--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -25,7 +25,7 @@ from atomic_reactor.constants import (
 )
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import map_to_user_params
-from atomic_reactor.utils.cachi2 import remote_source_to_cachi2, clone_only
+from atomic_reactor.utils.cachi2 import remote_source_to_cachi2, clone_only, validate_paths
 
 
 class Cachi2InitPlugin(Plugin):
@@ -128,6 +128,8 @@ class Cachi2InitPlugin(Plugin):
                 source_path_app,
                 remote_source_data["ref"]
             )
+
+            validate_paths(source_path_app, remote_source_data.get("packages", {}))
 
             if clone_only(remote_source_data):
                 # OSBS is doing all work here


### PR DESCRIPTION
For security reasons, only relative paths within cloned remote source can be specified by users

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
