### PR TITLE
cachi2: options to allow inject custom trustedCA

### DIFF
--- a/tekton/tasks/binary-container-cachi2.yaml
+++ b/tekton/tasks/binary-container-cachi2.yaml
@@ -21,6 +21,14 @@ spec:
     - name: log-level
       description: Set cachi2 log level (debug, info, warning, error)
       default: "info"
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
 
   workspaces:
     - name: ws-build-dir
@@ -30,6 +38,15 @@ spec:
     - name: ws-koji-secret  # access with $(workspaces.ws-koji-secret.path)/token
     - name: ws-reactor-config-map
     - name: ws-autobot-keytab
+
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.ca-trust-config-map-name)
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        optional: true
 
   stepTemplate:
     env:
@@ -66,6 +83,11 @@ spec:
         - name: LOG_LEVEL
           value: $(params.log-level)
       workingDir: $(workspaces.ws-home-dir.path)
+      volumeMounts:
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
       resources:
         requests:
           memory: 512Mi


### PR DESCRIPTION
Allow to use Cachi2 step custom CA certificates

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
