### PR TITLE
Fix: remote-sources default version

### DIFF
--- a/atomic_reactor/source.py
+++ b/atomic_reactor/source.py
@@ -72,7 +72,7 @@ class SourceConfig(object):
             self.compose.pop('inherit', None)
         self.remote_source = self.data.get('remote_source')
         self.remote_sources = self.data.get('remote_sources')
-        self.remote_sources_version = self.data.get('remote_sources_version', 1)
+        self.remote_sources_version = self.data.get('remote_sources_version')
         self.operator_manifests = self.data.get('operator_manifests')
 
         self.platforms = self.data.get('platforms') or {'not': [], 'only': []}


### PR DESCRIPTION
Don't hardcode default version as 1, it's specified by a separate config option

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
