### PR TITLE
Hermeto: generate cyclonedx SBOM

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -143,6 +143,7 @@ spec:
             cachi2 --log-level="$LOG_LEVEL" fetch-deps \
               --source="${REMOTE_SOURCE_PATH}/app/" \
               --output="${REMOTE_SOURCE_PATH}" \
+              --sbom-output-type=cyclonedx \
               "$(cat "${HERMETO_PKG_OPT_PATH}")"
 
             cachi2 --log-level="$LOG_LEVEL" generate-env "${REMOTE_SOURCE_PATH}" \


### PR DESCRIPTION
OSBS supports only cyclonedx, make sure to explicitly require cyclonedx format in case that default format changes

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
