### PR TITLE
Hermeto: default config

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -130,6 +130,15 @@ spec:
 
         echo "Using Hermeto version: $(hermeto --version | head -n1)"
 
+        # Default Hermeto conf file to keep compatibility with Cachito as much as possible
+        CONF_FILE="${HOME}/hermeto-conf.yaml"
+
+        cat <<EOF >"${CONF_FILE}"
+        ---
+        allow_yarnberry_processing: false
+        ignore_pip_dependencies_crates: true
+        EOF
+
         SBOMS=()
 
         # Process each remote source
@@ -148,7 +157,7 @@ spec:
 
             echo "Fetching dependencies using Hermeto options: $(cat "${HERMETO_PKG_OPT_PATH}")"
 
-            hermeto --log-level="$LOG_LEVEL" fetch-deps \
+            hermeto --log-level="$LOG_LEVEL" --config-file="${CONF_FILE}" fetch-deps \
               --source="${REMOTE_SOURCE_PATH}/app/" \
               --output="${REMOTE_SOURCE_PATH}" \
               --sbom-output-type=cyclonedx \


### PR DESCRIPTION
Provide default config to keep compatibility with OSBS/Cachito workflows as much as possible

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
