### PR TITLE
Skip Cachito/Hermeto tasks w/o remote_sources

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -191,6 +191,9 @@ KOJI_BTYPE_REMOTE_SOURCES = 'remote-sources'
 KOJI_BTYPE_REMOTE_SOURCE_FILE = 'remote-source-file'
 KOJI_BTYPE_ICM = 'icm'
 
+
+REMOTE_SOURCE_VERSION_SKIP = 0
+
 # Path to where the remote source bundle is copied to during the build process
 REMOTE_SOURCE_DIR = '/remote-source'
 

--- a/atomic_reactor/plugins/check_user_settings.py
+++ b/atomic_reactor/plugins/check_user_settings.py
@@ -6,7 +6,10 @@ This software may be modified and distributed under the terms
 of the BSD license. See the LICENSE file for details.
 """
 
-from atomic_reactor.constants import PLUGIN_CHECK_USER_SETTINGS
+from atomic_reactor.constants import (
+    PLUGIN_CHECK_USER_SETTINGS,
+    REMOTE_SOURCE_VERSION_SKIP,
+)
 from atomic_reactor.plugin import Plugin
 from atomic_reactor.util import (
     has_operator_appregistry_manifest,
@@ -114,6 +117,13 @@ class CheckUserSettingsPlugin(Plugin):
         version = self.workflow.source.config.remote_sources_version
         if not version:
             version = self.workflow.conf.remote_sources_default_version
+
+        if not (
+            self.workflow.source.config.remote_source
+            or self.workflow.source.config.remote_sources
+        ):
+            self.log.info('No remote source configuration')
+            version = REMOTE_SOURCE_VERSION_SKIP  # undefined remote sources, skip
 
         self.log.info("Remote sources version to be used: %d", version)
 

--- a/tests/stubs.py
+++ b/tests/stubs.py
@@ -10,15 +10,21 @@ of the BSD license. See the LICENSE file for details.
 
 # Stubs for commonly-mocked classes
 class StubConfig(object):
-    image_build_method = None
-    release_env_var = None
-    remote_sources_version = None
+
+    def __init__(self):
+        self.image_build_method = None
+        self.release_env_var = None
+        self.remote_sources_version = None
+        self.remote_source = None
+        self.remote_sources = None
 
 
 class StubSource(object):
-    dockerfile_path = None
-    path = ''
-    config = StubConfig()
+
+    def __init__(self):
+        self.dockerfile_path = None
+        self.path = ''
+        self.config = StubConfig()
 
     def get_vcs_info(self):
         return None


### PR DESCRIPTION
When remote sources are not configured, skip all tasks used for remote sources (cachito/hermeto)

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
