### PR TITLE
feat(utils): implement symlink sandbox for cachi2

### DIFF
--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -27,7 +27,7 @@ from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import map_to_user_params
 from atomic_reactor.utils.cachi2 import (
     remote_source_to_cachi2, clone_only, validate_paths,
-    normalize_gomod_pkg_manager
+    normalize_gomod_pkg_manager, enforce_sandbox,
 )
 
 
@@ -135,6 +135,7 @@ class Cachi2InitPlugin(Plugin):
                 remote_source_data["ref"]
             )
 
+            enforce_sandbox(source_path_app, remove_unsafe_symlinks=False)
             validate_paths(source_path_app, remote_source_data.get("packages", {}))
 
             if clone_only(remote_source_data):


### PR DESCRIPTION
What/why: implement detection/removal of unsafe symlinks in repos, specifically
covering cachi2 use case: Cachito already does this

How:

- copypasta `_enforce_sandbox()` and related unit tests from Cachito ("cachito/cachito/workers/tasks/general.py" and "cachito/tests/test_workers/test_tasks/test_general.py", respectively)
- add call to `_enforce_sandbox()`
- add CLI boolean arg `remove-unsafe-symlinks`, which toggles removing all symlinks which point to location(s) outside of any cloned repository

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
