### PR TITLE
remote-source: add generic name for remote-source.env

### DIFF
--- a/atomic_reactor/constants.py
+++ b/atomic_reactor/constants.py
@@ -11,6 +11,7 @@ import os
 DOCKER_SOCKET_PATH = '/var/run/docker.sock'
 DOCKERFILE_FILENAME = 'Dockerfile'
 CACHITO_ENV_FILENAME = 'cachito.env'
+REMOTE_SOURCE_ENV_FILENAME = 'remote-source.env'
 CACHITO_ENV_ARG_ALIAS = 'CACHITO_ENV_FILE'
 BUILD_JSON = 'build.json'
 BUILD_JSON_ENV = 'BUILD_JSON'

--- a/tests/plugins/test_hermeto_postprocess.py
+++ b/tests/plugins/test_hermeto_postprocess.py
@@ -846,10 +846,18 @@ def test_generate_cachito_env_file_shell_quoting(workflow):
     plugin = HermetoPostprocessPlugin(workflow)
 
     dest_dir = Path(expected_build_dir(workflow))
-    plugin.generate_cachito_env_file(dest_dir, {"foo": "somefile; rm -rf ~"})
+    plugin.generate_remote_source_env_file(dest_dir, {"foo": "somefile; rm -rf ~"})
 
     cachito_env = dest_dir / "cachito.env"
     assert cachito_env.read_text() == dedent(
+        """\
+        #!/bin/bash
+        export foo='somefile; rm -rf ~'
+        """
+    )
+
+    remote_source_env = dest_dir / "remote-source.env"
+    assert remote_source_env.read_text() == dedent(
         """\
         #!/bin/bash
         export foo='somefile; rm -rf ~'


### PR DESCRIPTION
With addition of Hermeto, we should provide a universal name for envfile so it's not tied with Cachito forever

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
