### PR TITLE
feat(cachi2): add support for git-submodules

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -143,6 +143,8 @@ HTTP_BACKOFF_FACTOR = 5
 HTTP_CLIENT_STATUS_RETRY = (408, 429, 500, 502, 503, 504)
 # requests timeout in seconds
 HTTP_REQUEST_TIMEOUT = 600
+# git cmd timeout in seconds
+GIT_CMD_TIMEOUT = 600
 # max retries for git clone
 GIT_MAX_RETRIES = 3
 # how many seconds should wait before another try of git clone

--- a/atomic_reactor/utils/retries.py
+++ b/atomic_reactor/utils/retries.py
@@ -89,7 +89,7 @@ def get_retrying_requests_session(client_statuses=HTTP_CLIENT_STATUS_RETRY,
     max_tries=SUBPROCESS_MAX_RETRIES + 1,  # total tries is N retries + 1 initial attempt
     jitter=None,  # use deterministic backoff, do not apply random jitter
 )
-def run_cmd(cmd: List[str], cleanup_cmd: List[str] = None) -> bytes:
+def run_cmd(cmd: List[str], cleanup_cmd: List[str] = None, **params) -> bytes:
     """Run a subprocess command, retry on any non-zero exit status.
 
     Whenever an attempt fails, the stdout and stderr of the failed command will be logged.
@@ -98,12 +98,14 @@ def run_cmd(cmd: List[str], cleanup_cmd: List[str] = None) -> bytes:
 
     If a cleanup command is specified it'll be run on exception before retry.
 
+    :param params: optional params to be passed to subprocess.run function
+
     :return: bytes, the combined stdout and stderr (if any) of the command
     """
     logger.debug("Running %s", " ".join(cmd))
 
     try:
-        process = subprocess.run(cmd, check=True, capture_output=True)
+        process = subprocess.run(cmd, check=True, capture_output=True, **params)
     except subprocess.CalledProcessError as e:
         logger.warning(
             "%s failed:\nSTDOUT:\n%s\nSTDERR:\n%s",
@@ -114,7 +116,7 @@ def run_cmd(cmd: List[str], cleanup_cmd: List[str] = None) -> bytes:
         if cleanup_cmd:
             try:
                 logger.debug("Running %s", " ".join(cleanup_cmd))
-                subprocess.run(cleanup_cmd, check=True, capture_output=True)
+                subprocess.run(cleanup_cmd, check=True, capture_output=True, **params)
             except subprocess.CalledProcessError as c_e:
                 logger.warning(
                     "Cleanup command: %s failed:\nSTDOUT:\n%s\nSTDERR:\n%s",

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@
 backoff
 dockerfile-parse>=0.0.13
 flatpak-module-tools>=0.14
+gitpython
 jsonschema
 paramiko>=3.4.0
 PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,10 @@ editables==0.5
     # via hatchling
 flatpak-module-tools==0.14
     # via -r requirements.in
+gitdb==4.0.12
+    # via gitpython
+gitpython==3.1.44
+    # via -r requirements.in
 googleapis-common-protos==1.60.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -176,6 +180,8 @@ six==1.16.0
     #   koji
     #   osbs-client
     #   python-dateutil
+smmap==5.0.2
+    # via gitdb
 tomli==2.0.1
     # via hatchling
 trove-classifiers==2023.8.7


### PR DESCRIPTION
for git-submodules pkg manager, OSBS msut hadnle all the work, cachi2 doesn't manipuilate git.

Submodules has to be cloned and metadata exported into SBOM and request.json

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
