### PR TITLE
cachi2: remote sources include-git-dir flag

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -208,6 +208,7 @@ CACHI2_BUILD_CONFIG_JSON = ".build-config.json"
 CACHI2_ENV_JSON = "cachi2.env.json"
 CACHI2_PKG_OPTIONS_FILE = "cachi2_pkg_options.json"
 CACHI2_FOR_OUTPUT_DIR_OPT_FILE = "cachi2_for_output_dir_opt.txt"
+CACHI2_INCLUDE_GIT_DIR_FILE = "cachi2_include_git_dir.txt"
 CACHI2_SINGLE_REMOTE_SOURCE_NAME = "remote-source"
 CACHI2_SBOM_JSON = "bom.json"
 

--- a/atomic_reactor/plugins/cachi2_init.py
+++ b/atomic_reactor/plugins/cachi2_init.py
@@ -19,6 +19,7 @@ from atomic_reactor.constants import (
     CACHI2_BUILD_APP_DIR,
     CACHI2_PKG_OPTIONS_FILE,
     CACHI2_FOR_OUTPUT_DIR_OPT_FILE,
+    CACHI2_INCLUDE_GIT_DIR_FILE,
     CACHI2_SINGLE_REMOTE_SOURCE_NAME,
     CACHI2_SBOM_JSON,
     CACHI2_ENV_JSON,
@@ -101,6 +102,16 @@ class Cachi2InitPlugin(Plugin):
         with open(env_path, "w") as f:
             json.dump([], f)
 
+    def process_include_git_dir_flag(self, remote_source: Dict, source_path: Path):
+        """Process remote source include-git-dir flag
+
+        Cachi2 needs git metadata, so git dir must be removed after in tekton run step.
+
+        If include-git-dir is specified, let know to cachi2 run step that git should be kept
+        """
+        if "include-git-dir" in (remote_source.get("flags") or []):
+            (source_path/CACHI2_INCLUDE_GIT_DIR_FILE).touch()
+
     def process_remote_sources(self) -> List[Dict[str, Any]]:
         """Process remote source requests and return information about the processed sources."""
 
@@ -170,6 +181,8 @@ class Cachi2InitPlugin(Plugin):
                 self.write_cachi2_for_output_dir(
                     source_name,
                     source_path / CACHI2_FOR_OUTPUT_DIR_OPT_FILE)
+
+            self.process_include_git_dir_flag(remote_source_data, source_path)
 
             processed_remote_sources.append({
                 "source_path": str(source_path),

--- a/tekton/tasks/binary-container-cachi2.yaml
+++ b/tekton/tasks/binary-container-cachi2.yaml
@@ -78,6 +78,7 @@ spec:
         set -eux
         CACHI2_DIR="$(workspaces.ws-build-dir.path)/_cachi2_remote_sources"
         CACHI2_PKG_OPT_PATH="cachi2_pkg_options.json"
+        CACHI2_INCLUDE_GIT_DIR_FILE="cachi2_include_git_dir.txt"
 
         if [ ! -d "$CACHI2_DIR" ]; then
           echo "Skipping step: remote sources not found"
@@ -113,7 +114,11 @@ spec:
           # we can rely on presence of this file
           SBOMS+=("${REMOTE_SOURCE_PATH}/bom.json")
 
-          rm -fr app/.git/   # remove git directory
+          if [ -f "${CACHI2_INCLUDE_GIT_DIR_FILE}" ]; then
+            echo "flag 'include-git-dir' used, keeping git directory present"
+          else
+            rm -fr app/.git/   # remove git directory by default
+          fi
 
           # create source archive before injecting files
           tar -czf remote-source.tar.gz app/ deps/


### PR DESCRIPTION
When include-git-dir flag is used, keep .git directory present

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Python type annotations added to new code
- n/a JSON/YAML configuration changes are updated in the relevant schema
- n/a Changes to metadata also update the documentation for the metadata
- n/a Pull request has a link to an osbs-docs PR for user documentation updates
- n/a New feature can be disabled from a configuration file
