### PR TITLE
fix(hermeto): better handle flags: None

### DIFF
--- a/atomic_reactor/plugins/hermeto_init.py
+++ b/atomic_reactor/plugins/hermeto_init.py
@@ -159,7 +159,7 @@ class HermetoInitPlugin(Plugin):
                 remote_source["git_submodules"] = git_submodules
 
             remove_unsafe_symlinks = False
-            flags = remote_source_data.get("flags", [])
+            flags = remote_source_data.get("flags") or []
             if "remove-unsafe-symlinks" in flags:
                 remove_unsafe_symlinks = True
 

--- a/atomic_reactor/utils/hermeto.py
+++ b/atomic_reactor/utils/hermeto.py
@@ -151,7 +151,7 @@ def remote_source_to_hermeto(remote_source: Dict[str, Any]) -> Dict[str, Any]:
     removed_pkg_managers = {"git-submodule"}
 
     hermeto_flags = sorted(
-        set(remote_source.get("flags", [])) - removed_flags
+        set(remote_source.get("flags") or []) - removed_flags
     )
     hermeto_packages = []
 
@@ -280,7 +280,7 @@ def generate_request_json(
         "ref": remote_source["ref"],
         "repo": remote_source["repo"],
         "environment_variables": {env['name']: env["value"] for env in remote_source_env_json},
-        "flags": remote_source.get("flags", []),
+        "flags": remote_source.get("flags") or [],
         "packages": [],  # this will be always empty Hermeto doesn't provide nested deps
     }
     return res

--- a/tests/plugins/test_hermeto_init.py
+++ b/tests/plugins/test_hermeto_init.py
@@ -259,6 +259,7 @@ def test_multi_remote_source_initialization(workflow, mocked_hermeto_init):
           remote_source:
             repo: {SECOND_REMOTE_SOURCE_REPO}
             ref: {SECOND_REMOTE_SOURCE_REF}
+            flags:  # Test case when flags are None to test handling
         """
     )
 
@@ -301,6 +302,7 @@ def test_multi_remote_source_initialization(workflow, mocked_hermeto_init):
             "repo": SECOND_REMOTE_SOURCE_REPO,
             "ref": SECOND_REMOTE_SOURCE_REF,
             "pkg_managers": ["gomod"],
+            "flags": None,
         }
     }]
 


### PR DESCRIPTION
Flags can be deinfed as None, handle this case better and don't fail on errors.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Python type annotations added to new code
- [n/a] JSON/YAML configuration changes are updated in the relevant schema
- [n/a] Changes to metadata also update the documentation for the metadata
- [n/a] Pull request has a link to an osbs-docs PR for user documentation updates
- [n/a] New feature can be disabled from a configuration file
