### PR TITLE
cachi2: export compatible env.json file

### DIFF
--- a/atomic_reactor/plugins/cachi2_postprocess.py
+++ b/atomic_reactor/plugins/cachi2_postprocess.py
@@ -290,6 +290,15 @@ class Cachi2PostprocessPlugin(Plugin):
     def remote_source_to_output(self, remote_source: Cachi2RemoteSource) -> Dict[str, Any]:
         """Convert a processed remote source to a dict to be used as output of this plugin."""
 
+        compat_json = {
+            # cachito return data in this format, keep compatibility for koji metadata
+            env_var['name']: {
+                "value": env_var['value'],
+                "kind": "literal",
+            }
+            for env_var in remote_source.json_env_data
+        }
+
         return {
             "name": remote_source.name,
             "remote_source_json": {
@@ -297,7 +306,7 @@ class Cachi2PostprocessPlugin(Plugin):
                 "filename": Cachi2RemoteSource.json_filename(remote_source.name),
             },
             "remote_source_json_env": {
-                "json": remote_source.json_env_data,
+                "json": compat_json,
                 "filename": Cachi2RemoteSource.json_env_filename(remote_source.name),
             },
             "remote_source_json_config": {

--- a/tests/plugins/test_cachi2_postprocess.py
+++ b/tests/plugins/test_cachi2_postprocess.py
@@ -252,6 +252,14 @@ def test_resolve_remote_source_single(workflow):
             single_source, remote_source_env_json, remote_source_sbom
         )
     )
+
+    expected_remote_source_env_json = {
+        "GOCACHE": {
+          "kind": "literal",
+          "value": "/remote-source/deps/gomod",
+        },
+    }
+
     expected_plugin_results = [
         {
             "name": None,
@@ -262,7 +270,7 @@ def test_resolve_remote_source_single(workflow):
                 "filename": REMOTE_SOURCE_JSON_FILENAME,
             },
             "remote_source_json_env": {
-                "json": remote_source_env_json,
+                "json": expected_remote_source_env_json,
                 "filename": REMOTE_SOURCE_JSON_ENV_FILENAME,
             },
             "remote_source_json_config": {
@@ -404,6 +412,21 @@ def test_multiple_remote_sources(workflow):
         RemoteSourceInitResult(
             second_source, second_remote_source_env_json, second_remote_source_sbom),
     )
+
+    expected_first_remote_source_env_json = {
+        "GOCACHE": {
+          "kind": "literal",
+          "value": "/remote-source/deps/gomod",
+        },
+    }
+
+    expected_second_remote_source_env_json = {
+        "PIP_INDEX": {
+          "kind": "literal",
+          "value": "/remote-source/deps/somewhere-here",
+        },
+    }
+
     expected_plugin_results = [
         {
             "name": FIRST_REMOTE_SOURCE_NAME,
@@ -414,7 +437,7 @@ def test_multiple_remote_sources(workflow):
                 "filename": "remote-source-first.json",
             },
             "remote_source_json_env": {
-                "json": first_remote_source_env_json,
+                "json": expected_first_remote_source_env_json,
                 "filename": "remote-source-first.env.json",
             },
             "remote_source_json_config": {
@@ -435,7 +458,7 @@ def test_multiple_remote_sources(workflow):
                 "filename": "remote-source-second.json",
             },
             "remote_source_json_env": {
-                "json": second_remote_source_env_json,
+                "json": expected_second_remote_source_env_json,
                 "filename": "remote-source-second.env.json",
             },
             "remote_source_json_config": {
@@ -619,6 +642,20 @@ def test_multiple_remote_sources_with_git_submodules(workflow):
             second_source, second_remote_source_env_json, second_remote_source_sbom),
     )
 
+    expected_first_remote_source_env_json = {
+        "GOCACHE": {
+          "kind": "literal",
+          "value": "/remote-source/deps/gomod",
+        },
+    }
+
+    expected_second_remote_source_env_json = {
+        "PIP_INDEX": {
+          "kind": "literal",
+          "value": "/remote-source/deps/somewhere-here",
+        },
+    }
+
     expected_request_json_first = {
         'dependencies': [
             {
@@ -671,7 +708,7 @@ def test_multiple_remote_sources_with_git_submodules(workflow):
                 "filename": "remote-source-first.json",
             },
             "remote_source_json_env": {
-                "json": first_remote_source_env_json,
+                "json": expected_first_remote_source_env_json,
                 "filename": "remote-source-first.env.json",
             },
             "remote_source_json_config": {
@@ -690,7 +727,7 @@ def test_multiple_remote_sources_with_git_submodules(workflow):
                 "filename": "remote-source-second.json",
             },
             "remote_source_json_env": {
-                "json": second_remote_source_env_json,
+                "json": expected_second_remote_source_env_json,
                 "filename": "remote-source-second.env.json",
             },
             "remote_source_json_config": {


### PR DESCRIPTION
remote-source.env.json wasn't compatible between CAchito and Cachi2, OSBS must provide compatible file formats for further processing by other tools

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
