### PR TITLE
fix(coveralls): bump pip version

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -53,7 +53,7 @@ jobs:
           COVERALLS_PARALLEL: true
         run: |
           sudo apt install python3-testresources
-          pip3 install --upgrade pip==20.0.2
+          pip3 install --upgrade pip==24.3.1
           pip3 install --upgrade setuptools
           pip3 install --upgrade coveralls
           /home/runner/.local/bin/coveralls --service=github
@@ -66,7 +66,7 @@ jobs:
     - name: Finished
       run: |
         sudo apt install python3-testresources
-        pip3 install --upgrade pip==20.0.2
+        pip3 install --upgrade pip==24.3.1
         pip3 install --upgrade setuptools
         pip3 install --upgrade coveralls
         /home/runner/.local/bin/coveralls --finish --service=github


### PR DESCRIPTION
Old pip cannot be installed due to import error:
`ModuleNotFoundError: No module named 'pip._vendor.six.moves'`

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
