### PR TITLE
Hermeto: print used version

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -128,6 +128,8 @@ spec:
           cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
         fi
 
+        echo "Using Hermeto version: $(cachi2 --version | head -n1)"
+
         SBOMS=()
 
         # Process each remote source


### PR DESCRIPTION
Print version fo hermeto used in OSBS build

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
