### PR TITLE
fix(hermeto): ruygems pkg parameters propagation

### DIFF
--- a/atomic_reactor/utils/hermeto.py
+++ b/atomic_reactor/utils/hermeto.py
@@ -163,11 +163,12 @@ def remote_source_to_hermeto(remote_source: Dict[str, Any]) -> Dict[str, Any]:
         if pkg_manager in removed_pkg_managers:
             continue
 
+        packages = remote_source.get("packages", {}).get(pkg_manager, [])
+        packages = packages or [{"path": "."}]
+
         # if pkg manager has different name in Hermeto update it
         pkg_manager = pkg_managers_map.get(pkg_manager, pkg_manager)
 
-        packages = remote_source.get("packages", {}).get(pkg_manager, [])
-        packages = packages or [{"path": "."}]
         for pkg in packages:
             hermeto_packages.append({"type": pkg_manager, **pkg})
 

--- a/tests/utils/test_hermeto.py
+++ b/tests/utils/test_hermeto.py
@@ -58,6 +58,11 @@ def mocked_repo_submodules():
         id="pkg_rubygems_to_bundler",
     ),
     pytest.param(
+        {"pkg_managers": ["rubygems"], "packages": {"rubygems": [{"path": "extra_path"}]}},
+        {"flags": [], "packages": [{"path": "extra_path", "type": "bundler"}]},
+        id="pkg_rubygems_to_bundler_with_extra",
+    ),
+    pytest.param(
         {},
         {"flags": [], "packages": [{"path": ".", "type": "gomod"}]},
         id="pkg_manager_missing",


### PR DESCRIPTION
OSBS must do renaming from rubygems to bundler.
Do this rename operation after all data are fetched from config, not before at it will omit configuration.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
