### PR TITLE
cachi2: export remote-source.config.json

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -204,6 +204,7 @@ ICM_JSON_FILENAME = 'icm-{}.json'
 # Cachi2 constants
 CACHI2_BUILD_DIR = "_cachi2_remote_sources"
 CACHI2_BUILD_APP_DIR = "app"
+CACHI2_BUILD_CONFIG_JSON = ".build-config.json"
 CACHI2_ENV_JSON = "cachi2.env.json"
 CACHI2_PKG_OPTIONS_FILE = "cachi2_pkg_options.json"
 CACHI2_FOR_OUTPUT_DIR_OPT_FILE = "cachi2_for_output_dir_opt.txt"

--- a/atomic_reactor/plugins/koji_import.py
+++ b/atomic_reactor/plugins/koji_import.py
@@ -352,6 +352,7 @@ class KojiImportBase(Plugin):
                         remote_source["remote_source_json"]["filename"],
                         remote_source["remote_source_tarball"]["filename"],
                         remote_source["remote_source_json_env"]["filename"],
+                        remote_source["remote_source_json_config"]["filename"],
                     ],
                 }
                 for remote_source in remote_source_result
@@ -660,9 +661,6 @@ class KojiImportPlugin(KojiImportBase):
         if not plugin_results:
             # Cachi2
             plugin_results = wf_data.plugins_results.get(PLUGIN_CACHI2_POSTPROCESS) or []
-            remote_source_keys = [
-                "remote_source_json", "remote_source_json_env",
-            ]
 
         tmpdir = tempfile.mkdtemp()
 

--- a/tests/plugins/test_koji_import.py
+++ b/tests/plugins/test_koji_import.py
@@ -533,54 +533,33 @@ def mock_environment(workflow: DockerBuildWorkflow, source_dir: Path,
         results = workflow.data.plugins_results
         results[PLUGIN_EXPORT_OPERATOR_MANIFESTS_KEY] = str(archive_file)
 
-    if has_remote_source == RemoteSourceKind.CACHITO:
+    if has_remote_source in [RemoteSourceKind.CACHITO, RemoteSourceKind.CACHI2]:
         source_path = build_dir_path / REMOTE_SOURCE_TARBALL_FILENAME
         source_path.write_text('dummy file', 'utf-8')
-        remote_source_result = [
-            {
-                "name": None,
-                "url": "https://cachito.com/api/v1/requests/21048/download",
-                "remote_source_json": {
-                    "filename": REMOTE_SOURCE_JSON_FILENAME,
-                    "json": {"stub": "data"},
-                },
-                "remote_source_json_config": {
-                    "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
-                    "json": [{"stub": "data"}],
-                },
-                "remote_source_json_env": {
-                    "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
-                    "json": {"var": {"stub": "data"}},
-                },
-                "remote_source_tarball": {
-                    "filename": REMOTE_SOURCE_TARBALL_FILENAME,
-                    "path": str(source_path),
-                },
-            }
-        ]
-        workflow.data.plugins_results[PLUGIN_RESOLVE_REMOTE_SOURCE] = remote_source_result
-    elif has_remote_source == RemoteSourceKind.CACHI2:
-        source_path = build_dir_path / REMOTE_SOURCE_TARBALL_FILENAME
-        source_path.write_text('dummy file', 'utf-8')
-        remote_source_result = [
-            {
-                "name": None,
-                "url": "https://cachito.com/api/v1/requests/21048/download",
-                "remote_source_json": {
-                    "filename": REMOTE_SOURCE_JSON_FILENAME,
-                    "json": {"stub": "data"},
-                },
-                "remote_source_json_env": {
-                    "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
-                    "json": {"var": {"stub": "data"}},
-                },
-                "remote_source_tarball": {
-                    "filename": REMOTE_SOURCE_TARBALL_FILENAME,
-                    "path": str(source_path),
-                },
-            }
-        ]
-        workflow.data.plugins_results[PLUGIN_CACHI2_POSTPROCESS] = remote_source_result
+        remote_source_result = {
+            "name": None,
+            "remote_source_json": {
+                "filename": REMOTE_SOURCE_JSON_FILENAME,
+                "json": {"stub": "data"},
+            },
+            "remote_source_json_config": {
+                "filename": REMOTE_SOURCE_JSON_CONFIG_FILENAME,
+                "json": [{"stub": "data"}],
+            },
+            "remote_source_json_env": {
+                "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
+                "json": {"var": {"stub": "data"}},
+            },
+            "remote_source_tarball": {
+                "filename": REMOTE_SOURCE_TARBALL_FILENAME,
+                "path": str(source_path),
+            },
+        }
+        if has_remote_source == RemoteSourceKind.CACHITO:
+            remote_source_result["url"] = "https://cachito.com/api/v1/requests/21048/download"
+            workflow.data.plugins_results[PLUGIN_RESOLVE_REMOTE_SOURCE] = [remote_source_result]
+        else:
+            workflow.data.plugins_results[PLUGIN_CACHI2_POSTPROCESS] = [remote_source_result]
     else:
         workflow.data.plugins_results[PLUGIN_RESOLVE_REMOTE_SOURCE] = None
 
@@ -2075,7 +2054,7 @@ class TestKojiImport(object):
                         'name': None,
                         'archives': [
                             'remote-source.json', 'remote-source.tar.gz',
-                            'remote-source.env.json'
+                            'remote-source.env.json', 'remote-source.config.json'
                         ],
                     }
                 ]


### PR DESCRIPTION
Export modifications to be done to sources to use deps resolved by cachi2. Us the same metadata format as Cachito in brew.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
