### PR TITLE
feat(utils): implement `remove-unsafe-symlinks` flag for cachi2

### DIFF
--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -135,7 +135,15 @@ class Cachi2InitPlugin(Plugin):
                 remote_source_data["ref"]
             )
 
-            enforce_sandbox(source_path_app, remove_unsafe_symlinks=False)
+            remove_unsafe_symlinks = False
+            flags = remote_source_data.get("flags", [])
+            if "remove-unsafe-symlinks" in flags:
+                remove_unsafe_symlinks = True
+
+            enforce_sandbox(
+                source_path_app,
+                remove_unsafe_symlinks,
+            )
             validate_paths(source_path_app, remote_source_data.get("packages", {}))
 
             if clone_only(remote_source_data):

--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -23,11 +23,12 @@ class SymlinkSandboxError(Exception):
     """Found symlink(s) pointing outside the sandbox."""
 
 
-def enforce_sandbox(repo_root: Path, remove_unsafe_symlinks: bool) -> None:
+def enforce_sandbox(repo_root: Path, remove_unsafe_symlinks: bool = False) -> None:
     """
     Check that there are no symlinks that try to leave the cloned repository.
 
     :param (str | Path) repo_root: absolute path to root of cloned repository
+    :param bool remove_unsafe_symlinks: remove unsafe symlinks if any are found
     :raises OsbsValidationException: if any symlink points outside of cloned repository
     """
     for path_to_dir, subdirs, files in os.walk(repo_root):

--- a/tests/utils/test_cachi2.py
+++ b/tests/utils/test_cachi2.py
@@ -180,7 +180,7 @@ def test_remote_source_invalid_paths(tmpdir, remote_source_packages, expected_er
 
 
 def test_remote_source_path_to_symlink_out_of_repo(tmpdir):
-    """If cloned repo contains symlink that points out fo repo,
+    """If cloned repo contains symlink that points out of repo,
     path in packages shouldn't be allowed"""
     tmpdir_path = Path(tmpdir)
 


### PR DESCRIPTION
What/why:

implement parsing `remove-unsafe-symlinks` flag, which toggles removing all symlinks which point to location(s) outside of any cloned repository (default `False`)

How:

 - parse flag `remove-unsafe-symlinks` from "remote-source" section of 'container.yaml'

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
