### PR TITLE
Hermeto: print content of env vars

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -160,6 +160,10 @@ spec:
               --format json \
               --for-output-dir="${FOR_OUTPUT_DIR}" \
               --output "${REMOTE_SOURCE_PATH}/hermeto.env.json"
+
+            echo "Content of envfile:"
+            cat "${REMOTE_SOURCE_PATH}/hermeto.env.json"
+            echo ""
           else
             echo "Skipping Hermeto run, the remote source is processed only by OSBS"
             mkdir deps/  # create empty deps/ dir to emulate Hermeto run


### PR DESCRIPTION
Print what Hermeto generated into env file

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
