### PR TITLE
Improve Hermeto task logs

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -114,7 +114,7 @@ spec:
           cpu: 1200m
       script: |
         #!/usr/bin/bash
-        set -eux
+        set -eu
         HERMETO_DIR="$(workspaces.ws-build-dir.path)/_hermeto_remote_sources"
         HERMETO_PKG_OPT_PATH="hermeto_pkg_options.json"
         HERMETO_INCLUDE_GIT_DIR_FILE="hermeto_include_git_dir.txt"
@@ -136,9 +136,15 @@ spec:
 
           pushd "${REMOTE_SOURCE_PATH}"
 
+          REMOTE_SOURCE_NAME=$(basename "${REMOTE_SOURCE_PATH}")
+
+          echo "Processing remote source: ${REMOTE_SOURCE_NAME}"
+
           if [ -f "${HERMETO_PKG_OPT_PATH}" ]; then
             # only presence of $HERMETO_PKG_OPT_PATH config file means that atomic-reactor wants to run Hermeto
             FOR_OUTPUT_DIR="$(cat hermeto_for_output_dir_opt.txt)"
+
+            echo "Fetching dependencies using Hermeto options: $(cat "${HERMETO_PKG_OPT_PATH}")"
 
             cachi2 --log-level="$LOG_LEVEL" fetch-deps \
               --source="${REMOTE_SOURCE_PATH}/app/" \
@@ -146,11 +152,14 @@ spec:
               --sbom-output-type=cyclonedx \
               "$(cat "${HERMETO_PKG_OPT_PATH}")"
 
+            echo "Generating envfile"
+
             cachi2 --log-level="$LOG_LEVEL" generate-env "${REMOTE_SOURCE_PATH}" \
               --format json \
               --for-output-dir="${FOR_OUTPUT_DIR}" \
               --output "${REMOTE_SOURCE_PATH}/hermeto.env.json"
           else
+            echo "Skipping Hermeto run, the remote source is processed only by OSBS"
             mkdir deps/  # create empty deps/ dir to emulate Hermeto run
           fi
 
@@ -159,29 +168,36 @@ spec:
           SBOMS+=("${REMOTE_SOURCE_PATH}/bom.json")
 
           if [ -f "${HERMETO_INCLUDE_GIT_DIR_FILE}" ]; then
-            echo "flag 'include-git-dir' used, keeping git directory present"
+            echo "Flag 'include-git-dir' used, keeping git directory present"
           else
             rm -fr app/.git/   # remove git directory by default
           fi
 
           # create source archive before injecting files
+          echo "Creating source archive"
           tar -czf remote-source.tar.gz app/ deps/
 
           if [ -f "${HERMETO_PKG_OPT_PATH}" ]; then
+            echo "Injecting Hermeto files into the remote source"
             cachi2 --log-level="$LOG_LEVEL" inject-files "${REMOTE_SOURCE_PATH}" \
               --for-output-dir="${FOR_OUTPUT_DIR}"
           fi
 
+          echo "Finished processing of remote source: ${REMOTE_SOURCE_NAME}"
+          echo ""
+
           popd
         done
 
+        GLOBAL_SBOM_FILE="${HERMETO_DIR}/bom.json"
         if [ "${#SBOMS[@]}" -gt 1 ]; then
           # merge multiple sboms into single one
+          echo "Merging multiple SBOMs into global SBOM: ${GLOBAL_SBOM_FILE}"
           cachi2 --log-level="$LOG_LEVEL" merge-sboms "${SBOMS[@]}" \
-            --output "${HERMETO_DIR}/bom.json"
+            --output "${GLOBAL_SBOM_FILE}"
         else
           # single SBOM is the final SBOM
-          cp "${SBOMS[0]}" "${HERMETO_DIR}/bom.json"
+          cp "${SBOMS[0]}" "${GLOBAL_SBOM_FILE}"
         fi
     - name: binary-container-hermeto-postprocess
       image: $(params.osbs-image)


### PR DESCRIPTION
Removing -x flag as it was generating too much fuzz and it was hard to anvigate for usesrs.

Added more logs for users to nabigate easier what's happeing in the task

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
