### PR TITLE
use hermeto permissive mode

### DIFF
--- a/tekton/tasks/binary-container-hermeto.yaml
+++ b/tekton/tasks/binary-container-hermeto.yaml
@@ -157,7 +157,7 @@ spec:
 
             echo "Fetching dependencies using Hermeto options: $(cat "${HERMETO_PKG_OPT_PATH}")"
 
-            hermeto --log-level="$LOG_LEVEL" --config-file="${CONF_FILE}" fetch-deps \
+            hermeto --log-level="$LOG_LEVEL" --config-file="${CONF_FILE}" --mode=permissive fetch-deps \
               --source="${REMOTE_SOURCE_PATH}/app/" \
               --output="${REMOTE_SOURCE_PATH}" \
               --sbom-output-type=cyclonedx \


### PR DESCRIPTION
Hermeto added a new permissive mode in:
https://github.com/hermetoproject/hermeto/commit/aaf0a0039e9483f9a3a173aae211da0908ffcc5c

Use it by default to make go vendoring checks as permissive as Cachito used to be:
https://github.com/hermetoproject/hermeto/commit/5a75c849ccb0cccb2a5d9153cb3e966234a77ede

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
