### PR TITLE
cachi2: keep limit under 2CPU

### DIFF
--- a/tekton/tasks/binary-container-cachi2.yaml
+++ b/tekton/tasks/binary-container-cachi2.yaml
@@ -111,7 +111,7 @@ spec:
           cpu: 250m
         limits:
           memory: 2500Mi
-          cpu: 1500m
+          cpu: 1200m
       script: |
         #!/usr/bin/bash
         set -eux


### PR DESCRIPTION
OSBS tasks are keeping rule that cumulative usage should be under 2CPUs

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
