### PR TITLE
Hermeto: add support for SSH git auth

### DIFF
--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -27,6 +27,11 @@ spec:
         Workspace containing a .netrc file. OSBS and Hermeto will use the credentials in this file when
         performing git/http(s) requests.
       optional: true
+    - name: git-ssh-privkey
+      description: |
+        Workspace containing an id_rsa file. OSBS and Hermeto will use the credentials in this file when
+        performing ssh git requests.
+      optional: true
 
   results:
     - name: repositories
@@ -164,6 +169,8 @@ spec:
           workspace: ws-autobot-keytab
         - name: netrc
           workspace: netrc
+        - name: git-ssh-privkey
+          workspace: git-ssh-privkey
       params:
         - name: osbs-image
           value: "$(params.osbs-image)"

--- a/tekton/pipelines/binary-container.yaml
+++ b/tekton/pipelines/binary-container.yaml
@@ -149,7 +149,14 @@ spec:
       runAfter:
         - binary-container-init
       taskRef:
-        name: binary-container-hermeto-0-1
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/MartinBasti/atomic-reactor.git
+        - name: revision
+          value: hermeto_git_ssh
+        - name: pathInRepo
+          value: tekton/tasks/binary-container-hermeto.yaml
       workspaces:
         - name: ws-build-dir
           workspace: ws-container

--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -43,6 +43,11 @@ spec:
         Workspace containing a .netrc file. OSBS and Hermeto will use the credentials in this file when
         performing git/http(s) requests.
       optional: true
+    - name: git-ssh-privkey
+      description: |
+        Workspace containing an id_rsa file. OSBS and Hermeto will use the credentials in this file when
+        performing ssh git requests.
+      optional: true
 
   volumes:
     - name: trusted-ca
@@ -69,6 +74,10 @@ spec:
           value: $(workspaces.netrc.bound)
         - name: WORKSPACE_NETRC_PATH
           value: $(workspaces.netrc.path)
+        - name: WORKSPACE_GIT_SSH_PRIVKEY_BOUND
+          value: $(workspaces.git-ssh-privkey.bound)
+        - name: WORKSPACE_GIT_SSH_PRIVKEY_PATH
+          value: $(workspaces.git-ssh-privkey.path)
       resources:
         requests:
           memory: 512Mi
@@ -78,8 +87,15 @@ spec:
           cpu: 395m
       script: |
         set -x
+        set -e
+
         if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
           cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+        fi
+
+        if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/id_rsa"
+          chmod 0400 "${HOME}/id_rsa"
         fi
 
         atomic-reactor -v task \
@@ -99,6 +115,10 @@ spec:
           value: $(workspaces.netrc.bound)
         - name: WORKSPACE_NETRC_PATH
           value: $(workspaces.netrc.path)
+        - name: WORKSPACE_GIT_SSH_PRIVKEY_BOUND
+          value: $(workspaces.git-ssh-privkey.bound)
+        - name: WORKSPACE_GIT_SSH_PRIVKEY_PATH
+          value: $(workspaces.git-ssh-privkey.path)
       workingDir: $(workspaces.ws-home-dir.path)
       volumeMounts:
         - name: trusted-ca
@@ -126,6 +146,11 @@ spec:
 
         if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
           cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+        fi
+
+        if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/id_rsa"
+          chmod 0400 "${HOME}/id_rsa"
         fi
 
         SBOMS=()

--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -94,6 +94,7 @@ spec:
         fi
 
         if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
+          mkdir -p ${HOME}/.ssh
           cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/.ssh/id_rsa"
           chmod 0400 "${HOME}/.ssh/id_rsa"
         fi
@@ -149,6 +150,7 @@ spec:
         fi
 
         if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
+          mkdir -p ${HOME}/.ssh
           cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/.ssh/id_rsa"
           chmod 0400 "${HOME}/.ssh/id_rsa"
         fi

--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -94,8 +94,8 @@ spec:
         fi
 
         if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
-          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/id_rsa"
-          chmod 0400 "${HOME}/id_rsa"
+          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/.ssh/id_rsa"
+          chmod 0400 "${HOME}/.ssh/id_rsa"
         fi
 
         atomic-reactor -v task \
@@ -149,8 +149,8 @@ spec:
         fi
 
         if [ "${WORKSPACE_GIT_SSH_PRIVKEY_BOUND}" = "true" ]; then
-          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/id_rsa"
-          chmod 0400 "${HOME}/id_rsa"
+          cp "${WORKSPACE_GIT_SSH_PRIVKEY_PATH}/id_rsa" "${HOME}/.ssh/id_rsa"
+          chmod 0400 "${HOME}/.ssh/id_rsa"
         fi
 
         SBOMS=()


### PR DESCRIPTION
Users may configure remote sources using SSH, OSBS should be able to clone and process such sources.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
