### PR TITLE
fix(cachi2): set gomod explicitly

### DIFF
--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -25,7 +25,10 @@ from atomic_reactor.constants import (
 )
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import map_to_user_params
-from atomic_reactor.utils.cachi2 import remote_source_to_cachi2, clone_only, validate_paths
+from atomic_reactor.utils.cachi2 import (
+    remote_source_to_cachi2, clone_only, validate_paths,
+    normalize_gomod_pkg_manager
+)
 
 
 class Cachi2InitPlugin(Plugin):
@@ -114,6 +117,9 @@ class Cachi2InitPlugin(Plugin):
                 remote_source["name"] if self.multiple_remote_sources_params
                 else CACHI2_SINGLE_REMOTE_SOURCE_NAME
             )
+
+            normalize_gomod_pkg_manager(remote_source['remote_source'])
+
             self.log.info("Initializing remote source %s", source_name)
             source_path = self.remote_sources_root_path / source_name
             source_path.mkdir()

--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -57,6 +57,19 @@ def validate_paths(repo_path: Path, remote_sources_packages: dict) -> None:
                     raise ValueError(f"unexpected key '{key}' in '{pkg_mgr}' config")
 
 
+def normalize_gomod_pkg_manager(remote_source: Dict[str, Any]):
+    """Cachito compatibility, empty/undefined pkg_managers means gomod.
+    Replace it to explicitly use gomod
+
+    Function does in-place change.
+    """
+    pkg_managers = remote_source.get("pkg_managers")
+    if pkg_managers is None:
+        # Cachito behavior, missing pkg_managers means to use gomod
+        pkg_managers = ["gomod"]
+    remote_source["pkg_managers"] = pkg_managers
+
+
 def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     """Converts remote source into cachi2 expected params.
 
@@ -84,10 +97,9 @@ def remote_source_to_cachi2(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     )
     cachi2_packages = []
 
-    pkg_managers = remote_source.get("pkg_managers")
-    if pkg_managers is None:
-        # Cachito behavior, missing pkg_managers means to use gomod
-        pkg_managers = ["gomod"]
+    normalize_gomod_pkg_manager(remote_source)
+
+    pkg_managers = remote_source["pkg_managers"]
 
     for pkg_manager in pkg_managers:
         if pkg_manager in removed_pkg_managers:

--- a/tests/plugins/test_cachi2_init.py
+++ b/tests/plugins/test_cachi2_init.py
@@ -141,6 +141,7 @@ def test_single_remote_source_initialization(workflow, mocked_cachi2_init):
         "remote_source": {
             "repo": REMOTE_SOURCE_REPO,
             "ref": REMOTE_SOURCE_REF,
+            "pkg_managers": ["gomod"],
         }
     }]
 
@@ -254,6 +255,7 @@ def test_multi_remote_source_initialization(workflow, mocked_cachi2_init):
         "remote_source": {
             "repo": SECOND_REMOTE_SOURCE_REPO,
             "ref": SECOND_REMOTE_SOURCE_REF,
+            "pkg_managers": ["gomod"],
         }
     }]
 


### PR DESCRIPTION
undefined pkg_managers means gomod, record this explictily in metadata, so this information is not lost in workflow and proper metadata are returned.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
