### PR TITLE
cachi2: update resources

### DIFF
--- a/tekton/tasks/binary-container-cachi2.yaml
+++ b/tekton/tasks/binary-container-cachi2.yaml
@@ -110,8 +110,8 @@ spec:
           memory: 512Mi
           cpu: 250m
         limits:
-          memory: 1Gi
-          cpu: 395m
+          memory: 2500Mi
+          cpu: 1500m
       script: |
         #!/usr/bin/bash
         set -eux


### PR DESCRIPTION
Increase limits to mem and CPU. From abother cachi2 deployment I've identified max used memory between 1.3-2.2Mi and 3-5 CPUs.

This limits are subject to change from real usage in OSBS.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
