### PR TITLE
cachi2: support pip dev dependencies

### DIFF
--- a/atomic_reactor/utils/cachi2.py
+++ b/atomic_reactor/utils/cachi2.py
@@ -251,8 +251,9 @@ def gen_dependency_from_sbom_component(sbom_dep: Dict[str, Any]) -> Dict[str, Op
     }
 
     # dev package definition
-    # currently only NPM
-    if any(p["name"] == "cdx:npm:package:development" and p["value"] == "true"
+    # currently only NPM and Pip
+    if any(p["name"] == "cdx:npm:package:development" and p["value"] == "true" or
+           p["name"] == "cdx:pip:package:build-dependency" and p["value"] == "true"
            for p in sbom_dep.get("properties", [])):
         res["dev"] = True
 

--- a/tests/utils/test_cachi2.py
+++ b/tests/utils/test_cachi2.py
@@ -501,6 +501,28 @@ def test_convert_SBOM_to_ICM(sbom, expected_icm):
     ),
     pytest.param(
         {
+            "name": "flit-core",
+            "purl": "pkg:pip/flit-core@3.10.1",
+            "type": "library",
+            "version": "3.10.1",
+            "properties": [
+                {
+                    "name": "cdx:pip:package:build-dependency",
+                    "value": "true"
+                }
+            ],
+        },
+        {
+            "name": "flit-core",
+            "replaces": None,
+            "type": "pip",
+            "version": "3.10.1",
+            "dev": True,
+        },
+        id="pip_dev"
+    ),
+    pytest.param(
+        {
             "name": "validate_url",
             "version": "1.0.5",
             "purl": "pkg:gem/validate_url#subpath",


### PR DESCRIPTION
In Cachi2, all dependencies declared in a "requirements-build.txt" file are reported as "cachi2:pip:package:build-dependency" in the CycloneDx SBOM.

Cachi2 simply declared those type of dependencies as dev dependencies, so we are adding a mechanism to keep the same behavior in the treated output.

Depends on https://github.com/containerbuildsystem/cachi2/pull/801

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- [x] JSON/YAML configuration changes are updated in the relevant schema
- [x] Changes to metadata also update the documentation for the metadata
- [x] Pull request has a link to an osbs-docs PR for user documentation updates
- [x] New feature can be disabled from a configuration file
