### PR TITLE
Add to the icm schema a field to indicate if the icm should be ignored

### DIFF
--- a/atomic_reactor/schemas/content_manifest.json
+++ b/atomic_reactor/schemas/content_manifest.json
@@ -35,6 +35,11 @@
       "description": "Pulp content sets available during the current image build",
       "type": "array",
       "items": { "$ref": "#/definitions/content_set" }
+    },
+    "from_dnf_hint": {
+      "description": "A hint indicating if scanners should ignore this file and use the dnf database instead for more precise content_sets",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": ["metadata"],


### PR DESCRIPTION
This enables a path to deprecation.

Today, scanners depend on this file primarilly for the list of content_sets.

In the future, with konflux-ci, we want third-party scanners to refer to the dnf database for a more precise mapping of which rpms come from which content_sets.

The idea here is that image providers can still publish an icm file, but if the from_dnf_hint is set to true, then scanners are supposed to ignore the icm file and trust the dnf database instead. Scanners that haven't been ported to the new method will continue to work in the current imprecise way until they adapt to scanning the dnf database.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
