### PR TITLE
fix(tekton): increment postbuild resources

### DIFF
--- a/tekton/tasks/binary-container-postbuild.yaml
+++ b/tekton/tasks/binary-container-postbuild.yaml
@@ -36,10 +36,10 @@ spec:
       workingDir: $(workspaces.ws-home-dir.path)
       resources:
         requests:
-          memory: 300Mi
+          memory: 500Mi
           cpu: 250m
         limits:
-          memory: 600Mi
+          memory: 1000Mi
           cpu: 395m
       script: |
         set -x


### PR DESCRIPTION
We are getting reports that the current limits aren't sufficient

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Python type annotations added to new code
- [ ] JSON/YAML configuration changes are updated in the relevant schema
- [ ] Changes to metadata also update the documentation for the metadata
- [ ] Pull request has a link to an osbs-docs PR for user documentation updates
- [ ] New feature can be disabled from a configuration file
